### PR TITLE
Add lock files to starter kits for distribution

### DIFF
--- a/.changeset/cold-snails-yell.md
+++ b/.changeset/cold-snails-yell.md
@@ -1,0 +1,6 @@
+---
+"@pantheon-systems/gatsby-wordpress-starter": patch
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+Add package-lock.json to gatsby-wordpress-starter and next-drupal-starter for distribution.

--- a/starters/gatsby-wordpress-starter/package-lock.json
+++ b/starters/gatsby-wordpress-starter/package-lock.json
@@ -1,0 +1,5505 @@
+{
+  "name": "@pantheon-systems/gatsby-wordpress-starter",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@pantheon-systems/gatsby-wordpress-starter",
+      "version": "1.0.0",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@tailwindcss/typography": "^0.5.2",
+        "autoprefixer": "^10.4.2",
+        "gatsby": "^4.9.1",
+        "gatsby-plugin-image": "^2.9.0",
+        "gatsby-plugin-manifest": "^4.9.0",
+        "gatsby-plugin-offline": "^5.9.0",
+        "gatsby-plugin-pnpm": "^1.2.10",
+        "gatsby-plugin-postcss": "^5.9.0",
+        "gatsby-plugin-react-helmet": "^5.9.0",
+        "gatsby-plugin-sharp": "^4.9.0",
+        "gatsby-source-filesystem": "^4.9.0",
+        "gatsby-source-wordpress": "^6.9.0",
+        "gatsby-transformer-sharp": "^4.9.0",
+        "html-react-parser": "^1.4.8",
+        "lodash": "^4.17.21",
+        "mitt": "^3.0.0",
+        "postcss": "^8.4.7",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-helmet": "^6.1.0",
+        "tailwindcss": "^3.0.23",
+        "typeface-merriweather": "1.1.13",
+        "typeface-montserrat": "1.1.13"
+      },
+      "devDependencies": {
+        "dumper.js": "^1.3.1",
+        "prettier": "2.5.1"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.12.3 <8.0.0",
+        "babel-eslint": "^10.0.0",
+        "typescript": ">=3.3.1",
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/@tailwindcss+typography@0.5.2_tailwindcss@3.0.23/node_modules/@tailwindcss/typography": {
+      "version": "0.5.2",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2"
+      },
+      "devDependencies": {
+        "@mdx-js/loader": "^1.0.19",
+        "@mdx-js/mdx": "^1.6.6",
+        "@next/mdx": "^8.1.0",
+        "autoprefixer": "^10.2.1",
+        "highlight.js": "^10.4.1",
+        "jest": "^26.6.1",
+        "jest-diff": "^27.3.1",
+        "next": "^12.0.1",
+        "postcss": "^8.2.3",
+        "prettier": "^2.1.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "tailwindcss": "^3.0.0-alpha.2"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || insiders"
+      }
+    },
+    "../../node_modules/.pnpm/autoprefixer@10.4.4_postcss@8.4.12/node_modules/autoprefixer": {
+      "version": "10.4.4",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.20.2",
+        "caniuse-lite": "^1.0.30001317",
+        "fraction.js": "^4.2.0",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "../../node_modules/.pnpm/dumper.js@1.3.1/node_modules/dumper.js": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caller-id": "^0.1.0",
+        "cycle": "^1.0.3",
+        "kind-of": "^6.0.2",
+        "kleur": "^3.0.2"
+      },
+      "devDependencies": {
+        "codecov": "^3.2.0",
+        "eslint": "^5.14.1",
+        "istanbul": "^0.4.5",
+        "jest": "^24.1.0",
+        "prettier": "^1.16.4"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-plugin-image@2.10.1_f74af8479d25966d617d12e25cc11177/node_modules/gatsby-plugin-image": {
+      "version": "2.10.1",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.14.0",
+        "@babel/parser": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "babel-jsx-utils": "^1.1.0",
+        "babel-plugin-remove-graphql-queries": "^4.10.1",
+        "camelcase": "^5.3.1",
+        "chokidar": "^3.5.2",
+        "common-tags": "^1.8.2",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.10.1",
+        "objectFitPolyfill": "^2.3.5",
+        "prop-types": "^15.7.2"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@testing-library/react": "^11.2.7",
+        "@types/babel__core": "^7.1.12",
+        "@types/babel__traverse": "^7.11.1",
+        "@types/fs-extra": "^9.0.13",
+        "@types/node": "^14.10.2",
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "^16.9.56",
+        "@types/react-dom": "^16.9.8",
+        "ast-pretty-print": "^2.0.1",
+        "babel-plugin-macros": "^2.8.0",
+        "cross-env": "^7.0.3",
+        "cssnano": "^4.1.10",
+        "del-cli": "^3.0.1",
+        "do-sync": "^3.0.11",
+        "microbundle": "^0.13.0",
+        "npm-run-all": "^4.1.5",
+        "postcss": "^8.2.9",
+        "terser": "^5.3.8",
+        "typescript": "^4.5.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.3",
+        "gatsby": "^4.0.0-next",
+        "gatsby-plugin-sharp": "^4.0.0-next",
+        "gatsby-source-filesystem": "^4.0.0-next",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-plugin-manifest@4.10.2_gatsby@4.10.3/node_modules/gatsby-plugin-manifest": {
+      "version": "4.10.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "gatsby-core-utils": "^3.10.1",
+        "gatsby-plugin-utils": "^3.4.2",
+        "semver": "^7.3.5",
+        "sharp": "^0.30.1"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-plugin-offline@5.10.2_81fde3177dbcd2f1894400551d888680/node_modules/gatsby-plugin-offline": {
+      "version": "5.10.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "cheerio": "^1.0.0-rc.10",
+        "gatsby-core-utils": "^3.10.1",
+        "glob": "^7.2.0",
+        "idb-keyval": "^3.2.0",
+        "lodash": "^4.17.21",
+        "workbox-build": "^4.3.1"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cpy-cli": "^3.1.1",
+        "cross-env": "^7.0.3",
+        "gatsby-plugin-utils": "^3.4.2",
+        "rewire": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-plugin-pnpm@1.2.10_gatsby@4.10.3/node_modules/gatsby-plugin-pnpm": {
+      "version": "1.2.10",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.uniq": "^4.5.0"
+      },
+      "devDependencies": {
+        "@jtechsvcs/eslint-config-typescript": "^2.0.3",
+        "@types/jest": "^25.1.2",
+        "@types/lodash.get": "^4.4.6",
+        "@types/lodash.uniq": "^4.5.6",
+        "@types/node": "^12.12.26",
+        "@types/webpack": "^4.41.5",
+        "@typescript-eslint/eslint-plugin": "^2.19.0",
+        "@typescript-eslint/parser": "^2.19.0",
+        "@typescript-eslint/typescript-estree": "^2.19.0",
+        "coveralls": "^3.0.9",
+        "eslint": "^6.8.0",
+        "gatsby": "^2.19.12",
+        "jest": "^25.1.0",
+        "npm-run-all": "^4.1.5",
+        "rimraf": "^3.0.1",
+        "ts-jest": "^25.2.0",
+        "type-fest": "^0.10.0",
+        "typedoc": "^0.15.8",
+        "typescript": "^3.7.5"
+      },
+      "peerDependencies": {
+        "gatsby": "~2.x.x || ~3.x.x || ~4.x.x"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-plugin-postcss@5.10.0_gatsby@4.10.3+postcss@8.4.12/node_modules/gatsby-plugin-postcss": {
+      "version": "5.10.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "postcss-loader": "^4.3.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next",
+        "postcss": "^8.0.5"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-plugin-react-helmet@5.10.0_gatsby@4.10.3+react-helmet@6.1.0/node_modules/gatsby-plugin-react-helmet": {
+      "version": "5.10.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next",
+        "react-helmet": "^5.1.3 || ^6.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-plugin-sharp@4.10.2_gatsby@4.10.3/node_modules/gatsby-plugin-sharp": {
+      "version": "4.10.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "async": "^3.2.3",
+        "bluebird": "^3.7.2",
+        "debug": "^4.3.3",
+        "filenamify": "^4.3.0",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.10.1",
+        "gatsby-plugin-utils": "^3.4.2",
+        "gatsby-telemetry": "^3.10.1",
+        "got": "^11.8.3",
+        "lodash": "^4.17.21",
+        "mini-svg-data-uri": "^1.4.3",
+        "potrace": "^2.1.8",
+        "probe-image-size": "^7.0.0",
+        "progress": "^2.0.3",
+        "semver": "^7.3.5",
+        "sharp": "^0.30.1",
+        "svgo": "1.3.2",
+        "uuid": "3.4.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@types/sharp": "^0.29.5",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3",
+        "gatsby-plugin-image": "^2.10.1"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-source-filesystem@4.10.1_gatsby@4.10.3/node_modules/gatsby-source-filesystem": {
+      "version": "4.10.1",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "chokidar": "^3.5.2",
+        "file-type": "^16.5.3",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.10.1",
+        "got": "^9.6.0",
+        "md5-file": "^5.0.0",
+        "mime": "^2.5.2",
+        "pretty-bytes": "^5.4.1",
+        "progress": "^2.0.3",
+        "valid-url": "^1.0.9",
+        "xstate": "^4.26.1"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-source-wordpress@6.10.2_bd9be9687c4c504d5e68b179d7a78803/node_modules/gatsby-source-wordpress": {
+      "version": "6.10.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@rematch/core": "^1.4.0",
+        "@rematch/immer": "^1.2.0",
+        "async-retry": "^1.3.3",
+        "atob": "^2.1.2",
+        "axios": "^0.21.1",
+        "axios-rate-limit": "^1.3.0",
+        "better-queue": "^3.8.10",
+        "btoa": "^1.2.1",
+        "cache-manager": "^3.6.0",
+        "cache-manager-fs-hash": "^0.0.9",
+        "chalk": "^4.1.2",
+        "cheerio": "^1.0.0-rc.10",
+        "clipboardy": "^2.3.0",
+        "diff": "^5.0.0",
+        "dumper.js": "^1.3.1",
+        "execall": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "file-type": "^15.0.1",
+        "filesize": "^6.4.0",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.10.1",
+        "gatsby-plugin-catch-links": "^4.10.0",
+        "gatsby-plugin-utils": "^3.4.2",
+        "gatsby-source-filesystem": "^4.10.1",
+        "glob": "^7.2.0",
+        "got": "^11.8.3",
+        "lodash": "^4.17.21",
+        "node-fetch": "^2.6.7",
+        "p-queue": "^6.6.2",
+        "prettier": "^2.5.1",
+        "read-chunk": "^3.2.0",
+        "replaceall": "^0.1.6",
+        "semver": "^7.3.5",
+        "sharp": "^0.30.1",
+        "valid-url": "^1.0.9"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@babel/plugin-proposal-class-properties": "^7.14.0",
+        "@babel/plugin-proposal-private-methods": "^7.14.0",
+        "@types/cache-manager": "^2.10.3",
+        "@types/ink": "^2.0.3",
+        "@types/semver": "^7.3.9",
+        "babel-plugin-import-globals": "^2.0.0",
+        "babel-plugin-module-resolver": "4.1.0",
+        "babel-preset-gatsby": "^2.10.1",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3",
+        "gatsby-plugin-image": "^2.10.1",
+        "identity-obj-proxy": "^3.0.0",
+        "react-test-renderer": "^16.14.0",
+        "rimraf": "^3.0.2",
+        "tree-kill": "^1.2.2",
+        "wait-on": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-zz-next.1",
+        "gatsby-plugin-image": "^2.0.0-zz-next.1",
+        "gatsby-plugin-sharp": "^4.0.0-zz-next.1",
+        "gatsby-transformer-sharp": "^4.0.0-zz-next.1"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby-transformer-sharp@4.10.0_bced32841dc092f03f390304902b3e7f/node_modules/gatsby-transformer-sharp": {
+      "version": "4.10.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "bluebird": "^3.7.2",
+        "common-tags": "^1.8.2",
+        "fs-extra": "^10.0.0",
+        "potrace": "^2.1.8",
+        "probe-image-size": "^7.0.0",
+        "semver": "^7.3.5",
+        "sharp": "^0.30.1"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@types/sharp": "^0.29.5",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next",
+        "gatsby-plugin-sharp": "^4.0.0-next"
+      }
+    },
+    "../../node_modules/.pnpm/gatsby@4.10.3_3a6359ff0dae16692fd6f0778ea71593/node_modules/gatsby": {
+      "version": "4.10.3",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.14.0",
+        "@babel/core": "^7.15.5",
+        "@babel/eslint-parser": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/parser": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "@gatsbyjs/reach-router": "^1.3.6",
+        "@gatsbyjs/webpack-hot-middleware": "^2.25.2",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@parcel/core": "^2.3.1",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
+        "@types/http-proxy": "^1.17.7",
+        "@typescript-eslint/eslint-plugin": "^4.33.0",
+        "@typescript-eslint/parser": "^4.33.0",
+        "@vercel/webpack-asset-relocator-loader": "^1.7.0",
+        "address": "1.1.2",
+        "anser": "^2.1.0",
+        "autoprefixer": "^10.4.0",
+        "axios": "^0.21.1",
+        "babel-loader": "^8.2.3",
+        "babel-plugin-add-module-exports": "^1.0.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "babel-plugin-lodash": "^3.3.4",
+        "babel-plugin-remove-graphql-queries": "^4.10.1",
+        "babel-preset-gatsby": "^2.10.1",
+        "better-opn": "^2.1.1",
+        "bluebird": "^3.7.2",
+        "body-parser": "^1.19.0",
+        "browserslist": "^4.17.5",
+        "cache-manager": "^2.11.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.2",
+        "common-tags": "^1.8.0",
+        "compression": "^1.7.4",
+        "cookie": "^0.4.1",
+        "core-js": "^3.17.2",
+        "cors": "^2.8.5",
+        "css-loader": "^5.2.7",
+        "css-minimizer-webpack-plugin": "^2.0.0",
+        "css.escape": "^1.5.1",
+        "date-fns": "^2.25.0",
+        "debug": "^3.2.7",
+        "deepmerge": "^4.2.2",
+        "detect-port": "^1.3.0",
+        "devcert": "^1.2.0",
+        "dotenv": "^8.6.0",
+        "enhanced-resolve": "^5.8.3",
+        "eslint": "^7.32.0",
+        "eslint-config-react-app": "^6.0.0",
+        "eslint-plugin-flowtype": "^5.10.0",
+        "eslint-plugin-graphql": "^4.0.0",
+        "eslint-plugin-import": "^2.25.4",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.29.2",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-webpack-plugin": "^2.6.0",
+        "event-source-polyfill": "^1.0.25",
+        "execa": "^5.1.1",
+        "express": "^4.17.1",
+        "express-graphql": "^0.12.0",
+        "fastest-levenshtein": "^1.0.12",
+        "fastq": "^1.13.0",
+        "file-loader": "^6.2.0",
+        "find-cache-dir": "^3.3.2",
+        "fs-exists-cached": "1.0.0",
+        "fs-extra": "^10.0.0",
+        "gatsby-cli": "^4.10.2",
+        "gatsby-core-utils": "^3.10.1",
+        "gatsby-graphiql-explorer": "^2.10.0",
+        "gatsby-legacy-polyfills": "^2.10.0",
+        "gatsby-link": "^4.10.1",
+        "gatsby-page-utils": "^2.10.1",
+        "gatsby-parcel-config": "^0.1.0",
+        "gatsby-plugin-page-creator": "^4.10.2",
+        "gatsby-plugin-typescript": "^4.10.1",
+        "gatsby-plugin-utils": "^3.4.2",
+        "gatsby-react-router-scroll": "^5.10.0",
+        "gatsby-telemetry": "^3.10.1",
+        "gatsby-worker": "^1.10.1",
+        "glob": "^7.2.0",
+        "globby": "^11.1.0",
+        "got": "^11.8.2",
+        "graphql": "^15.7.2",
+        "graphql-compose": "^9.0.7",
+        "graphql-playground-middleware-express": "^1.7.22",
+        "hasha": "^5.2.2",
+        "http-proxy": "^1.18.1",
+        "invariant": "^2.2.4",
+        "is-relative": "^1.0.0",
+        "is-relative-url": "^3.0.0",
+        "joi": "^17.4.2",
+        "json-loader": "^0.5.7",
+        "latest-version": "5.1.0",
+        "lmdb": "^2.2.3",
+        "lodash": "^4.17.21",
+        "md5-file": "^5.0.0",
+        "meant": "^1.0.3",
+        "memoizee": "^0.4.15",
+        "micromatch": "^4.0.4",
+        "mime": "^2.5.2",
+        "mini-css-extract-plugin": "1.6.2",
+        "mitt": "^1.2.0",
+        "moment": "^2.29.1",
+        "multer": "^1.4.3",
+        "node-fetch": "^2.6.6",
+        "normalize-path": "^3.0.0",
+        "null-loader": "^4.0.1",
+        "opentracing": "^0.14.5",
+        "p-defer": "^3.0.0",
+        "parseurl": "^1.3.3",
+        "physical-cpu-count": "^2.0.0",
+        "platform": "^1.3.6",
+        "postcss": "^8.3.11",
+        "postcss-flexbugs-fixes": "^5.0.2",
+        "postcss-loader": "^5.3.0",
+        "prompts": "^2.4.2",
+        "prop-types": "^15.7.2",
+        "query-string": "^6.14.1",
+        "raw-loader": "^4.0.2",
+        "react-dev-utils": "^11.0.4",
+        "react-refresh": "^0.9.0",
+        "redux": "4.1.2",
+        "redux-thunk": "^2.4.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.5",
+        "shallow-compare": "^1.2.2",
+        "signal-exit": "^3.0.5",
+        "slugify": "^1.6.1",
+        "socket.io": "3.1.2",
+        "socket.io-client": "3.1.3",
+        "source-map": "^0.7.3",
+        "source-map-support": "^0.5.20",
+        "st": "^2.0.0",
+        "stack-trace": "^0.0.10",
+        "string-similarity": "^1.2.2",
+        "strip-ansi": "^6.0.1",
+        "style-loader": "^2.0.0",
+        "terser-webpack-plugin": "^5.2.4",
+        "tmp": "^0.2.1",
+        "true-case-path": "^2.2.1",
+        "type-of": "^2.0.1",
+        "url-loader": "^4.1.1",
+        "uuid": "^8.3.2",
+        "webpack": "^5.61.0",
+        "webpack-dev-middleware": "^4.3.0",
+        "webpack-merge": "^5.8.0",
+        "webpack-stats-plugin": "^1.0.3",
+        "webpack-virtual-modules": "^0.3.2",
+        "xstate": "^4.26.0",
+        "yaml-loader": "^0.6.0"
+      },
+      "bin": {
+        "gatsby": "cli.js"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/register": "^7.15.3",
+        "@types/eslint": "^8.2.1",
+        "@types/express": "^4.17.13",
+        "@types/micromatch": "^4.0.1",
+        "@types/normalize-path": "^3.0.0",
+        "@types/reach__router": "^1.3.5",
+        "@types/react-dom": "^17.0.9",
+        "@types/semver": "^7.3.9",
+        "@types/sharp": "^0.29.5",
+        "@types/signal-exit": "^3.0.0",
+        "@types/string-similarity": "^4.0.0",
+        "@types/tmp": "^0.2.0",
+        "@types/webpack-virtual-modules": "^0.1.1",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "copyfiles": "^2.3.0",
+        "cross-env": "^7.0.3",
+        "documentation": "^13.1.0",
+        "react": "^16.12.0",
+        "react-dom": "^16.12.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.5.5",
+        "xhr-mock": "^2.5.1",
+        "zipkin": "^0.22.0",
+        "zipkin-javascript-opentracing": "^3.0.0",
+        "zipkin-transport-http": "^0.22.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "optionalDependencies": {
+        "gatsby-sharp": "^0.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/html-react-parser@1.4.9_react@17.0.2/node_modules/html-react-parser": {
+      "version": "1.4.9",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "4.3.1",
+        "html-dom-parser": "1.1.1",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.0"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "16.2.3",
+        "@commitlint/config-conventional": "16.2.1",
+        "@rollup/plugin-commonjs": "21.0.2",
+        "@rollup/plugin-node-resolve": "13.1.3",
+        "@size-limit/preset-big-lib": "7.0.8",
+        "@types/react": "17.0.41",
+        "@typescript-eslint/parser": "5.15.0",
+        "benchmark": "2.1.4",
+        "dtslint": "4.2.1",
+        "eslint": "8.11.0",
+        "eslint-plugin-prettier": "4.0.0",
+        "husky": "7.0.4",
+        "jest": "27.5.1",
+        "lint-staged": "12.3.7",
+        "pinst": "3.0.0",
+        "preact": "10.6.6",
+        "prettier": "2.6.0",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
+        "rimraf": "3.0.2",
+        "rollup": "2.70.1",
+        "rollup-plugin-terser": "7.0.2",
+        "size-limit": "7.0.8",
+        "typescript": "4.6.2"
+      },
+      "peerDependencies": {
+        "react": "0.14 || 15 || 16 || 17"
+      }
+    },
+    "../../node_modules/.pnpm/lodash@4.17.21/node_modules/lodash": {
+      "version": "4.17.21",
+      "license": "MIT"
+    },
+    "../../node_modules/.pnpm/mitt@3.0.0/node_modules/mitt": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/chai": "^4.2.11",
+        "@types/mocha": "^7.0.2",
+        "@types/sinon": "^9.0.4",
+        "@types/sinon-chai": "^3.2.4",
+        "@typescript-eslint/eslint-plugin": "^3.0.1",
+        "@typescript-eslint/parser": "^3.0.1",
+        "chai": "^4.2.0",
+        "documentation": "^13.0.0",
+        "eslint": "^7.1.0",
+        "eslint-config-developit": "^1.2.0",
+        "esm": "^3.2.25",
+        "microbundle": "^0.12.3",
+        "mocha": "^8.0.1",
+        "npm-run-all": "^4.1.5",
+        "rimraf": "^3.0.2",
+        "sinon": "^9.0.2",
+        "sinon-chai": "^3.5.0",
+        "ts-node": "^8.10.2",
+        "typescript": "^3.9.7"
+      }
+    },
+    "../../node_modules/.pnpm/postcss@8.4.12/node_modules/postcss": {
+      "version": "8.4.12",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.1",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "../../node_modules/.pnpm/prettier@2.5.1/node_modules/prettier": {
+      "version": "2.5.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "../../node_modules/.pnpm/react-dom@17.0.2_react@17.0.2/node_modules/react-dom": {
+      "version": "17.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "../../node_modules/.pnpm/react-helmet@6.1.0_react@17.0.2/node_modules/react-helmet": {
+      "version": "6.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "devDependencies": {
+        "babel-core": "^6.24.0",
+        "babel-eslint": "^9.0.0",
+        "babel-plugin-external-helpers": "^6.22.0",
+        "babel-plugin-istanbul": "^4.0.0",
+        "babel-plugin-transform-class-properties": "^6.23.0",
+        "babel-plugin-transform-object-rest-spread": "^6.23.0",
+        "babel-preset-env": "^1.2.2",
+        "babel-preset-react": "^6.23.0",
+        "chai": "^3.5.0",
+        "codecov": "^3.6.5",
+        "conventional-changelog-cli": "^1.3.1",
+        "cz-conventional-changelog": "^2.0.0",
+        "eslint": "^3.18.0",
+        "eslint-config-nfl": "^11.1.0",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-plugin-import": "^2.2.0",
+        "eslint-plugin-jsx-a11y": "^6.2.3",
+        "eslint-plugin-mocha": "^4.9.0",
+        "eslint-plugin-prettier": "^2.1.2",
+        "eslint-plugin-react": "^6.10.2",
+        "istanbul": "^0.4.5",
+        "karma": "^1.5.0",
+        "karma-chai": "^0.1.0",
+        "karma-chai-sinon": "^0.1.5",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-coverage": "^1.1.1",
+        "karma-firefox-launcher": "^1.0.1",
+        "karma-html-reporter": "^0.2.7",
+        "karma-mocha": "^2.0.1",
+        "karma-rollup-preprocessor": "^6.1.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-spec-reporter": "^0.0.32",
+        "karma-tap-reporter": "^0.0.6",
+        "mocha": "^7.2.0",
+        "prettier": "^1.4.4",
+        "react": "16.13.1",
+        "react-dom": "16.13.1",
+        "rimraf": "^3.0.2",
+        "rollup": "^0.67.0",
+        "rollup-plugin-babel": "^3.0.7",
+        "rollup-plugin-commonjs": "^9.2.0",
+        "rollup-plugin-node-resolve": "^3.4.0",
+        "rollup-plugin-replace": "^2.1.0",
+        "sinon": "^2.1.0",
+        "sinon-chai": "^2.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "../../node_modules/.pnpm/react@17.0.2/node_modules/react": {
+      "version": "17.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/.pnpm/tailwindcss@3.0.23_autoprefixer@10.4.4/node_modules/tailwindcss": {
+      "version": "3.0.23",
+      "license": "MIT",
+      "dependencies": {
+        "arg": "^5.0.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "color-name": "^1.1.4",
+        "cosmiconfig": "^7.0.1",
+        "detective": "^5.2.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^2.2.0",
+        "postcss": "^8.4.6",
+        "postcss-js": "^4.0.0",
+        "postcss-load-config": "^3.1.0",
+        "postcss-nested": "5.0.6",
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0",
+        "quick-lru": "^5.1.1",
+        "resolve": "^1.22.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "devDependencies": {
+        "@swc/cli": "^0.1.55",
+        "@swc/core": "^1.2.127",
+        "@swc/jest": "^0.2.17",
+        "@swc/register": "^0.1.10",
+        "autoprefixer": "^10.4.2",
+        "cssnano": "^5.0.16",
+        "esbuild": "^0.14.21",
+        "eslint": "^8.8.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "jest": "^27.5.1",
+        "jest-diff": "^27.5.1",
+        "prettier": "^2.5.1",
+        "prettier-plugin-tailwindcss": "^0.1.7",
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "autoprefixer": "^10.0.2",
+        "postcss": "^8.0.9"
+      }
+    },
+    "../../node_modules/.pnpm/typeface-merriweather@1.1.13/node_modules/typeface-merriweather": {
+      "version": "1.1.13",
+      "license": "MIT"
+    },
+    "../../node_modules/.pnpm/typeface-montserrat@1.1.13/node_modules/typeface-montserrat": {
+      "version": "1.1.13",
+      "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/highlight": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
+      "integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
+      "peer": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.9",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helpers": "^7.17.9",
+        "@babel/parser": "^7.17.9",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.9",
+        "@babel/types": "^7.17.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.9.tgz",
+      "integrity": "sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-validator-option": "^7.16.7",
+        "browserslist": "^4.17.5",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+      "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.17.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-simple-access": "^7.17.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.17.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
+      "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.9",
+        "@babel/types": "^7.17.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.9.tgz",
+      "integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==",
+      "peer": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.9.tgz",
+      "integrity": "sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.9",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.17.9",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.9",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.1",
+        "globals": "^13.9.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "peer": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "peer": true
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "peer": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "resolved": "../../node_modules/.pnpm/@tailwindcss+typography@0.5.2_tailwindcss@3.0.23/node_modules/@tailwindcss/typography",
+      "link": true
+    },
+    "node_modules/@types/eslint": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+      "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "peer": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "peer": true
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/helper-wasm-section": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-opt": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "@webassemblyjs/wast-printer": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "peer": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "peer": true
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "peer": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "peer": true
+    },
+    "node_modules/autoprefixer": {
+      "resolved": "../../node_modules/.pnpm/autoprefixer@10.4.4_postcss@8.4.12/node_modules/autoprefixer",
+      "link": true
+    },
+    "node_modules/babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.12.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "peer": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.20.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001317",
+        "electron-to-chromium": "^1.4.84",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.2",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "peer": true
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001331",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001331.tgz",
+      "integrity": "sha512-Y1xk6paHpUXKP/P6YjQv1xqyTbgAP05ycHBcRdQjTcyXlWol868sJJPlmk5ylOekw2BrucWes5jk+LvVd7WZ5Q==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "peer": true
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "peer": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "peer": true
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "peer": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dumper.js": {
+      "resolved": "../../node_modules/.pnpm/dumper.js@1.3.1/node_modules/dumper.js",
+      "link": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.107",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.107.tgz",
+      "integrity": "sha512-Huen6taaVrUrSy8o7mGStByba8PfOWWluHNxSHGBrCgEdFVLtvdQDBr9LBCF9Uci8SYxh28QNNMO0oC17wbGAg==",
+      "peer": true
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+      "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "peer": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "peer": true,
+      "dependencies": {
+        "@eslint/eslintrc": "^1.2.1",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "peer": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "peer": true
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "peer": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "peer": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "peer": true
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "peer": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "peer": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "peer": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "peer": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "peer": true
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "peer": true
+    },
+    "node_modules/gatsby": {
+      "resolved": "../../node_modules/.pnpm/gatsby@4.10.3_3a6359ff0dae16692fd6f0778ea71593/node_modules/gatsby",
+      "link": true
+    },
+    "node_modules/gatsby-plugin-image": {
+      "resolved": "../../node_modules/.pnpm/gatsby-plugin-image@2.10.1_f74af8479d25966d617d12e25cc11177/node_modules/gatsby-plugin-image",
+      "link": true
+    },
+    "node_modules/gatsby-plugin-manifest": {
+      "resolved": "../../node_modules/.pnpm/gatsby-plugin-manifest@4.10.2_gatsby@4.10.3/node_modules/gatsby-plugin-manifest",
+      "link": true
+    },
+    "node_modules/gatsby-plugin-offline": {
+      "resolved": "../../node_modules/.pnpm/gatsby-plugin-offline@5.10.2_81fde3177dbcd2f1894400551d888680/node_modules/gatsby-plugin-offline",
+      "link": true
+    },
+    "node_modules/gatsby-plugin-pnpm": {
+      "resolved": "../../node_modules/.pnpm/gatsby-plugin-pnpm@1.2.10_gatsby@4.10.3/node_modules/gatsby-plugin-pnpm",
+      "link": true
+    },
+    "node_modules/gatsby-plugin-postcss": {
+      "resolved": "../../node_modules/.pnpm/gatsby-plugin-postcss@5.10.0_gatsby@4.10.3+postcss@8.4.12/node_modules/gatsby-plugin-postcss",
+      "link": true
+    },
+    "node_modules/gatsby-plugin-react-helmet": {
+      "resolved": "../../node_modules/.pnpm/gatsby-plugin-react-helmet@5.10.0_gatsby@4.10.3+react-helmet@6.1.0/node_modules/gatsby-plugin-react-helmet",
+      "link": true
+    },
+    "node_modules/gatsby-plugin-sharp": {
+      "resolved": "../../node_modules/.pnpm/gatsby-plugin-sharp@4.10.2_gatsby@4.10.3/node_modules/gatsby-plugin-sharp",
+      "link": true
+    },
+    "node_modules/gatsby-source-filesystem": {
+      "resolved": "../../node_modules/.pnpm/gatsby-source-filesystem@4.10.1_gatsby@4.10.3/node_modules/gatsby-source-filesystem",
+      "link": true
+    },
+    "node_modules/gatsby-source-wordpress": {
+      "resolved": "../../node_modules/.pnpm/gatsby-source-wordpress@6.10.2_bd9be9687c4c504d5e68b179d7a78803/node_modules/gatsby-source-wordpress",
+      "link": true
+    },
+    "node_modules/gatsby-transformer-sharp": {
+      "resolved": "../../node_modules/.pnpm/gatsby-transformer-sharp@4.10.0_bced32841dc092f03f390304902b3e7f/node_modules/gatsby-transformer-sharp",
+      "link": true
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "peer": true
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "peer": true
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "resolved": "../../node_modules/.pnpm/html-react-parser@1.4.9_react@17.0.2/node_modules/html-react-parser",
+      "link": true
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "peer": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "peer": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "peer": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "peer": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "peer": true
+    },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "peer": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "peer": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "peer": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "peer": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "node_modules/lodash": {
+      "resolved": "../../node_modules/.pnpm/lodash@4.17.21/node_modules/lodash",
+      "link": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "peer": true
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "peer": true
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mitt": {
+      "resolved": "../../node_modules/.pnpm/mitt@3.0.0/node_modules/mitt",
+      "link": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "peer": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "peer": true
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "peer": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
+      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
+      "peer": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "peer": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "peer": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "peer": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "peer": true
+    },
+    "node_modules/postcss": {
+      "resolved": "../../node_modules/.pnpm/postcss@8.4.12/node_modules/postcss",
+      "link": true
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "resolved": "../../node_modules/.pnpm/prettier@2.5.1/node_modules/prettier",
+      "link": true
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "resolved": "../../node_modules/.pnpm/react@17.0.2/node_modules/react",
+      "link": true
+    },
+    "node_modules/react-dom": {
+      "resolved": "../../node_modules/.pnpm/react-dom@17.0.2_react@17.0.2/node_modules/react-dom",
+      "link": true
+    },
+    "node_modules/react-helmet": {
+      "resolved": "../../node_modules/.pnpm/react-helmet@6.1.0_react@17.0.2/node_modules/react-helmet",
+      "link": true
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "peer": true,
+      "dependencies": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "peer": true
+    },
+    "node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "peer": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "resolved": "../../node_modules/.pnpm/tailwindcss@3.0.23_autoprefixer@10.4.4/node_modules/tailwindcss",
+      "link": true
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
+      "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
+      "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+      "peer": true,
+      "dependencies": {
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^3.1.1",
+        "serialize-javascript": "^6.0.0",
+        "source-map": "^0.6.1",
+        "terser": "^5.7.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/terser/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "peer": true
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typeface-merriweather": {
+      "resolved": "../../node_modules/.pnpm/typeface-merriweather@1.1.13/node_modules/typeface-merriweather",
+      "link": true
+    },
+    "node_modules/typeface-montserrat": {
+      "resolved": "../../node_modules/.pnpm/typeface-montserrat@1.1.13/node_modules/typeface-montserrat",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "peer": true
+    },
+    "node_modules/watchpack": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+      "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+      "peer": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.72.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
+      "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/wasm-edit": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "acorn": "^8.4.1",
+        "acorn-import-assertions": "^1.7.6",
+        "browserslist": "^4.14.5",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.9.2",
+        "es-module-lexer": "^0.9.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.9",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.1.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.1.3",
+        "watchpack": "^2.3.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    }
+  },
+  "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "peer": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "peer": true,
+      "requires": {
+        "@babel/highlight": "^7.16.7"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
+      "peer": true
+    },
+    "@babel/core": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
+      "integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
+      "peer": true,
+      "requires": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.9",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helpers": "^7.17.9",
+        "@babel/parser": "^7.17.9",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.9",
+        "@babel/types": "^7.17.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.9.tgz",
+      "integrity": "sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
+      "peer": true,
+      "requires": {
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-validator-option": "^7.16.7",
+        "browserslist": "^4.17.5",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+      "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+      "peer": true,
+      "requires": {
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.17.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-simple-access": "^7.17.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.17.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "peer": true,
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "peer": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+      "peer": true
+    },
+    "@babel/helpers": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
+      "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+      "peer": true,
+      "requires": {
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.9",
+        "@babel/types": "^7.17.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.9.tgz",
+      "integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==",
+      "peer": true
+    },
+    "@babel/template": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.9.tgz",
+      "integrity": "sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.9",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.17.9",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.9",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+      "peer": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.1",
+        "globals": "^13.9.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "13.13.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+          "peer": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        }
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "peer": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "peer": true
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "peer": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "peer": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "peer": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@tailwindcss/typography": {
+      "version": "file:../../node_modules/.pnpm/@tailwindcss+typography@0.5.2_tailwindcss@3.0.23/node_modules/@tailwindcss/typography",
+      "requires": {
+        "@mdx-js/loader": "^1.0.19",
+        "@mdx-js/mdx": "^1.6.6",
+        "@next/mdx": "^8.1.0",
+        "autoprefixer": "^10.2.1",
+        "highlight.js": "^10.4.1",
+        "jest": "^26.6.1",
+        "jest-diff": "^27.3.1",
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "next": "^12.0.1",
+        "postcss": "^8.2.3",
+        "prettier": "^2.1.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "tailwindcss": "^3.0.0-alpha.2"
+      }
+    },
+    "@types/eslint": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+      "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+      "peer": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
+      "peer": true,
+      "requires": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "peer": true
+    },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "peer": true
+    },
+    "@types/node": {
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "peer": true
+    },
+    "@webassemblyjs/ast": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/helper-numbers": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+      "peer": true
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+      "peer": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+      "peer": true
+    },
+    "@webassemblyjs/helper-numbers": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+      "peer": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+      "peer": true,
+      "requires": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+      "peer": true,
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+      "peer": true
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/helper-wasm-section": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-opt": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "@webassemblyjs/wast-printer": "1.11.1"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+      "peer": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "peer": true
+    },
+    "@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "peer": true
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "peer": true
+    },
+    "acorn-import-assertions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "peer": true,
+      "requires": {}
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "peer": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "peer": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "peer": true
+    },
+    "autoprefixer": {
+      "version": "file:../../node_modules/.pnpm/autoprefixer@10.4.4_postcss@8.4.12/node_modules/autoprefixer",
+      "requires": {
+        "browserslist": "^4.20.2",
+        "caniuse-lite": "^1.0.30001317",
+        "fraction.js": "^4.2.0",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "peer": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "peer": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.20.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "peer": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001317",
+        "electron-to-chromium": "^1.4.84",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.2",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "peer": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "peer": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001331",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001331.tgz",
+      "integrity": "sha512-Y1xk6paHpUXKP/P6YjQv1xqyTbgAP05ycHBcRdQjTcyXlWol868sJJPlmk5ylOekw2BrucWes5jk+LvVd7WZ5Q==",
+      "peer": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "peer": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chrome-trace-event": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "peer": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "peer": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "peer": true
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "peer": true
+    },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "peer": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "peer": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "peer": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "peer": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "peer": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "dumper.js": {
+      "version": "file:../../node_modules/.pnpm/dumper.js@1.3.1/node_modules/dumper.js",
+      "requires": {
+        "caller-id": "^0.1.0",
+        "codecov": "^3.2.0",
+        "cycle": "^1.0.3",
+        "eslint": "^5.14.1",
+        "istanbul": "^0.4.5",
+        "jest": "^24.1.0",
+        "kind-of": "^6.0.2",
+        "kleur": "^3.0.2",
+        "prettier": "^1.16.4"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.4.107",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.107.tgz",
+      "integrity": "sha512-Huen6taaVrUrSy8o7mGStByba8PfOWWluHNxSHGBrCgEdFVLtvdQDBr9LBCF9Uci8SYxh28QNNMO0oC17wbGAg==",
+      "peer": true
+    },
+    "enhanced-resolve": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
+      "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
+      "peer": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      }
+    },
+    "es-module-lexer": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "peer": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "peer": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "peer": true
+    },
+    "eslint": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
+      "peer": true,
+      "requires": {
+        "@eslint/eslintrc": "^1.2.1",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "peer": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "peer": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "peer": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "peer": true
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "peer": true
+        },
+        "globals": {
+          "version": "13.13.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+          "peer": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "peer": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "peer": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "peer": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "peer": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "peer": true
+    },
+    "espree": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "peer": true,
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "peer": true
+        }
+      }
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "peer": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "peer": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "peer": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "peer": true
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "peer": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "peer": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "peer": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "peer": true
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "peer": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "peer": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "peer": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "peer": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "peer": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "peer": true
+    },
+    "gatsby": {
+      "version": "file:../../node_modules/.pnpm/gatsby@4.10.3_3a6359ff0dae16692fd6f0778ea71593/node_modules/gatsby",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/code-frame": "^7.14.0",
+        "@babel/core": "^7.15.5",
+        "@babel/eslint-parser": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/parser": "^7.15.5",
+        "@babel/register": "^7.15.3",
+        "@babel/runtime": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "@gatsbyjs/reach-router": "^1.3.6",
+        "@gatsbyjs/webpack-hot-middleware": "^2.25.2",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@parcel/core": "^2.3.1",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
+        "@types/eslint": "^8.2.1",
+        "@types/express": "^4.17.13",
+        "@types/http-proxy": "^1.17.7",
+        "@types/micromatch": "^4.0.1",
+        "@types/normalize-path": "^3.0.0",
+        "@types/reach__router": "^1.3.5",
+        "@types/react-dom": "^17.0.9",
+        "@types/semver": "^7.3.9",
+        "@types/sharp": "^0.29.5",
+        "@types/signal-exit": "^3.0.0",
+        "@types/string-similarity": "^4.0.0",
+        "@types/tmp": "^0.2.0",
+        "@types/webpack-virtual-modules": "^0.1.1",
+        "@typescript-eslint/eslint-plugin": "^4.33.0",
+        "@typescript-eslint/parser": "^4.33.0",
+        "@vercel/webpack-asset-relocator-loader": "^1.7.0",
+        "address": "1.1.2",
+        "anser": "^2.1.0",
+        "autoprefixer": "^10.4.0",
+        "axios": "^0.21.1",
+        "babel-loader": "^8.2.3",
+        "babel-plugin-add-module-exports": "^1.0.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "babel-plugin-lodash": "^3.3.4",
+        "babel-plugin-remove-graphql-queries": "^4.10.1",
+        "babel-preset-gatsby": "^2.10.1",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "better-opn": "^2.1.1",
+        "bluebird": "^3.7.2",
+        "body-parser": "^1.19.0",
+        "browserslist": "^4.17.5",
+        "cache-manager": "^2.11.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.2",
+        "common-tags": "^1.8.0",
+        "compression": "^1.7.4",
+        "cookie": "^0.4.1",
+        "copyfiles": "^2.3.0",
+        "core-js": "^3.17.2",
+        "cors": "^2.8.5",
+        "cross-env": "^7.0.3",
+        "css-loader": "^5.2.7",
+        "css-minimizer-webpack-plugin": "^2.0.0",
+        "css.escape": "^1.5.1",
+        "date-fns": "^2.25.0",
+        "debug": "^3.2.7",
+        "deepmerge": "^4.2.2",
+        "detect-port": "^1.3.0",
+        "devcert": "^1.2.0",
+        "documentation": "^13.1.0",
+        "dotenv": "^8.6.0",
+        "enhanced-resolve": "^5.8.3",
+        "eslint": "^7.32.0",
+        "eslint-config-react-app": "^6.0.0",
+        "eslint-plugin-flowtype": "^5.10.0",
+        "eslint-plugin-graphql": "^4.0.0",
+        "eslint-plugin-import": "^2.25.4",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.29.2",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-webpack-plugin": "^2.6.0",
+        "event-source-polyfill": "^1.0.25",
+        "execa": "^5.1.1",
+        "express": "^4.17.1",
+        "express-graphql": "^0.12.0",
+        "fastest-levenshtein": "^1.0.12",
+        "fastq": "^1.13.0",
+        "file-loader": "^6.2.0",
+        "find-cache-dir": "^3.3.2",
+        "fs-exists-cached": "1.0.0",
+        "fs-extra": "^10.0.0",
+        "gatsby-cli": "^4.10.2",
+        "gatsby-core-utils": "^3.10.1",
+        "gatsby-graphiql-explorer": "^2.10.0",
+        "gatsby-legacy-polyfills": "^2.10.0",
+        "gatsby-link": "^4.10.1",
+        "gatsby-page-utils": "^2.10.1",
+        "gatsby-parcel-config": "^0.1.0",
+        "gatsby-plugin-page-creator": "^4.10.2",
+        "gatsby-plugin-typescript": "^4.10.1",
+        "gatsby-plugin-utils": "^3.4.2",
+        "gatsby-react-router-scroll": "^5.10.0",
+        "gatsby-sharp": "^0.4.0",
+        "gatsby-telemetry": "^3.10.1",
+        "gatsby-worker": "^1.10.1",
+        "glob": "^7.2.0",
+        "globby": "^11.1.0",
+        "got": "^11.8.2",
+        "graphql": "^15.7.2",
+        "graphql-compose": "^9.0.7",
+        "graphql-playground-middleware-express": "^1.7.22",
+        "hasha": "^5.2.2",
+        "http-proxy": "^1.18.1",
+        "invariant": "^2.2.4",
+        "is-relative": "^1.0.0",
+        "is-relative-url": "^3.0.0",
+        "joi": "^17.4.2",
+        "json-loader": "^0.5.7",
+        "latest-version": "5.1.0",
+        "lmdb": "^2.2.3",
+        "lodash": "^4.17.21",
+        "md5-file": "^5.0.0",
+        "meant": "^1.0.3",
+        "memoizee": "^0.4.15",
+        "micromatch": "^4.0.4",
+        "mime": "^2.5.2",
+        "mini-css-extract-plugin": "1.6.2",
+        "mitt": "^1.2.0",
+        "moment": "^2.29.1",
+        "multer": "^1.4.3",
+        "node-fetch": "^2.6.6",
+        "normalize-path": "^3.0.0",
+        "null-loader": "^4.0.1",
+        "opentracing": "^0.14.5",
+        "p-defer": "^3.0.0",
+        "parseurl": "^1.3.3",
+        "physical-cpu-count": "^2.0.0",
+        "platform": "^1.3.6",
+        "postcss": "^8.3.11",
+        "postcss-flexbugs-fixes": "^5.0.2",
+        "postcss-loader": "^5.3.0",
+        "prompts": "^2.4.2",
+        "prop-types": "^15.7.2",
+        "query-string": "^6.14.1",
+        "raw-loader": "^4.0.2",
+        "react": "^16.12.0",
+        "react-dev-utils": "^11.0.4",
+        "react-dom": "^16.12.0",
+        "react-refresh": "^0.9.0",
+        "redux": "4.1.2",
+        "redux-thunk": "^2.4.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "shallow-compare": "^1.2.2",
+        "signal-exit": "^3.0.5",
+        "slugify": "^1.6.1",
+        "socket.io": "3.1.2",
+        "socket.io-client": "3.1.3",
+        "source-map": "^0.7.3",
+        "source-map-support": "^0.5.20",
+        "st": "^2.0.0",
+        "stack-trace": "^0.0.10",
+        "string-similarity": "^1.2.2",
+        "strip-ansi": "^6.0.1",
+        "style-loader": "^2.0.0",
+        "terser-webpack-plugin": "^5.2.4",
+        "tmp": "^0.2.1",
+        "true-case-path": "^2.2.1",
+        "type-of": "^2.0.1",
+        "typescript": "^4.5.5",
+        "url-loader": "^4.1.1",
+        "uuid": "^8.3.2",
+        "webpack": "^5.61.0",
+        "webpack-dev-middleware": "^4.3.0",
+        "webpack-merge": "^5.8.0",
+        "webpack-stats-plugin": "^1.0.3",
+        "webpack-virtual-modules": "^0.3.2",
+        "xhr-mock": "^2.5.1",
+        "xstate": "^4.26.0",
+        "yaml-loader": "^0.6.0",
+        "zipkin": "^0.22.0",
+        "zipkin-javascript-opentracing": "^3.0.0",
+        "zipkin-transport-http": "^0.22.0"
+      }
+    },
+    "gatsby-plugin-image": {
+      "version": "file:../../node_modules/.pnpm/gatsby-plugin-image@2.10.1_f74af8479d25966d617d12e25cc11177/node_modules/gatsby-plugin-image",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/code-frame": "^7.14.0",
+        "@babel/core": "^7.15.5",
+        "@babel/parser": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@testing-library/react": "^11.2.7",
+        "@types/babel__core": "^7.1.12",
+        "@types/babel__traverse": "^7.11.1",
+        "@types/fs-extra": "^9.0.13",
+        "@types/node": "^14.10.2",
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "^16.9.56",
+        "@types/react-dom": "^16.9.8",
+        "ast-pretty-print": "^2.0.1",
+        "babel-jsx-utils": "^1.1.0",
+        "babel-plugin-macros": "^2.8.0",
+        "babel-plugin-remove-graphql-queries": "^4.10.1",
+        "camelcase": "^5.3.1",
+        "chokidar": "^3.5.2",
+        "common-tags": "^1.8.2",
+        "cross-env": "^7.0.3",
+        "cssnano": "^4.1.10",
+        "del-cli": "^3.0.1",
+        "do-sync": "^3.0.11",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.10.1",
+        "microbundle": "^0.13.0",
+        "npm-run-all": "^4.1.5",
+        "objectFitPolyfill": "^2.3.5",
+        "postcss": "^8.2.9",
+        "prop-types": "^15.7.2",
+        "terser": "^5.3.8",
+        "typescript": "^4.5.5"
+      }
+    },
+    "gatsby-plugin-manifest": {
+      "version": "file:../../node_modules/.pnpm/gatsby-plugin-manifest@4.10.2_gatsby@4.10.3/node_modules/gatsby-plugin-manifest",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3",
+        "gatsby-core-utils": "^3.10.1",
+        "gatsby-plugin-utils": "^3.4.2",
+        "semver": "^7.3.5",
+        "sharp": "^0.30.1"
+      }
+    },
+    "gatsby-plugin-offline": {
+      "version": "file:../../node_modules/.pnpm/gatsby-plugin-offline@5.10.2_81fde3177dbcd2f1894400551d888680/node_modules/gatsby-plugin-offline",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cheerio": "^1.0.0-rc.10",
+        "cpy-cli": "^3.1.1",
+        "cross-env": "^7.0.3",
+        "gatsby-core-utils": "^3.10.1",
+        "gatsby-plugin-utils": "^3.4.2",
+        "glob": "^7.2.0",
+        "idb-keyval": "^3.2.0",
+        "lodash": "^4.17.21",
+        "rewire": "^6.0.0",
+        "workbox-build": "^4.3.1"
+      }
+    },
+    "gatsby-plugin-pnpm": {
+      "version": "file:../../node_modules/.pnpm/gatsby-plugin-pnpm@1.2.10_gatsby@4.10.3/node_modules/gatsby-plugin-pnpm",
+      "requires": {
+        "@jtechsvcs/eslint-config-typescript": "^2.0.3",
+        "@types/jest": "^25.1.2",
+        "@types/lodash.get": "^4.4.6",
+        "@types/lodash.uniq": "^4.5.6",
+        "@types/node": "^12.12.26",
+        "@types/webpack": "^4.41.5",
+        "@typescript-eslint/eslint-plugin": "^2.19.0",
+        "@typescript-eslint/parser": "^2.19.0",
+        "@typescript-eslint/typescript-estree": "^2.19.0",
+        "coveralls": "^3.0.9",
+        "eslint": "^6.8.0",
+        "gatsby": "^2.19.12",
+        "jest": "^25.1.0",
+        "lodash.get": "^4.4.2",
+        "lodash.uniq": "^4.5.0",
+        "npm-run-all": "^4.1.5",
+        "rimraf": "^3.0.1",
+        "ts-jest": "^25.2.0",
+        "type-fest": "^0.10.0",
+        "typedoc": "^0.15.8",
+        "typescript": "^3.7.5"
+      }
+    },
+    "gatsby-plugin-postcss": {
+      "version": "file:../../node_modules/.pnpm/gatsby-plugin-postcss@5.10.0_gatsby@4.10.3+postcss@8.4.12/node_modules/gatsby-plugin-postcss",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3",
+        "postcss-loader": "^4.3.0"
+      }
+    },
+    "gatsby-plugin-react-helmet": {
+      "version": "file:../../node_modules/.pnpm/gatsby-plugin-react-helmet@5.10.0_gatsby@4.10.3+react-helmet@6.1.0/node_modules/gatsby-plugin-react-helmet",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "cross-env": "^7.0.3"
+      }
+    },
+    "gatsby-plugin-sharp": {
+      "version": "file:../../node_modules/.pnpm/gatsby-plugin-sharp@4.10.2_gatsby@4.10.3/node_modules/gatsby-plugin-sharp",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "@types/sharp": "^0.29.5",
+        "async": "^3.2.3",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "bluebird": "^3.7.2",
+        "cross-env": "^7.0.3",
+        "debug": "^4.3.3",
+        "filenamify": "^4.3.0",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.10.1",
+        "gatsby-plugin-image": "^2.10.1",
+        "gatsby-plugin-utils": "^3.4.2",
+        "gatsby-telemetry": "^3.10.1",
+        "got": "^11.8.3",
+        "lodash": "^4.17.21",
+        "mini-svg-data-uri": "^1.4.3",
+        "potrace": "^2.1.8",
+        "probe-image-size": "^7.0.0",
+        "progress": "^2.0.3",
+        "semver": "^7.3.5",
+        "sharp": "^0.30.1",
+        "svgo": "1.3.2",
+        "uuid": "3.4.0"
+      }
+    },
+    "gatsby-source-filesystem": {
+      "version": "file:../../node_modules/.pnpm/gatsby-source-filesystem@4.10.1_gatsby@4.10.3/node_modules/gatsby-source-filesystem",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "chokidar": "^3.5.2",
+        "cross-env": "^7.0.3",
+        "file-type": "^16.5.3",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.10.1",
+        "got": "^9.6.0",
+        "md5-file": "^5.0.0",
+        "mime": "^2.5.2",
+        "pretty-bytes": "^5.4.1",
+        "progress": "^2.0.3",
+        "valid-url": "^1.0.9",
+        "xstate": "^4.26.1"
+      }
+    },
+    "gatsby-source-wordpress": {
+      "version": "file:../../node_modules/.pnpm/gatsby-source-wordpress@6.10.2_bd9be9687c4c504d5e68b179d7a78803/node_modules/gatsby-source-wordpress",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@babel/plugin-proposal-class-properties": "^7.14.0",
+        "@babel/plugin-proposal-private-methods": "^7.14.0",
+        "@babel/runtime": "^7.15.4",
+        "@rematch/core": "^1.4.0",
+        "@rematch/immer": "^1.2.0",
+        "@types/cache-manager": "^2.10.3",
+        "@types/ink": "^2.0.3",
+        "@types/semver": "^7.3.9",
+        "async-retry": "^1.3.3",
+        "atob": "^2.1.2",
+        "axios": "^0.21.1",
+        "axios-rate-limit": "^1.3.0",
+        "babel-plugin-import-globals": "^2.0.0",
+        "babel-plugin-module-resolver": "4.1.0",
+        "babel-preset-gatsby": "^2.10.1",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "better-queue": "^3.8.10",
+        "btoa": "^1.2.1",
+        "cache-manager": "^3.6.0",
+        "cache-manager-fs-hash": "^0.0.9",
+        "chalk": "^4.1.2",
+        "cheerio": "^1.0.0-rc.10",
+        "clipboardy": "^2.3.0",
+        "cross-env": "^7.0.3",
+        "diff": "^5.0.0",
+        "dumper.js": "^1.3.1",
+        "execall": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "file-type": "^15.0.1",
+        "filesize": "^6.4.0",
+        "fs-extra": "^10.0.0",
+        "gatsby-core-utils": "^3.10.1",
+        "gatsby-plugin-catch-links": "^4.10.0",
+        "gatsby-plugin-image": "^2.10.1",
+        "gatsby-plugin-utils": "^3.4.2",
+        "gatsby-source-filesystem": "^4.10.1",
+        "glob": "^7.2.0",
+        "got": "^11.8.3",
+        "identity-obj-proxy": "^3.0.0",
+        "lodash": "^4.17.21",
+        "node-fetch": "^2.6.7",
+        "p-queue": "^6.6.2",
+        "prettier": "^2.5.1",
+        "react-test-renderer": "^16.14.0",
+        "read-chunk": "^3.2.0",
+        "replaceall": "^0.1.6",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "sharp": "^0.30.1",
+        "tree-kill": "^1.2.2",
+        "valid-url": "^1.0.9",
+        "wait-on": "^4.0.2"
+      }
+    },
+    "gatsby-transformer-sharp": {
+      "version": "file:../../node_modules/.pnpm/gatsby-transformer-sharp@4.10.0_bced32841dc092f03f390304902b3e7f/node_modules/gatsby-transformer-sharp",
+      "requires": {
+        "@babel/cli": "^7.15.4",
+        "@babel/core": "^7.15.5",
+        "@babel/runtime": "^7.15.4",
+        "@types/sharp": "^0.29.5",
+        "babel-preset-gatsby-package": "^2.10.0",
+        "bluebird": "^3.7.2",
+        "common-tags": "^1.8.2",
+        "cross-env": "^7.0.3",
+        "fs-extra": "^10.0.0",
+        "potrace": "^2.1.8",
+        "probe-image-size": "^7.0.0",
+        "semver": "^7.3.5",
+        "sharp": "^0.30.1"
+      }
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "peer": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "peer": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "peer": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "peer": true
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "peer": true
+    },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "peer": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "peer": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "peer": true
+    },
+    "html-react-parser": {
+      "version": "file:../../node_modules/.pnpm/html-react-parser@1.4.9_react@17.0.2/node_modules/html-react-parser",
+      "requires": {
+        "@commitlint/cli": "16.2.3",
+        "@commitlint/config-conventional": "16.2.1",
+        "@rollup/plugin-commonjs": "21.0.2",
+        "@rollup/plugin-node-resolve": "13.1.3",
+        "@size-limit/preset-big-lib": "7.0.8",
+        "@types/react": "17.0.41",
+        "@typescript-eslint/parser": "5.15.0",
+        "benchmark": "2.1.4",
+        "domhandler": "4.3.1",
+        "dtslint": "4.2.1",
+        "eslint": "8.11.0",
+        "eslint-plugin-prettier": "4.0.0",
+        "html-dom-parser": "1.1.1",
+        "husky": "7.0.4",
+        "jest": "27.5.1",
+        "lint-staged": "12.3.7",
+        "pinst": "3.0.0",
+        "preact": "10.6.6",
+        "prettier": "2.6.0",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
+        "react-property": "2.0.0",
+        "rimraf": "3.0.2",
+        "rollup": "2.70.1",
+        "rollup-plugin-terser": "7.0.2",
+        "size-limit": "7.0.8",
+        "style-to-js": "1.1.0",
+        "typescript": "4.6.2"
+      }
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "peer": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "peer": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "peer": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "peer": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "peer": true
+    },
+    "is-core-module": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "peer": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "peer": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "peer": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "peer": true
+    },
+    "jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "peer": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "peer": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "peer": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "peer": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "peer": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "peer": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "peer": true
+    },
+    "json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "peer": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "peer": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "loader-runner": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "peer": true
+    },
+    "lodash": {
+      "version": "file:../../node_modules/.pnpm/lodash@4.17.21/node_modules/lodash"
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "peer": true
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "peer": true
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "peer": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "peer": true,
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "peer": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "mitt": {
+      "version": "file:../../node_modules/.pnpm/mitt@3.0.0/node_modules/mitt",
+      "requires": {
+        "@types/chai": "^4.2.11",
+        "@types/mocha": "^7.0.2",
+        "@types/sinon": "^9.0.4",
+        "@types/sinon-chai": "^3.2.4",
+        "@typescript-eslint/eslint-plugin": "^3.0.1",
+        "@typescript-eslint/parser": "^3.0.1",
+        "chai": "^4.2.0",
+        "documentation": "^13.0.0",
+        "eslint": "^7.1.0",
+        "eslint-config-developit": "^1.2.0",
+        "esm": "^3.2.25",
+        "microbundle": "^0.12.3",
+        "mocha": "^8.0.1",
+        "npm-run-all": "^4.1.5",
+        "rimraf": "^3.0.2",
+        "sinon": "^9.0.2",
+        "sinon-chai": "^3.5.0",
+        "ts-node": "^8.10.2",
+        "typescript": "^3.9.7"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "peer": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "peer": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "peer": true
+    },
+    "node-releases": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
+      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
+      "peer": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "peer": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "peer": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "peer": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "peer": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "peer": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "peer": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "peer": true
+    },
+    "postcss": {
+      "version": "file:../../node_modules/.pnpm/postcss@8.4.12/node_modules/postcss",
+      "requires": {
+        "nanoid": "^3.3.1",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "peer": true
+    },
+    "prettier": {
+      "version": "file:../../node_modules/.pnpm/prettier@2.5.1/node_modules/prettier"
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "peer": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "peer": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "react": {
+      "version": "file:../../node_modules/.pnpm/react@17.0.2/node_modules/react",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "react-dom": {
+      "version": "file:../../node_modules/.pnpm/react-dom@17.0.2_react@17.0.2/node_modules/react-dom",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      }
+    },
+    "react-helmet": {
+      "version": "file:../../node_modules/.pnpm/react-helmet@6.1.0_react@17.0.2/node_modules/react-helmet",
+      "requires": {
+        "babel-core": "^6.24.0",
+        "babel-eslint": "^9.0.0",
+        "babel-plugin-external-helpers": "^6.22.0",
+        "babel-plugin-istanbul": "^4.0.0",
+        "babel-plugin-transform-class-properties": "^6.23.0",
+        "babel-plugin-transform-object-rest-spread": "^6.23.0",
+        "babel-preset-env": "^1.2.2",
+        "babel-preset-react": "^6.23.0",
+        "chai": "^3.5.0",
+        "codecov": "^3.6.5",
+        "conventional-changelog-cli": "^1.3.1",
+        "cz-conventional-changelog": "^2.0.0",
+        "eslint": "^3.18.0",
+        "eslint-config-nfl": "^11.1.0",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-plugin-import": "^2.2.0",
+        "eslint-plugin-jsx-a11y": "^6.2.3",
+        "eslint-plugin-mocha": "^4.9.0",
+        "eslint-plugin-prettier": "^2.1.2",
+        "eslint-plugin-react": "^6.10.2",
+        "istanbul": "^0.4.5",
+        "karma": "^1.5.0",
+        "karma-chai": "^0.1.0",
+        "karma-chai-sinon": "^0.1.5",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-coverage": "^1.1.1",
+        "karma-firefox-launcher": "^1.0.1",
+        "karma-html-reporter": "^0.2.7",
+        "karma-mocha": "^2.0.1",
+        "karma-rollup-preprocessor": "^6.1.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-spec-reporter": "^0.0.32",
+        "karma-tap-reporter": "^0.0.6",
+        "mocha": "^7.2.0",
+        "object-assign": "^4.1.1",
+        "prettier": "^1.4.4",
+        "prop-types": "^15.7.2",
+        "react": "16.13.1",
+        "react-dom": "16.13.1",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0",
+        "rimraf": "^3.0.2",
+        "rollup": "^0.67.0",
+        "rollup-plugin-babel": "^3.0.7",
+        "rollup-plugin-commonjs": "^9.2.0",
+        "rollup-plugin-node-resolve": "^3.4.0",
+        "rollup-plugin-replace": "^2.1.0",
+        "sinon": "^2.1.0",
+        "sinon-chai": "^2.8.0"
+      }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "peer": true
+    },
+    "resolve": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "peer": true,
+      "requires": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "peer": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "peer": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "peer": true
+    },
+    "schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "peer": true,
+      "requires": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "peer": true
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "peer": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "peer": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "peer": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "peer": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "peer": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "peer": true
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "peer": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "peer": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "peer": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "peer": true
+    },
+    "tailwindcss": {
+      "version": "file:../../node_modules/.pnpm/tailwindcss@3.0.23_autoprefixer@10.4.4/node_modules/tailwindcss",
+      "requires": {
+        "@swc/cli": "^0.1.55",
+        "@swc/core": "^1.2.127",
+        "@swc/jest": "^0.2.17",
+        "@swc/register": "^0.1.10",
+        "arg": "^5.0.1",
+        "autoprefixer": "^10.4.2",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "color-name": "^1.1.4",
+        "cosmiconfig": "^7.0.1",
+        "cssnano": "^5.0.16",
+        "detective": "^5.2.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "esbuild": "^0.14.21",
+        "eslint": "^8.8.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jest": "^27.5.1",
+        "jest-diff": "^27.5.1",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^2.2.0",
+        "postcss": "^8.4.6",
+        "postcss-js": "^4.0.0",
+        "postcss-load-config": "^3.1.0",
+        "postcss-nested": "5.0.6",
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0",
+        "prettier": "^2.5.1",
+        "prettier-plugin-tailwindcss": "^0.1.7",
+        "quick-lru": "^5.1.1",
+        "resolve": "^1.22.0",
+        "rimraf": "^3.0.0"
+      }
+    },
+    "tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "peer": true
+    },
+    "terser": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
+      "integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+      "peer": true,
+      "requires": {
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "peer": true
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
+      "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+      "peer": true,
+      "requires": {
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^3.1.1",
+        "serialize-javascript": "^6.0.0",
+        "source-map": "^0.6.1",
+        "terser": "^5.7.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "peer": true
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "peer": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "peer": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "peer": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true
+    },
+    "typeface-merriweather": {
+      "version": "file:../../node_modules/.pnpm/typeface-merriweather@1.1.13/node_modules/typeface-merriweather"
+    },
+    "typeface-montserrat": {
+      "version": "file:../../node_modules/.pnpm/typeface-montserrat@1.1.13/node_modules/typeface-montserrat"
+    },
+    "typescript": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "peer": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "peer": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "peer": true
+    },
+    "watchpack": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+      "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+      "peer": true,
+      "requires": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "webpack": {
+      "version": "5.72.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
+      "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
+      "peer": true,
+      "requires": {
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/wasm-edit": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "acorn": "^8.4.1",
+        "acorn-import-assertions": "^1.7.6",
+        "browserslist": "^4.14.5",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.9.2",
+        "es-module-lexer": "^0.9.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.9",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.1.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.1.3",
+        "watchpack": "^2.3.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "peer": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "peer": true
+        }
+      }
+    },
+    "webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "peer": true
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "peer": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "peer": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "peer": true
+    }
+  }
+}

--- a/starters/next-drupal-starter/package-lock.json
+++ b/starters/next-drupal-starter/package-lock.json
@@ -1,0 +1,1498 @@
+{
+  "name": "@pantheon-systems/next-drupal-starter",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@pantheon-systems/next-drupal-starter",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@pantheon-systems/drupal-kit": "^1.0.0",
+        "@tailwindcss/typography": "^0.5.2",
+        "dotenv": "^16.0.0",
+        "next": "^12.1.0",
+        "next-absolute-url": "^1.2.2",
+        "next-seo": "^5.1.0",
+        "react": "17.0.2",
+        "react-dom": "17.0.2"
+      },
+      "devDependencies": {
+        "autoprefixer": "^10.4.2",
+        "encoding": "^0.1.13",
+        "eslint": "8.10.0",
+        "eslint-config-next": "12.1.0",
+        "postcss": "^8.4.7",
+        "tailwindcss": "^3.0.23"
+      }
+    },
+    "../../node_modules/.pnpm/@apollo+client@3.5.10_react@17.0.2/node_modules/@apollo/client": {
+      "version": "3.5.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.1",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.9.4",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.0"
+      },
+      "devDependencies": {
+        "@babel/parser": "7.17.3",
+        "@graphql-tools/schema": "8.3.1",
+        "@rollup/plugin-node-resolve": "11.2.1",
+        "@testing-library/react": "12.1.3",
+        "@testing-library/react-hooks": "7.0.2",
+        "@types/fast-json-stable-stringify": "2.0.0",
+        "@types/fetch-mock": "7.3.5",
+        "@types/glob": "7.2.0",
+        "@types/hoist-non-react-statics": "3.3.1",
+        "@types/jest": "27.4.0",
+        "@types/lodash": "4.14.178",
+        "@types/node": "16.11.25",
+        "@types/react": "17.0.34",
+        "@types/react-dom": "17.0.2",
+        "bundlesize": "0.18.1",
+        "cross-fetch": "3.1.5",
+        "crypto-hash": "1.3.0",
+        "fetch-mock": "9.11.0",
+        "glob": "7.2.0",
+        "graphql": "16.0.1",
+        "graphql-ws": "5.6.2",
+        "jest": "27.5.1",
+        "jest-fetch-mock": "3.0.3",
+        "jest-junit": "13.0.0",
+        "lodash": "4.17.21",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
+        "recast": "0.21.0",
+        "resolve": "1.22.0",
+        "rimraf": "3.0.2",
+        "rollup": "2.67.3",
+        "rollup-plugin-terser": "7.0.2",
+        "rxjs": "6.6.7",
+        "subscriptions-transport-ws": "0.11.0",
+        "terser": "5.10.0",
+        "ts-jest": "27.1.3",
+        "ts-node": "10.5.0",
+        "typescript": "4.5.5",
+        "wait-for-observables": "1.0.3",
+        "whatwg-fetch": "3.6.2"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/@gdwc+drupal-state@2.5.2_react@17.0.2+typescript@4.5.5/node_modules/@gdwc/drupal-state": {
+      "version": "2.5.2",
+      "hasInstallScript": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@apollo/client": "^3.4.15",
+        "@babel/runtime": "^7.16.7",
+        "@docsearch/react": "^1.0.0-alpha.28",
+        "@types/humps": "^2.0.1",
+        "@types/isomorphic-fetch": "0.0.35",
+        "@types/jest": "^27.0.1",
+        "apollo-link": "^1.2.14",
+        "apollo-link-json-api": "^0.1.2",
+        "drupal-jsonapi-params": "^1.2.2",
+        "graphql": "^15.6.0",
+        "graphql-anywhere": "^4.2.7",
+        "humps": "^2.0.1",
+        "isomorphic-fetch": "^3.0.0",
+        "jest": "^27.0.6",
+        "jest-junit": "^12.2.0",
+        "jsona": "^1.9.7",
+        "patch-package": "^6.4.7",
+        "qs": "^6.10.1",
+        "ts-jest": "^27.0.5",
+        "zustand": "^3.5.7"
+      },
+      "devDependencies": {
+        "@astrojs/renderer-preact": "^0.4.0",
+        "@babel/plugin-transform-runtime": "^7.16.10",
+        "@babel/preset-env": "^7.15.8",
+        "@rollup/plugin-babel": "^5.3.0",
+        "@rollup/plugin-typescript": "^8.2.5",
+        "@snowpack/plugin-dotenv": "^2.2.0",
+        "@typescript-eslint/eslint-plugin": "^4.29.1",
+        "@typescript-eslint/parser": "^4.29.1",
+        "@vitejs/plugin-legacy": "^1.6.1",
+        "astro": "^0.22.9",
+        "dotenv-cli": "^4.0.0",
+        "dpdm": "^3.7.1",
+        "eslint": "^7.32.0",
+        "eslint-config-prettier": "^8.3.0",
+        "fetch-mock-jest": "^1.5.1",
+        "husky": "^7.0.1",
+        "lint-staged": "^11.1.2",
+        "prettier": "2.3.2",
+        "release-it": "^14.11.5",
+        "rollup": "^2.56.3",
+        "typedoc": "^0.21.6",
+        "typescript": "^4.3.2",
+        "vite": "^2.4.4"
+      }
+    },
+    "../../node_modules/.pnpm/@tailwindcss+typography@0.5.2_tailwindcss@3.0.23/node_modules/@tailwindcss/typography": {
+      "version": "0.5.2",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2"
+      },
+      "devDependencies": {
+        "@mdx-js/loader": "^1.0.19",
+        "@mdx-js/mdx": "^1.6.6",
+        "@next/mdx": "^8.1.0",
+        "autoprefixer": "^10.2.1",
+        "highlight.js": "^10.4.1",
+        "jest": "^26.6.1",
+        "jest-diff": "^27.3.1",
+        "next": "^12.0.1",
+        "postcss": "^8.2.3",
+        "prettier": "^2.1.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "tailwindcss": "^3.0.0-alpha.2"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || insiders"
+      }
+    },
+    "../../node_modules/.pnpm/autoprefixer@10.4.4_postcss@8.4.12/node_modules/autoprefixer": {
+      "version": "10.4.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.20.2",
+        "caniuse-lite": "^1.0.30001317",
+        "fraction.js": "^4.2.0",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "../../node_modules/.pnpm/dotenv@16.0.0/node_modules/dotenv": {
+      "version": "16.0.0",
+      "license": "BSD-2-Clause",
+      "devDependencies": {
+        "@types/node": "^17.0.9",
+        "decache": "^4.6.1",
+        "dtslint": "^3.7.0",
+        "sinon": "^12.0.1",
+        "standard": "^16.0.4",
+        "standard-markdown": "^7.1.0",
+        "standard-version": "^9.3.2",
+        "tap": "^15.1.6",
+        "typescript": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "../../node_modules/.pnpm/encoding@0.1.13/node_modules/encoding": {
+      "version": "0.1.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      },
+      "devDependencies": {
+        "nodeunit": "0.11.3"
+      }
+    },
+    "../../node_modules/.pnpm/eslint-config-next@12.1.0_4c2038871e8233f2b143838d68f90b16/node_modules/eslint-config-next": {
+      "version": "12.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "12.1.0",
+        "@rushstack/eslint-patch": "^1.0.8",
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.27.0",
+        "eslint-plugin-react-hooks": "^4.3.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0",
+        "next": ">=10.2.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/eslint@8.10.0/node_modules/eslint": {
+      "version": "8.10.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/eslintrc": "^1.2.0",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.4.3",
+        "@babel/preset-env": "^7.4.3",
+        "babel-loader": "^8.0.5",
+        "chai": "^4.0.1",
+        "cheerio": "^0.22.0",
+        "common-tags": "^1.8.0",
+        "core-js": "^3.1.3",
+        "dateformat": "^4.5.1",
+        "ejs": "^3.0.2",
+        "eslint": "file:.",
+        "eslint-config-eslint": "file:packages/eslint-config-eslint",
+        "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-eslint-plugin": "^4.0.1",
+        "eslint-plugin-internal-rules": "file:tools/internal-rules",
+        "eslint-plugin-jsdoc": "^37.0.0",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-release": "^3.2.0",
+        "eslump": "^3.0.0",
+        "esprima": "^4.0.1",
+        "fs-teardown": "^0.1.3",
+        "glob": "^7.1.6",
+        "jsdoc": "^3.5.5",
+        "karma": "^6.1.1",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-mocha": "^2.0.1",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-webpack": "^5.0.0",
+        "lint-staged": "^11.0.0",
+        "load-perf": "^0.2.0",
+        "markdownlint": "^0.24.0",
+        "markdownlint-cli": "^0.30.0",
+        "marked": "^4.0.8",
+        "memfs": "^3.0.1",
+        "mocha": "^8.3.2",
+        "mocha-junit-reporter": "^2.0.0",
+        "node-polyfill-webpack-plugin": "^1.0.3",
+        "npm-license": "^0.3.3",
+        "nyc": "^15.0.1",
+        "pirates": "^4.0.5",
+        "progress": "^2.0.3",
+        "proxyquire": "^2.0.1",
+        "puppeteer": "^9.1.1",
+        "recast": "^0.20.4",
+        "regenerator-runtime": "^0.13.2",
+        "semver": "^7.3.5",
+        "shelljs": "^0.8.2",
+        "sinon": "^11.0.0",
+        "temp": "^0.9.0",
+        "webpack": "^5.23.0",
+        "webpack-cli": "^4.5.0",
+        "yorkie": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../node_modules/.pnpm/humps@2.0.1/node_modules/humps": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      }
+    },
+    "../../node_modules/.pnpm/isomorphic-fetch@3.0.0/node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      },
+      "devDependencies": {
+        "chai": "^4.2.0",
+        "jshint": "^2.5.11",
+        "lintspaces-cli": "^0.7.1",
+        "mocha": "^8.1.3",
+        "nock": "^13.0.4"
+      }
+    },
+    "../../node_modules/.pnpm/jsona@1.9.7/node_modules/jsona": {
+      "version": "1.9.7",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/chai": "^4.2.4",
+        "@types/mocha": "^5.2.7",
+        "@types/node": "^12.11.5",
+        "chai": "^4.3.4",
+        "mocha": "^8.3.2",
+        "ts-mocha": "^8.0.0",
+        "typescript": "^4.2.4"
+      }
+    },
+    "../../node_modules/.pnpm/next-absolute-url@1.2.2/node_modules/next-absolute-url": {
+      "version": "1.2.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/jest": "24.0.25",
+        "@types/node": "13.1.6",
+        "@zeit/git-hooks": "0.1.4",
+        "jest": "24.9.0",
+        "prettier": "1.19.1",
+        "ts-jest": "24.3.0",
+        "typescript": "3.7.4"
+      }
+    },
+    "../../node_modules/.pnpm/next-seo@5.2.0_caa633a00319350dbda42996613fe26c/node_modules/next-seo": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.16.12",
+        "@babel/preset-env": "^7.16.11",
+        "@babel/preset-react": "^7.16.7",
+        "@babel/preset-typescript": "^7.16.7",
+        "@cypress/schema-tools": "^4.7.9",
+        "@types/jest": "^27.4.0",
+        "@types/node": "^17.0.13",
+        "@types/react": "^17.0.38",
+        "@types/react-dom": "^17.0.11",
+        "babel-jest": "^27.4.6",
+        "cypress": "^9.3.1",
+        "cypress-testing-library": "^4.0.0",
+        "doctoc": "^2.1.0",
+        "husky": "4.3.8",
+        "jest": "^27.4.7",
+        "lint-staged": "11.1.1",
+        "microbundle": "^0.14.2",
+        "next": "^12.0.9",
+        "npm-run-all": "4.1.5",
+        "prettier": "2.5.1",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
+        "react-testing-library": "7.0.0",
+        "rimraf": "3.0.2",
+        "typescript": "^4.5.5"
+      },
+      "peerDependencies": {
+        "next": "^8.1.1-canary.54 || >=9.0.0",
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/next@12.1.0_react-dom@17.0.2+react@17.0.2/node_modules/next": {
+      "version": "12.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "12.1.0",
+        "caniuse-lite": "^1.0.30001283",
+        "postcss": "8.4.5",
+        "styled-jsx": "5.0.0",
+        "use-subscription": "1.5.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "devDependencies": {
+        "@ampproject/toolbox-optimizer": "2.7.1-alpha.0",
+        "@babel/code-frame": "7.12.11",
+        "@babel/core": "7.15.0",
+        "@babel/eslint-parser": "7.13.14",
+        "@babel/generator": "7.15.0",
+        "@babel/plugin-proposal-class-properties": "7.14.5",
+        "@babel/plugin-proposal-export-namespace-from": "7.14.5",
+        "@babel/plugin-proposal-numeric-separator": "7.14.5",
+        "@babel/plugin-proposal-object-rest-spread": "7.14.7",
+        "@babel/plugin-syntax-bigint": "7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "7.8.3",
+        "@babel/plugin-syntax-jsx": "7.14.5",
+        "@babel/plugin-transform-modules-commonjs": "7.15.0",
+        "@babel/plugin-transform-runtime": "7.15.0",
+        "@babel/preset-env": "7.15.0",
+        "@babel/preset-react": "7.14.5",
+        "@babel/preset-typescript": "7.15.0",
+        "@babel/runtime": "7.15.4",
+        "@babel/traverse": "7.15.0",
+        "@babel/types": "7.15.0",
+        "@hapi/accept": "5.0.2",
+        "@napi-rs/cli": "1.2.1",
+        "@napi-rs/triples": "1.0.3",
+        "@next/polyfill-module": "12.1.0",
+        "@next/polyfill-nomodule": "12.1.0",
+        "@next/react-dev-overlay": "12.1.0",
+        "@next/react-refresh-utils": "12.1.0",
+        "@next/swc": "12.1.0",
+        "@peculiar/webcrypto": "1.1.7",
+        "@taskr/clear": "1.1.0",
+        "@taskr/esnext": "1.1.0",
+        "@taskr/watch": "1.1.0",
+        "@types/amphtml-validator": "1.0.0",
+        "@types/babel__code-frame": "7.0.2",
+        "@types/babel__core": "7.1.12",
+        "@types/babel__generator": "7.6.2",
+        "@types/babel__template": "7.4.0",
+        "@types/babel__traverse": "7.11.0",
+        "@types/ci-info": "2.0.0",
+        "@types/compression": "0.0.36",
+        "@types/content-disposition": "0.5.4",
+        "@types/content-type": "1.1.3",
+        "@types/cookie": "0.3.3",
+        "@types/cross-spawn": "6.0.0",
+        "@types/debug": "4.1.5",
+        "@types/etag": "1.8.0",
+        "@types/fresh": "0.5.0",
+        "@types/jsonwebtoken": "8.3.7",
+        "@types/lodash.curry": "4.1.6",
+        "@types/lru-cache": "5.1.0",
+        "@types/micromatch": "4.0.2",
+        "@types/node-fetch": "2.3.4",
+        "@types/path-to-regexp": "1.7.0",
+        "@types/react": "16.9.17",
+        "@types/react-dom": "16.9.4",
+        "@types/react-is": "16.7.1",
+        "@types/semver": "7.3.1",
+        "@types/send": "0.14.4",
+        "@types/styled-jsx": "2.2.8",
+        "@types/text-table": "0.2.1",
+        "@types/ua-parser-js": "0.7.36",
+        "@types/uuid": "8.3.1",
+        "@types/webpack-sources1": "npm:@types/webpack-sources@0.1.5",
+        "@types/ws": "8.2.0",
+        "@vercel/ncc": "0.33.1",
+        "@vercel/nft": "0.17.5",
+        "acorn": "8.5.0",
+        "amphtml-validator": "1.0.35",
+        "arg": "4.1.0",
+        "assert": "2.0.0",
+        "async-retry": "1.2.3",
+        "async-sema": "3.0.0",
+        "babel-plugin-transform-define": "2.0.0",
+        "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+        "browserify-zlib": "0.2.0",
+        "browserslist": "4.18.1",
+        "buffer": "5.6.0",
+        "chalk": "2.4.2",
+        "ci-info": "watson/ci-info#f43f6a1cefff47fb361c88cf4b943fdbcaafe540",
+        "cli-select": "1.1.2",
+        "comment-json": "3.0.3",
+        "compression": "1.7.4",
+        "conf": "5.0.0",
+        "constants-browserify": "1.0.0",
+        "content-disposition": "0.5.3",
+        "content-type": "1.0.4",
+        "cookie": "0.4.1",
+        "cross-spawn": "6.0.5",
+        "crypto-browserify": "3.12.0",
+        "cssnano-simple": "3.0.0",
+        "debug": "4.1.1",
+        "devalue": "2.0.1",
+        "domain-browser": "4.19.0",
+        "etag": "1.8.1",
+        "events": "3.3.0",
+        "find-cache-dir": "3.3.1",
+        "find-up": "4.1.0",
+        "formdata-node": "4.3.0",
+        "fresh": "0.5.2",
+        "get-orientation": "1.1.2",
+        "glob": "7.1.7",
+        "gzip-size": "5.1.1",
+        "http-proxy": "1.18.1",
+        "https-browserify": "1.0.0",
+        "icss-utils": "5.1.0",
+        "ignore-loader": "0.1.2",
+        "image-size": "1.0.0",
+        "is-docker": "2.0.0",
+        "is-wsl": "2.2.0",
+        "jest-worker": "27.0.0-next.5",
+        "json5": "2.2.0",
+        "jsonwebtoken": "8.5.1",
+        "loader-utils2": "npm:loader-utils@2.0.0",
+        "loader-utils3": "npm:loader-utils@3.1.3",
+        "lodash.curry": "4.1.1",
+        "lru-cache": "5.1.1",
+        "micromatch": "4.0.4",
+        "mini-css-extract-plugin": "2.4.3",
+        "nanoid": "3.1.30",
+        "native-url": "0.3.4",
+        "neo-async": "2.6.1",
+        "node-fetch": "2.6.7",
+        "node-html-parser": "1.4.9",
+        "ora": "4.0.4",
+        "os-browserify": "0.3.0",
+        "p-limit": "3.1.0",
+        "path-browserify": "1.0.1",
+        "path-to-regexp": "6.1.0",
+        "postcss-flexbugs-fixes": "5.0.2",
+        "postcss-modules-extract-imports": "3.0.0",
+        "postcss-modules-local-by-default": "4.0.0",
+        "postcss-modules-scope": "3.0.0",
+        "postcss-modules-values": "4.0.0",
+        "postcss-preset-env": "6.7.0",
+        "postcss-safe-parser": "6.0.0",
+        "postcss-scss": "3.0.5",
+        "postcss-value-parser": "4.1.0",
+        "process": "0.11.10",
+        "punycode": "2.1.1",
+        "querystring-es3": "0.2.1",
+        "raw-body": "2.4.1",
+        "react-is": "17.0.2",
+        "react-refresh": "0.8.3",
+        "react-server-dom-webpack": "0.0.0-experimental-13455d26d-20211104",
+        "regenerator-runtime": "0.13.4",
+        "sass-loader": "12.4.0",
+        "schema-utils2": "npm:schema-utils@2.7.1",
+        "schema-utils3": "npm:schema-utils@3.0.0",
+        "semver": "7.3.2",
+        "send": "0.17.1",
+        "setimmediate": "1.0.5",
+        "source-map": "0.6.1",
+        "stream-browserify": "3.0.0",
+        "stream-http": "3.1.1",
+        "string_decoder": "1.3.0",
+        "string-hash": "1.1.3",
+        "strip-ansi": "6.0.0",
+        "taskr": "1.1.0",
+        "terser": "5.10.0",
+        "text-table": "0.2.0",
+        "timers-browserify": "2.0.12",
+        "tty-browserify": "0.0.1",
+        "ua-parser-js": "0.7.28",
+        "unistore": "3.4.1",
+        "util": "0.12.4",
+        "uuid": "8.3.2",
+        "vm-browserify": "1.1.2",
+        "watchpack": "2.3.1",
+        "web-streams-polyfill": "3.0.3",
+        "web-vitals": "2.1.0",
+        "webpack-sources1": "npm:webpack-sources@1.4.3",
+        "webpack-sources3": "npm:webpack-sources@3.2.3",
+        "webpack4": "npm:webpack@4.44.1",
+        "webpack5": "npm:webpack@5.69.1",
+        "ws": "8.2.3"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-android-arm64": "12.1.0",
+        "@next/swc-darwin-arm64": "12.1.0",
+        "@next/swc-darwin-x64": "12.1.0",
+        "@next/swc-linux-arm-gnueabihf": "12.1.0",
+        "@next/swc-linux-arm64-gnu": "12.1.0",
+        "@next/swc-linux-arm64-musl": "12.1.0",
+        "@next/swc-linux-x64-gnu": "12.1.0",
+        "@next/swc-linux-x64-musl": "12.1.0",
+        "@next/swc-win32-arm64-msvc": "12.1.0",
+        "@next/swc-win32-ia32-msvc": "12.1.0",
+        "@next/swc-win32-x64-msvc": "12.1.0"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^6.0.0 || ^7.0.0",
+        "react": "^17.0.2 || ^18.0.0-0",
+        "react-dom": "^17.0.2 || ^18.0.0-0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/postcss@8.4.12/node_modules/postcss": {
+      "version": "8.4.12",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.1",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "../../node_modules/.pnpm/react-dom@17.0.2_react@17.0.2/node_modules/react-dom": {
+      "version": "17.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "../../node_modules/.pnpm/react@17.0.2/node_modules/react": {
+      "version": "17.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/.pnpm/tailwindcss@3.0.23_autoprefixer@10.4.4/node_modules/tailwindcss": {
+      "version": "3.0.23",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arg": "^5.0.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "color-name": "^1.1.4",
+        "cosmiconfig": "^7.0.1",
+        "detective": "^5.2.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^2.2.0",
+        "postcss": "^8.4.6",
+        "postcss-js": "^4.0.0",
+        "postcss-load-config": "^3.1.0",
+        "postcss-nested": "5.0.6",
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0",
+        "quick-lru": "^5.1.1",
+        "resolve": "^1.22.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "devDependencies": {
+        "@swc/cli": "^0.1.55",
+        "@swc/core": "^1.2.127",
+        "@swc/jest": "^0.2.17",
+        "@swc/register": "^0.1.10",
+        "autoprefixer": "^10.4.2",
+        "cssnano": "^5.0.16",
+        "esbuild": "^0.14.21",
+        "eslint": "^8.8.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "jest": "^27.5.1",
+        "jest-diff": "^27.5.1",
+        "prettier": "^2.5.1",
+        "prettier-plugin-tailwindcss": "^0.1.7",
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "autoprefixer": "^10.0.2",
+        "postcss": "^8.0.9"
+      }
+    },
+    "../../packages/drupal-kit": {
+      "name": "@pantheon-systems/drupal-kit",
+      "version": "1.0.0",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@gdwc/drupal-state": "^2.5.2"
+      },
+      "devDependencies": {
+        "@apollo/client": "^3.5.10",
+        "humps": "^2.0.1",
+        "isomorphic-fetch": "^3.0.0",
+        "jsona": "^1.9.7"
+      },
+      "peerDependencies": {
+        "graphql": ">=14.0.0 <15.0.0 || >=15.0.0 <16.0.0 || >=16.0.0 <17.0.0",
+        "tslib": "*",
+        "typescript": ">=4.0.0 <4.1.0 || >=4.1.0 <4.2.0 || >=4.2.0 <4.3.0 || >=4.3.0 <4.4.0 || >=4.4.0 <4.5.0 || >=4.5.0 <4.6.0"
+      }
+    },
+    "../../packages/drupal-kit/node_modules/@apollo/client": {
+      "resolved": "../../node_modules/.pnpm/@apollo+client@3.5.10_react@17.0.2/node_modules/@apollo/client",
+      "link": true
+    },
+    "../../packages/drupal-kit/node_modules/@gdwc/drupal-state": {
+      "resolved": "../../node_modules/.pnpm/@gdwc+drupal-state@2.5.2_react@17.0.2+typescript@4.5.5/node_modules/@gdwc/drupal-state",
+      "link": true
+    },
+    "../../packages/drupal-kit/node_modules/humps": {
+      "resolved": "../../node_modules/.pnpm/humps@2.0.1/node_modules/humps",
+      "link": true
+    },
+    "../../packages/drupal-kit/node_modules/isomorphic-fetch": {
+      "resolved": "../../node_modules/.pnpm/isomorphic-fetch@3.0.0/node_modules/isomorphic-fetch",
+      "link": true
+    },
+    "../../packages/drupal-kit/node_modules/jsona": {
+      "resolved": "../../node_modules/.pnpm/jsona@1.9.7/node_modules/jsona",
+      "link": true
+    },
+    "node_modules/@pantheon-systems/drupal-kit": {
+      "resolved": "../../packages/drupal-kit",
+      "link": true
+    },
+    "node_modules/@tailwindcss/typography": {
+      "resolved": "../../node_modules/.pnpm/@tailwindcss+typography@0.5.2_tailwindcss@3.0.23/node_modules/@tailwindcss/typography",
+      "link": true
+    },
+    "node_modules/autoprefixer": {
+      "resolved": "../../node_modules/.pnpm/autoprefixer@10.4.4_postcss@8.4.12/node_modules/autoprefixer",
+      "link": true
+    },
+    "node_modules/dotenv": {
+      "resolved": "../../node_modules/.pnpm/dotenv@16.0.0/node_modules/dotenv",
+      "link": true
+    },
+    "node_modules/encoding": {
+      "resolved": "../../node_modules/.pnpm/encoding@0.1.13/node_modules/encoding",
+      "link": true
+    },
+    "node_modules/eslint": {
+      "resolved": "../../node_modules/.pnpm/eslint@8.10.0/node_modules/eslint",
+      "link": true
+    },
+    "node_modules/eslint-config-next": {
+      "resolved": "../../node_modules/.pnpm/eslint-config-next@12.1.0_4c2038871e8233f2b143838d68f90b16/node_modules/eslint-config-next",
+      "link": true
+    },
+    "node_modules/next": {
+      "resolved": "../../node_modules/.pnpm/next@12.1.0_react-dom@17.0.2+react@17.0.2/node_modules/next",
+      "link": true
+    },
+    "node_modules/next-absolute-url": {
+      "resolved": "../../node_modules/.pnpm/next-absolute-url@1.2.2/node_modules/next-absolute-url",
+      "link": true
+    },
+    "node_modules/next-seo": {
+      "resolved": "../../node_modules/.pnpm/next-seo@5.2.0_caa633a00319350dbda42996613fe26c/node_modules/next-seo",
+      "link": true
+    },
+    "node_modules/postcss": {
+      "resolved": "../../node_modules/.pnpm/postcss@8.4.12/node_modules/postcss",
+      "link": true
+    },
+    "node_modules/react": {
+      "resolved": "../../node_modules/.pnpm/react@17.0.2/node_modules/react",
+      "link": true
+    },
+    "node_modules/react-dom": {
+      "resolved": "../../node_modules/.pnpm/react-dom@17.0.2_react@17.0.2/node_modules/react-dom",
+      "link": true
+    },
+    "node_modules/tailwindcss": {
+      "resolved": "../../node_modules/.pnpm/tailwindcss@3.0.23_autoprefixer@10.4.4/node_modules/tailwindcss",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "@pantheon-systems/drupal-kit": {
+      "version": "file:../../packages/drupal-kit",
+      "requires": {
+        "@apollo/client": "^3.5.10",
+        "@gdwc/drupal-state": "^2.5.2",
+        "humps": "^2.0.1",
+        "isomorphic-fetch": "^3.0.0",
+        "jsona": "^1.9.7"
+      },
+      "dependencies": {
+        "@apollo/client": {
+          "version": "file:../../node_modules/.pnpm/@apollo+client@3.5.10_react@17.0.2/node_modules/@apollo/client",
+          "requires": {
+            "@babel/parser": "7.17.3",
+            "@graphql-tools/schema": "8.3.1",
+            "@graphql-typed-document-node/core": "^3.0.0",
+            "@rollup/plugin-node-resolve": "11.2.1",
+            "@testing-library/react": "12.1.3",
+            "@testing-library/react-hooks": "7.0.2",
+            "@types/fast-json-stable-stringify": "2.0.0",
+            "@types/fetch-mock": "7.3.5",
+            "@types/glob": "7.2.0",
+            "@types/hoist-non-react-statics": "3.3.1",
+            "@types/jest": "27.4.0",
+            "@types/lodash": "4.14.178",
+            "@types/node": "16.11.25",
+            "@types/react": "17.0.34",
+            "@types/react-dom": "17.0.2",
+            "@wry/context": "^0.6.0",
+            "@wry/equality": "^0.5.0",
+            "@wry/trie": "^0.3.0",
+            "bundlesize": "0.18.1",
+            "cross-fetch": "3.1.5",
+            "crypto-hash": "1.3.0",
+            "fetch-mock": "9.11.0",
+            "glob": "7.2.0",
+            "graphql": "16.0.1",
+            "graphql-tag": "^2.12.3",
+            "graphql-ws": "5.6.2",
+            "hoist-non-react-statics": "^3.3.2",
+            "jest": "27.5.1",
+            "jest-fetch-mock": "3.0.3",
+            "jest-junit": "13.0.0",
+            "lodash": "4.17.21",
+            "optimism": "^0.16.1",
+            "prop-types": "^15.7.2",
+            "react": "17.0.2",
+            "react-dom": "17.0.2",
+            "recast": "0.21.0",
+            "resolve": "1.22.0",
+            "rimraf": "3.0.2",
+            "rollup": "2.67.3",
+            "rollup-plugin-terser": "7.0.2",
+            "rxjs": "6.6.7",
+            "subscriptions-transport-ws": "0.11.0",
+            "symbol-observable": "^4.0.0",
+            "terser": "5.10.0",
+            "ts-invariant": "^0.9.4",
+            "ts-jest": "27.1.3",
+            "ts-node": "10.5.0",
+            "tslib": "^2.3.0",
+            "typescript": "4.5.5",
+            "wait-for-observables": "1.0.3",
+            "whatwg-fetch": "3.6.2",
+            "zen-observable-ts": "^1.2.0"
+          }
+        },
+        "@gdwc/drupal-state": {
+          "version": "file:../../node_modules/.pnpm/@gdwc+drupal-state@2.5.2_react@17.0.2+typescript@4.5.5/node_modules/@gdwc/drupal-state",
+          "requires": {
+            "@apollo/client": "^3.4.15",
+            "@astrojs/renderer-preact": "^0.4.0",
+            "@babel/plugin-transform-runtime": "^7.16.10",
+            "@babel/preset-env": "^7.15.8",
+            "@babel/runtime": "^7.16.7",
+            "@docsearch/react": "^1.0.0-alpha.28",
+            "@rollup/plugin-babel": "^5.3.0",
+            "@rollup/plugin-typescript": "^8.2.5",
+            "@snowpack/plugin-dotenv": "^2.2.0",
+            "@types/humps": "^2.0.1",
+            "@types/isomorphic-fetch": "0.0.35",
+            "@types/jest": "^27.0.1",
+            "@typescript-eslint/eslint-plugin": "^4.29.1",
+            "@typescript-eslint/parser": "^4.29.1",
+            "@vitejs/plugin-legacy": "^1.6.1",
+            "apollo-link": "^1.2.14",
+            "apollo-link-json-api": "^0.1.2",
+            "astro": "^0.22.9",
+            "dotenv-cli": "^4.0.0",
+            "dpdm": "^3.7.1",
+            "drupal-jsonapi-params": "^1.2.2",
+            "eslint": "^7.32.0",
+            "eslint-config-prettier": "^8.3.0",
+            "fetch-mock-jest": "^1.5.1",
+            "graphql": "^15.6.0",
+            "graphql-anywhere": "^4.2.7",
+            "humps": "^2.0.1",
+            "husky": "^7.0.1",
+            "isomorphic-fetch": "^3.0.0",
+            "jest": "^27.0.6",
+            "jest-junit": "^12.2.0",
+            "jsona": "^1.9.7",
+            "lint-staged": "^11.1.2",
+            "patch-package": "^6.4.7",
+            "prettier": "2.3.2",
+            "qs": "^6.10.1",
+            "release-it": "^14.11.5",
+            "rollup": "^2.56.3",
+            "ts-jest": "^27.0.5",
+            "typedoc": "^0.21.6",
+            "typescript": "^4.3.2",
+            "vite": "^2.4.4",
+            "zustand": "^3.5.7"
+          }
+        },
+        "humps": {
+          "version": "file:../../node_modules/.pnpm/humps@2.0.1/node_modules/humps",
+          "requires": {
+            "mocha": "^2.2.5"
+          }
+        },
+        "isomorphic-fetch": {
+          "version": "file:../../node_modules/.pnpm/isomorphic-fetch@3.0.0/node_modules/isomorphic-fetch",
+          "requires": {
+            "chai": "^4.2.0",
+            "jshint": "^2.5.11",
+            "lintspaces-cli": "^0.7.1",
+            "mocha": "^8.1.3",
+            "nock": "^13.0.4",
+            "node-fetch": "^2.6.1",
+            "whatwg-fetch": "^3.4.1"
+          }
+        },
+        "jsona": {
+          "version": "file:../../node_modules/.pnpm/jsona@1.9.7/node_modules/jsona",
+          "requires": {
+            "@types/chai": "^4.2.4",
+            "@types/mocha": "^5.2.7",
+            "@types/node": "^12.11.5",
+            "chai": "^4.3.4",
+            "mocha": "^8.3.2",
+            "ts-mocha": "^8.0.0",
+            "typescript": "^4.2.4"
+          }
+        }
+      }
+    },
+    "@tailwindcss/typography": {
+      "version": "file:../../node_modules/.pnpm/@tailwindcss+typography@0.5.2_tailwindcss@3.0.23/node_modules/@tailwindcss/typography",
+      "requires": {
+        "@mdx-js/loader": "^1.0.19",
+        "@mdx-js/mdx": "^1.6.6",
+        "@next/mdx": "^8.1.0",
+        "autoprefixer": "^10.2.1",
+        "highlight.js": "^10.4.1",
+        "jest": "^26.6.1",
+        "jest-diff": "^27.3.1",
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "next": "^12.0.1",
+        "postcss": "^8.2.3",
+        "prettier": "^2.1.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "tailwindcss": "^3.0.0-alpha.2"
+      }
+    },
+    "autoprefixer": {
+      "version": "file:../../node_modules/.pnpm/autoprefixer@10.4.4_postcss@8.4.12/node_modules/autoprefixer",
+      "requires": {
+        "browserslist": "^4.20.2",
+        "caniuse-lite": "^1.0.30001317",
+        "fraction.js": "^4.2.0",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "dotenv": {
+      "version": "file:../../node_modules/.pnpm/dotenv@16.0.0/node_modules/dotenv",
+      "requires": {
+        "@types/node": "^17.0.9",
+        "decache": "^4.6.1",
+        "dtslint": "^3.7.0",
+        "sinon": "^12.0.1",
+        "standard": "^16.0.4",
+        "standard-markdown": "^7.1.0",
+        "standard-version": "^9.3.2",
+        "tap": "^15.1.6",
+        "typescript": "^4.5.4"
+      }
+    },
+    "encoding": {
+      "version": "file:../../node_modules/.pnpm/encoding@0.1.13/node_modules/encoding",
+      "requires": {
+        "iconv-lite": "^0.6.2",
+        "nodeunit": "0.11.3"
+      }
+    },
+    "eslint": {
+      "version": "file:../../node_modules/.pnpm/eslint@8.10.0/node_modules/eslint",
+      "requires": {
+        "@babel/core": "^7.4.3",
+        "@babel/preset-env": "^7.4.3",
+        "@eslint/eslintrc": "^1.2.0",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "babel-loader": "^8.0.5",
+        "chai": "^4.0.1",
+        "chalk": "^4.0.0",
+        "cheerio": "^0.22.0",
+        "common-tags": "^1.8.0",
+        "core-js": "^3.1.3",
+        "cross-spawn": "^7.0.2",
+        "dateformat": "^4.5.1",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "ejs": "^3.0.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint": "file:",
+        "eslint-config-eslint": "file:packages/eslint-config-eslint",
+        "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-eslint-plugin": "^4.0.1",
+        "eslint-plugin-internal-rules": "file:tools/internal-rules",
+        "eslint-plugin-jsdoc": "^37.0.0",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-release": "^3.2.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "eslump": "^3.0.0",
+        "espree": "^9.3.1",
+        "esprima": "^4.0.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "fs-teardown": "^0.1.3",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.6",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "jsdoc": "^3.5.5",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "karma": "^6.1.1",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-mocha": "^2.0.1",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-webpack": "^5.0.0",
+        "levn": "^0.4.1",
+        "lint-staged": "^11.0.0",
+        "load-perf": "^0.2.0",
+        "lodash.merge": "^4.6.2",
+        "markdownlint": "^0.24.0",
+        "markdownlint-cli": "^0.30.0",
+        "marked": "^4.0.8",
+        "memfs": "^3.0.1",
+        "minimatch": "^3.0.4",
+        "mocha": "^8.3.2",
+        "mocha-junit-reporter": "^2.0.0",
+        "natural-compare": "^1.4.0",
+        "node-polyfill-webpack-plugin": "^1.0.3",
+        "npm-license": "^0.3.3",
+        "nyc": "^15.0.1",
+        "optionator": "^0.9.1",
+        "pirates": "^4.0.5",
+        "progress": "^2.0.3",
+        "proxyquire": "^2.0.1",
+        "puppeteer": "^9.1.1",
+        "recast": "^0.20.4",
+        "regenerator-runtime": "^0.13.2",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.5",
+        "shelljs": "^0.8.2",
+        "sinon": "^11.0.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "temp": "^0.9.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3",
+        "webpack": "^5.23.0",
+        "webpack-cli": "^4.5.0",
+        "yorkie": "^2.0.0"
+      }
+    },
+    "eslint-config-next": {
+      "version": "file:../../node_modules/.pnpm/eslint-config-next@12.1.0_4c2038871e8233f2b143838d68f90b16/node_modules/eslint-config-next",
+      "requires": {
+        "@next/eslint-plugin-next": "12.1.0",
+        "@rushstack/eslint-patch": "^1.0.8",
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-import-resolver-typescript": "^2.4.0",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.27.0",
+        "eslint-plugin-react-hooks": "^4.3.0"
+      }
+    },
+    "next": {
+      "version": "file:../../node_modules/.pnpm/next@12.1.0_react-dom@17.0.2+react@17.0.2/node_modules/next",
+      "requires": {
+        "@ampproject/toolbox-optimizer": "2.7.1-alpha.0",
+        "@babel/code-frame": "7.12.11",
+        "@babel/core": "7.15.0",
+        "@babel/eslint-parser": "7.13.14",
+        "@babel/generator": "7.15.0",
+        "@babel/plugin-proposal-class-properties": "7.14.5",
+        "@babel/plugin-proposal-export-namespace-from": "7.14.5",
+        "@babel/plugin-proposal-numeric-separator": "7.14.5",
+        "@babel/plugin-proposal-object-rest-spread": "7.14.7",
+        "@babel/plugin-syntax-bigint": "7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "7.8.3",
+        "@babel/plugin-syntax-jsx": "7.14.5",
+        "@babel/plugin-transform-modules-commonjs": "7.15.0",
+        "@babel/plugin-transform-runtime": "7.15.0",
+        "@babel/preset-env": "7.15.0",
+        "@babel/preset-react": "7.14.5",
+        "@babel/preset-typescript": "7.15.0",
+        "@babel/runtime": "7.15.4",
+        "@babel/traverse": "7.15.0",
+        "@babel/types": "7.15.0",
+        "@hapi/accept": "5.0.2",
+        "@napi-rs/cli": "1.2.1",
+        "@napi-rs/triples": "1.0.3",
+        "@next/env": "12.1.0",
+        "@next/polyfill-module": "12.1.0",
+        "@next/polyfill-nomodule": "12.1.0",
+        "@next/react-dev-overlay": "12.1.0",
+        "@next/react-refresh-utils": "12.1.0",
+        "@next/swc": "12.1.0",
+        "@next/swc-android-arm64": "12.1.0",
+        "@next/swc-darwin-arm64": "12.1.0",
+        "@next/swc-darwin-x64": "12.1.0",
+        "@next/swc-linux-arm-gnueabihf": "12.1.0",
+        "@next/swc-linux-arm64-gnu": "12.1.0",
+        "@next/swc-linux-arm64-musl": "12.1.0",
+        "@next/swc-linux-x64-gnu": "12.1.0",
+        "@next/swc-linux-x64-musl": "12.1.0",
+        "@next/swc-win32-arm64-msvc": "12.1.0",
+        "@next/swc-win32-ia32-msvc": "12.1.0",
+        "@next/swc-win32-x64-msvc": "12.1.0",
+        "@peculiar/webcrypto": "1.1.7",
+        "@taskr/clear": "1.1.0",
+        "@taskr/esnext": "1.1.0",
+        "@taskr/watch": "1.1.0",
+        "@types/amphtml-validator": "1.0.0",
+        "@types/babel__code-frame": "7.0.2",
+        "@types/babel__core": "7.1.12",
+        "@types/babel__generator": "7.6.2",
+        "@types/babel__template": "7.4.0",
+        "@types/babel__traverse": "7.11.0",
+        "@types/ci-info": "2.0.0",
+        "@types/compression": "0.0.36",
+        "@types/content-disposition": "0.5.4",
+        "@types/content-type": "1.1.3",
+        "@types/cookie": "0.3.3",
+        "@types/cross-spawn": "6.0.0",
+        "@types/debug": "4.1.5",
+        "@types/etag": "1.8.0",
+        "@types/fresh": "0.5.0",
+        "@types/jsonwebtoken": "8.3.7",
+        "@types/lodash.curry": "4.1.6",
+        "@types/lru-cache": "5.1.0",
+        "@types/micromatch": "4.0.2",
+        "@types/node-fetch": "2.3.4",
+        "@types/path-to-regexp": "1.7.0",
+        "@types/react": "16.9.17",
+        "@types/react-dom": "16.9.4",
+        "@types/react-is": "16.7.1",
+        "@types/semver": "7.3.1",
+        "@types/send": "0.14.4",
+        "@types/styled-jsx": "2.2.8",
+        "@types/text-table": "0.2.1",
+        "@types/ua-parser-js": "0.7.36",
+        "@types/uuid": "8.3.1",
+        "@types/webpack-sources1": "npm:@types/webpack-sources@0.1.5",
+        "@types/ws": "8.2.0",
+        "@vercel/ncc": "0.33.1",
+        "@vercel/nft": "0.17.5",
+        "acorn": "8.5.0",
+        "amphtml-validator": "1.0.35",
+        "arg": "4.1.0",
+        "assert": "2.0.0",
+        "async-retry": "1.2.3",
+        "async-sema": "3.0.0",
+        "babel-plugin-transform-define": "2.0.0",
+        "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+        "browserify-zlib": "0.2.0",
+        "browserslist": "4.18.1",
+        "buffer": "5.6.0",
+        "caniuse-lite": "^1.0.30001283",
+        "chalk": "2.4.2",
+        "ci-info": "watson/ci-info#f43f6a1cefff47fb361c88cf4b943fdbcaafe540",
+        "cli-select": "1.1.2",
+        "comment-json": "3.0.3",
+        "compression": "1.7.4",
+        "conf": "5.0.0",
+        "constants-browserify": "1.0.0",
+        "content-disposition": "0.5.3",
+        "content-type": "1.0.4",
+        "cookie": "0.4.1",
+        "cross-spawn": "6.0.5",
+        "crypto-browserify": "3.12.0",
+        "cssnano-simple": "3.0.0",
+        "debug": "4.1.1",
+        "devalue": "2.0.1",
+        "domain-browser": "4.19.0",
+        "etag": "1.8.1",
+        "events": "3.3.0",
+        "find-cache-dir": "3.3.1",
+        "find-up": "4.1.0",
+        "formdata-node": "4.3.0",
+        "fresh": "0.5.2",
+        "get-orientation": "1.1.2",
+        "glob": "7.1.7",
+        "gzip-size": "5.1.1",
+        "http-proxy": "1.18.1",
+        "https-browserify": "1.0.0",
+        "icss-utils": "5.1.0",
+        "ignore-loader": "0.1.2",
+        "image-size": "1.0.0",
+        "is-docker": "2.0.0",
+        "is-wsl": "2.2.0",
+        "jest-worker": "27.0.0-next.5",
+        "json5": "2.2.0",
+        "jsonwebtoken": "8.5.1",
+        "loader-utils2": "npm:loader-utils@2.0.0",
+        "loader-utils3": "npm:loader-utils@3.1.3",
+        "lodash.curry": "4.1.1",
+        "lru-cache": "5.1.1",
+        "micromatch": "4.0.4",
+        "mini-css-extract-plugin": "2.4.3",
+        "nanoid": "3.1.30",
+        "native-url": "0.3.4",
+        "neo-async": "2.6.1",
+        "node-fetch": "2.6.7",
+        "node-html-parser": "1.4.9",
+        "ora": "4.0.4",
+        "os-browserify": "0.3.0",
+        "p-limit": "3.1.0",
+        "path-browserify": "1.0.1",
+        "path-to-regexp": "6.1.0",
+        "postcss": "8.4.5",
+        "postcss-flexbugs-fixes": "5.0.2",
+        "postcss-modules-extract-imports": "3.0.0",
+        "postcss-modules-local-by-default": "4.0.0",
+        "postcss-modules-scope": "3.0.0",
+        "postcss-modules-values": "4.0.0",
+        "postcss-preset-env": "6.7.0",
+        "postcss-safe-parser": "6.0.0",
+        "postcss-scss": "3.0.5",
+        "postcss-value-parser": "4.1.0",
+        "process": "0.11.10",
+        "punycode": "2.1.1",
+        "querystring-es3": "0.2.1",
+        "raw-body": "2.4.1",
+        "react-is": "17.0.2",
+        "react-refresh": "0.8.3",
+        "react-server-dom-webpack": "0.0.0-experimental-13455d26d-20211104",
+        "regenerator-runtime": "0.13.4",
+        "sass-loader": "12.4.0",
+        "schema-utils2": "npm:schema-utils@2.7.1",
+        "schema-utils3": "npm:schema-utils@3.0.0",
+        "semver": "7.3.2",
+        "send": "0.17.1",
+        "setimmediate": "1.0.5",
+        "source-map": "0.6.1",
+        "stream-browserify": "3.0.0",
+        "stream-http": "3.1.1",
+        "string_decoder": "1.3.0",
+        "string-hash": "1.1.3",
+        "strip-ansi": "6.0.0",
+        "styled-jsx": "5.0.0",
+        "taskr": "1.1.0",
+        "terser": "5.10.0",
+        "text-table": "0.2.0",
+        "timers-browserify": "2.0.12",
+        "tty-browserify": "0.0.1",
+        "ua-parser-js": "0.7.28",
+        "unistore": "3.4.1",
+        "use-subscription": "1.5.1",
+        "util": "0.12.4",
+        "uuid": "8.3.2",
+        "vm-browserify": "1.1.2",
+        "watchpack": "2.3.1",
+        "web-streams-polyfill": "3.0.3",
+        "web-vitals": "2.1.0",
+        "webpack-sources1": "npm:webpack-sources@1.4.3",
+        "webpack-sources3": "npm:webpack-sources@3.2.3",
+        "webpack4": "npm:webpack@4.44.1",
+        "webpack5": "npm:webpack@5.69.1",
+        "ws": "8.2.3"
+      }
+    },
+    "next-absolute-url": {
+      "version": "file:../../node_modules/.pnpm/next-absolute-url@1.2.2/node_modules/next-absolute-url",
+      "requires": {
+        "@types/jest": "24.0.25",
+        "@types/node": "13.1.6",
+        "@zeit/git-hooks": "0.1.4",
+        "jest": "24.9.0",
+        "prettier": "1.19.1",
+        "ts-jest": "24.3.0",
+        "typescript": "3.7.4"
+      }
+    },
+    "next-seo": {
+      "version": "file:../../node_modules/.pnpm/next-seo@5.2.0_caa633a00319350dbda42996613fe26c/node_modules/next-seo",
+      "requires": {
+        "@babel/core": "^7.16.12",
+        "@babel/preset-env": "^7.16.11",
+        "@babel/preset-react": "^7.16.7",
+        "@babel/preset-typescript": "^7.16.7",
+        "@cypress/schema-tools": "^4.7.9",
+        "@types/jest": "^27.4.0",
+        "@types/node": "^17.0.13",
+        "@types/react": "^17.0.38",
+        "@types/react-dom": "^17.0.11",
+        "babel-jest": "^27.4.6",
+        "cypress": "^9.3.1",
+        "cypress-testing-library": "^4.0.0",
+        "doctoc": "^2.1.0",
+        "husky": "4.3.8",
+        "jest": "^27.4.7",
+        "lint-staged": "11.1.1",
+        "microbundle": "^0.14.2",
+        "next": "^12.0.9",
+        "npm-run-all": "4.1.5",
+        "prettier": "2.5.1",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
+        "react-testing-library": "7.0.0",
+        "rimraf": "3.0.2",
+        "typescript": "^4.5.5"
+      }
+    },
+    "postcss": {
+      "version": "file:../../node_modules/.pnpm/postcss@8.4.12/node_modules/postcss",
+      "requires": {
+        "nanoid": "^3.3.1",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "react": {
+      "version": "file:../../node_modules/.pnpm/react@17.0.2/node_modules/react",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "react-dom": {
+      "version": "file:../../node_modules/.pnpm/react-dom@17.0.2_react@17.0.2/node_modules/react-dom",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      }
+    },
+    "tailwindcss": {
+      "version": "file:../../node_modules/.pnpm/tailwindcss@3.0.23_autoprefixer@10.4.4/node_modules/tailwindcss",
+      "requires": {
+        "@swc/cli": "^0.1.55",
+        "@swc/core": "^1.2.127",
+        "@swc/jest": "^0.2.17",
+        "@swc/register": "^0.1.10",
+        "arg": "^5.0.1",
+        "autoprefixer": "^10.4.2",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "color-name": "^1.1.4",
+        "cosmiconfig": "^7.0.1",
+        "cssnano": "^5.0.16",
+        "detective": "^5.2.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "esbuild": "^0.14.21",
+        "eslint": "^8.8.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jest": "^27.5.1",
+        "jest-diff": "^27.5.1",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^2.2.0",
+        "postcss": "^8.4.6",
+        "postcss-js": "^4.0.0",
+        "postcss-load-config": "^3.1.0",
+        "postcss-nested": "5.0.6",
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0",
+        "prettier": "^2.5.1",
+        "prettier-plugin-tailwindcss": "^0.1.7",
+        "quick-lru": "^5.1.1",
+        "resolve": "^1.22.0",
+        "rimraf": "^3.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added lock files to each of the starters. Tested to confirm that it didn't make pnpm mad.

Ideally we wouldn't have to do this, but in the meantime it will at least unblock things. We'll either need to remember to update the locks manually before we merge to main, or automate something if this becomes a long term fix.