### PR TITLE
DB-2114: [next-drupal] Refine environment variable config

### DIFF
--- a/.changeset/sweet-eggs-call.md
+++ b/.changeset/sweet-eggs-call.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+Reconfigure env vars so empty BACKEND_URL does not fail builds on infra

--- a/starters/next-drupal-starter/lib/constants.js
+++ b/starters/next-drupal-starter/lib/constants.js
@@ -1,0 +1,7 @@
+const DRUPAL_URL = process.env.backendUrl;
+const IMAGE_URL = process.env.imageUrl || DRUPAL_URL;
+
+module.exports = {
+  DRUPAL_URL,
+  IMAGE_URL,
+};

--- a/starters/next-drupal-starter/package.json
+++ b/starters/next-drupal-starter/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "cp -n .env.dev .env.local || true"
+    "postinstall": "cp -n .env.example .env.local || true"
   },
   "dependencies": {
     "@pantheon-systems/drupal-kit": "^1.0.0",

--- a/starters/next-drupal-starter/pages/articles/[...slug].js
+++ b/starters/next-drupal-starter/pages/articles/[...slug].js
@@ -7,8 +7,7 @@ import {
 } from "@pantheon-systems/drupal-kit";
 import { isMultiLanguage } from "../../lib/isMultiLanguage";
 import Layout from "../../components/layout";
-
-const drupalUrl = process.env.backendUrl;
+import { DRUPAL_URL, IMAGE_URL } from "../../lib/constants.js";
 
 export default function Home({ article, hrefLang }) {
   const imgSrc = article.field_media_image?.field_media_image?.uri?.url || "";
@@ -33,7 +32,7 @@ export default function Home({ article, hrefLang }) {
               style={{ height: "50vh" }}
             >
               <Image
-                src={imgSrc}
+                src={IMAGE_URL + imgSrc}
                 layout="fill"
                 objectFit="cover"
                 alt={article.title}
@@ -54,7 +53,7 @@ export async function getStaticPaths(context) {
   // Get paths for each locale.
   const pathsByLocale = context.locales.map(async (locale) => {
     const store = new DrupalState({
-      apiBase: drupalUrl,
+      apiBase: DRUPAL_URL,
       defaultLocale: multiLanguage ? locale : "",
       clientId: process.env.CLIENT_ID,
       clientSecret: process.env.CLIENT_SECRET,
@@ -96,7 +95,7 @@ export async function getStaticProps(context) {
   const multiLanguage = isMultiLanguage(context.locales);
   // TODO - determine apiBase from environment variables
   const store = new DrupalState({
-    apiBase: drupalUrl,
+    apiBase: DRUPAL_URL,
     defaultLocale: multiLanguage ? context.locale : "",
     clientId: process.env.CLIENT_ID,
     clientSecret: process.env.CLIENT_SECRET,
@@ -161,7 +160,7 @@ export async function getStaticProps(context) {
   // Load all the paths for the current article.
   const paths = locales.map(async (locale) => {
     const storeByLocales = new DrupalState({
-      apiBase: drupalUrl,
+      apiBase: DRUPAL_URL,
       defaultLocale: multiLanguage ? locale : "",
       clientId: process.env.CLIENT_ID,
       clientSecret: process.env.CLIENT_SECRET,

--- a/starters/next-drupal-starter/pages/articles/index.js
+++ b/starters/next-drupal-starter/pages/articles/index.js
@@ -5,8 +5,9 @@ import absoluteUrl from "next-absolute-url";
 import { DrupalState } from "@pantheon-systems/drupal-kit";
 import { isMultiLanguage } from "../../lib/isMultiLanguage";
 import Layout from "../../components/layout";
+import { DRUPAL_URL, IMAGE_URL } from "../../lib/constants.js"
 
-const drupalUrl = process.env.backendUrl;
+
 export default function SSRArticlesList({ articles, hrefLang }) {
   return (
     <Layout>
@@ -34,7 +35,7 @@ export default function SSRArticlesList({ articles, hrefLang }) {
                   <div className="flex-shrink-0 relative h-40">
                     {imgSrc !== "" ? (
                       <Image
-                        src={drupalUrl + imgSrc}
+                        src={IMAGE_URL + imgSrc}
                         layout="fill"
                         objectFit="cover"
                         alt={
@@ -83,7 +84,7 @@ export async function getServerSideProps(context) {
 
     // TODO - determine apiRoot from environment variables
     const store = new DrupalState({
-      apiBase: drupalUrl,
+      apiBase: DRUPAL_URL,
       defaultLocale: multiLanguage ? context.locale : "",
     });
 

--- a/starters/next-drupal-starter/pages/examples/pagination/[[...page]].js
+++ b/starters/next-drupal-starter/pages/examples/pagination/[[...page]].js
@@ -2,11 +2,10 @@ import { useEffect, useState } from "react";
 import { DrupalState } from "@pantheon-systems/drupal-kit";
 import Head from "next/head";
 import { useRouter } from "next/router";
-
 import Layout from "../../../components/layout";
 
 // To use your configured backend, use:
-// const drupalUrl = process.env.backendUrl;
+// const drupalUrl = DRUPAL_URL
 
 // Example paginated data set
 const drupalUrl = "https://dev-ds-demo.pantheonsite.io";

--- a/starters/next-drupal-starter/pages/index.js
+++ b/starters/next-drupal-starter/pages/index.js
@@ -4,8 +4,7 @@ import { NextSeo } from "next-seo";
 import { DrupalState } from "@pantheon-systems/drupal-kit";
 import { isMultiLanguage } from "../lib/isMultiLanguage";
 import Layout from "../components/layout";
-
-const drupalUrl = process.env.backendUrl;
+import { DRUPAL_URL, IMAGE_URL } from "../lib/constants.js";
 
 export default function Home({ articles, hrefLang, multiLanguage }) {
   return (
@@ -59,7 +58,7 @@ export default function Home({ articles, hrefLang, multiLanguage }) {
                       {/* if thre's no imgSrc, default to Pantheon logo */}
                       {imgSrc !== "" ? (
                         <Image
-                          src={drupalUrl + imgSrc}
+                          src={IMAGE_URL + imgSrc}
                           layout="fill"
                           objectFit="cover"
                           alt={
@@ -108,7 +107,7 @@ export async function getStaticProps(context) {
   try {
     // TODO - determine apiRoot from environment variables
     const store = new DrupalState({
-      apiBase: process.env.BACKEND_URL,
+      apiBase: DRUPAL_URL,
       // if multilanguage NOT enabled, passing in a locale here will
       // break calls to Drupal, so pass an empty string.
       defaultLocale: multiLanguage ? context.locale : "",

--- a/starters/next-drupal-starter/pages/pages/index.js
+++ b/starters/next-drupal-starter/pages/pages/index.js
@@ -3,6 +3,7 @@ import { NextSeo } from "next-seo";
 import { DrupalState } from "@pantheon-systems/drupal-kit";
 import { isMultiLanguage } from "../../lib/isMultiLanguage";
 import Layout from "../../components/layout";
+import { DRUPAL_URL } from "../../lib/constants.js";
 
 export default function PagesList({ hrefLang, pages }) {
   return (
@@ -49,7 +50,7 @@ export async function getStaticProps(context) {
   });
 
   const store = new DrupalState({
-    apiBase: process.env.BACKEND_URL,
+    apiBase: DRUPAL_URL,
     defaultLocale: multiLanguage ? locale : "",
   });
 

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -5,6 +5,8 @@ import { isMultiLanguage } from "../../lib/isMultiLanguage";
 import { DrupalState } from "@pantheon-systems/drupal-kit";
 import Layout from "../../components/layout";
 
+import { DRUPAL_URL, IMAGE_URL } from "../../lib/constants.js";
+
 export default function Recipe({ recipe, hrefLang }) {
   const imgSrc = recipe.field_media_image?.field_media_image?.uri?.url || "";
 
@@ -30,7 +32,7 @@ export default function Recipe({ recipe, hrefLang }) {
         {imgSrc ? (
           <div className="relative max-w-lg mx-auto min-w-full h-[50vh] rounded-lg shadow-lg overflow-hidden mt-12 mb-10">
             <Image
-              src={imgSrc}
+              src={IMAGE_URL + imgSrc}
               layout="fill"
               objectFit="cover"
               alt={recipe.title}
@@ -77,7 +79,7 @@ export async function getStaticPaths(context) {
   // Get paths for each locale.
   const pathsByLocale = locales.map(async (locale) => {
     const store = new DrupalState({
-      apiBase: process.env.BACKEND_URL,
+      apiBase: DRUPAL_URL,
       defaultLocale: multiLanguage ? locale : "",
     });
 
@@ -118,7 +120,7 @@ export async function getStaticProps(context) {
   const multiLanguage = isMultiLanguage(locales);
 
   const store = new DrupalState({
-    apiBase: process.env.BACKEND_URL,
+    apiBase: DRUPAL_URL,
     defaultLocale: multiLanguage ? locale : "",
   });
   store.params.addInclude([
@@ -157,7 +159,7 @@ export async function getStaticProps(context) {
     // Load all the paths for the current recipe.
     const paths = locales.map(async (locale) => {
       const storeByLocales = new DrupalState({
-        apiBase: process.env.BACKEND_URL,
+        apiBase: DRUPAL_URL,
         defaultLocale: multiLanguage ? locale : "",
       });
       const { path } = await storeByLocales.getObject({

--- a/starters/next-drupal-starter/pages/recipes/index.js
+++ b/starters/next-drupal-starter/pages/recipes/index.js
@@ -4,8 +4,9 @@ import { NextSeo } from "next-seo";
 import { DrupalState } from "@pantheon-systems/drupal-kit";
 import { isMultiLanguage } from "../../lib/isMultiLanguage";
 import Layout from "../../components/layout";
+import { DRUPAL_URL, IMAGE_URL } from "../../lib/constants.js";
 
-const drupalUrl = process.env.backendUrl;
+
 export default function Recipes({ recipes, hrefLang }) {
   function RecipesList() {
     return (
@@ -33,7 +34,7 @@ export default function Recipes({ recipes, hrefLang }) {
                         <div className="flex-shrink-0 relative h-40">
                           {imgSrc !== "" ? (
                             <Image
-                              src={drupalUrl + imgSrc}
+                              src={IMAGE_URL + imgSrc}
                               layout="fill"
                               objectFit="cover"
                               alt={
@@ -100,7 +101,7 @@ export async function getStaticProps(context) {
   });
 
   const store = new DrupalState({
-    apiBase: process.env.BACKEND_URL,
+    apiBase: DRUPAL_URL,
     defaultLocale: multiLanguage ? locale : "",
   });
 


### PR DESCRIPTION
- Added  `/lib/constants.js` file that contains the single-source of truth for relevant env vars consumed by pages & components
- Added logic to allow an empty BACKEND_URL to fallback to PANTHEON_CMS_ENDPOINT which should prevent builds from failing if this variable is not set when creating a new site.
- Added logic to determine the IMAGE_DOMAIN from the BACKEND_URL or PANTHEON_CMS_ENDPOINT, and will take the value of IMAGE_DOMAIN if it exists.
