### PR TITLE
DB-1787: Renovate bot setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,14 +90,16 @@ jobs:
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
+  nightly-audit:
+    when:
+      and:
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ["nightly audit", << pipeline.schedule.name >>]
+    jobs:
+      - audit
   orb-free-workflow:
     when:
       not: # Run test job when trigger is not the scheduled pipeline
         equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - test
-  nightly-audit:
-    when:
-        equal: ["nightly audit", << pipeline.schedule.name >>]
-    jobs:
-      - audit


### PR DESCRIPTION
[DO NOT MERGE]

- setup renovate bot circleci orb https://circleci.com/developer/orbs/orb/daniel-shuy/renovate
- add renovate.json config file

I'm not sure this will work. I've set the cron to run every hour. I think this workflow still requires renovate bot to be self-hosted somewhere. 

The easiest way to enable renovate bot on this repo seems to be enabling the GitHub app which will involve tracking down the owner of the org to approve and add the app to our repo. 