### PR TITLE
DB-2112: change gatsby serve port to 8000 to play nice with Lando

### DIFF
--- a/starters/gatsby-wordpress-starter/package.json
+++ b/starters/gatsby-wordpress-starter/package.json
@@ -42,7 +42,7 @@
     "develop": "ENABLE_GATSBY_REFRESH_ENDPOINT=true gatsby develop -H 0.0.0.0",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "npm run develop",
-    "serve": "gatsby serve",
+    "serve": "gatsby serve -p 8000",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
   },


### PR DESCRIPTION
The real work for DB-2112 is in https://github.com/pantheon-systems/decoupled-wordpress-dev-sandbox, but I haven't been able to figure out how to get Lando to serve multiple ports for a single service/proxy. So I just punted and changed our serve command to use the same port as dev :)