### PR TITLE
DB-2114: [next-drupal] Refine environment variable config

### DIFF
--- a/.changeset/big-hotels-repair.md
+++ b/.changeset/big-hotels-repair.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+Further refined env variable config

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -4,22 +4,20 @@ const getLocales = require("./scripts/get-locales");
 // Load the .env.local env file
 require("dotenv").config({ path: path.resolve(process.cwd(), ".env.local") });
 
-// Fallback to PANTHEON_CMS_ENDPOINT if BACKEND_URL is not set
 let backendUrl, imageDomain;
 if (process.env.BACKEND_URL === undefined) {
-  backendUrl = process.env.PANTHEON_CMS_ENDPOINT;
-  imageDomain =
-    process.env.IMAGE_DOMAIN ||
-    process.env.PANTHEON_CMS_ENDPOINT?.replace(/^https:\/\//, "");
+  backendUrl = `https://${process.env.PANTHEON_CMS_ENDPOINT}`;
+  imageDomain = process.env.IMAGE_DOMAIN || process.env.PANTHEON_CMS_ENDPOINT;
 
-  process.env.BACKEND_URL = process.env.PANTHEON_CMS_ENDPOINT;
+  // populate BACKEND_URL as a fallback and for build scripts
+  process.env.BACKEND_URL = `https://${process.env.PANTHEON_CMS_ENDPOINT}`;
 } else {
   backendUrl = process.env.BACKEND_URL;
   imageDomain =
     process.env.IMAGE_DOMAIN ||
     process.env.BACKEND_URL.replace(/^https:\/\//, "");
 }
-// remove trailing slash from iamgeDomain if it exists
+// remove trailing slash if it exists
 imageDomain = imageDomain.replace(/\/$/, "");
 
 module.exports = async () => {

--- a/starters/next-drupal-starter/scripts/generate-layout.js
+++ b/starters/next-drupal-starter/scripts/generate-layout.js
@@ -9,12 +9,11 @@ const getLocales = require("./get-locales");
  */
 const getLayoutData = async () => {
   const locales = await getLocales();
-  const drupalUrl = process.env.BACKEND_URL;
 
   try {
     locales.forEach(async (locale) => {
       const store = new DrupalState({
-        apiBase: drupalUrl,
+        apiBase: process.env.BACKEND_URL,
         defaultLocale: locales.length <= 1 ? "" : locale,
       });
       let menuData;

--- a/starters/next-drupal-starter/scripts/get-locales.js
+++ b/starters/next-drupal-starter/scripts/get-locales.js
@@ -1,4 +1,5 @@
 const fetch = require("isomorphic-fetch");
+
 const getLocales = async () => {
   try {
     const res = await fetch(
@@ -16,4 +17,5 @@ const getLocales = async () => {
     return ["en"];
   }
 };
+
 module.exports = getLocales;


### PR DESCRIPTION
- Add https protocol to PANTHEON_CMS_ENDPOINT
- Update scripts

PANTHEON_CMS_ENDPOINT does not have the `https://` prepended, so this will add it and make sure builds don't fail as long as a CMS is linked in the dashboard.