### PR TITLE
DB-2115: [gatsby-wordpress] Refine environment variable config

### DIFF
--- a/.changeset/forty-bikes-lick.md
+++ b/.changeset/forty-bikes-lick.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/gatsby-wordpress-starter": patch
+---
+
+Refined environment variable fallback

--- a/starters/gatsby-wordpress-starter/gatsby-config.js
+++ b/starters/gatsby-wordpress-starter/gatsby-config.js
@@ -1,26 +1,13 @@
 const path = require("path")
-const dotenv = require("dotenv")
+require("dotenv").config({
+  path: path.resolve(process.cwd(), ".env.local"),
+})
 
-// Register envars for dev, test, live or local if available
-switch (process.env.BACKEND_ENV) {
-  case "dev":
-    dotenv.config({ path: path.resolve(process.cwd(), ".env.dev") })
-  case "test":
-    dotenv.config({ path: path.resolve(process.cwd(), ".env.test") })
-  case "live":
-    dotenv.config({ path: path.resolve(process.cwd(), ".env.live") })
-  default:
-    dotenv.config({
-      path: path.resolve(process.cwd(), ".env.local"),
-    })
-}
-
-const env = process.env.BACKEND_ENV
-const site = process.env.BACKEND_SITE
-// Use URL from .env if it exists, otherwise fall back on constructing
-// Pantheon site URL
+// Use URL from .env if it exists, otherwise fall back on the
+// Pantheon CMS endpoint
 const url =
-  process.env.WPGRAPHQL_URL || `https://${env}-${site}.pantheonsite.io/graphql`
+  process.env.WPGRAPHQL_URL ||
+  `https://${process.env.PANTHEON_CMS_ENDPOINT}/wp/graphql`
 
 /**
  * 👋 Hey there!
@@ -97,6 +84,6 @@ module.exports = {
      * To learn more, visit: https://gatsby.dev/offline
      */
     // `gatsby-plugin-offline`,
-    'gatsby-plugin-pnpm'
+    "gatsby-plugin-pnpm",
   ],
 }


### PR DESCRIPTION
- Gatsby will now fallback to the `PANTHEON_CMS_ENDPOINT` if a `WPGRAPHQL_URL` is not provided