### PR TITLE
DB-2114: [next-drupal] Fix .env.local loading in production

### DIFF
--- a/.changeset/thirty-chairs-compete.md
+++ b/.changeset/thirty-chairs-compete.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+[next-drupal] Change .env.local to .env.development.local so it does not load in production

--- a/starters/next-drupal-starter/.gitignore
+++ b/starters/next-drupal-starter/.gitignore
@@ -25,10 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # vercel
 .vercel

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -1,8 +1,9 @@
 const path = require("path");
 const getLocales = require("./scripts/get-locales");
 
-// Load the .env.local env file
-require("dotenv").config({ path: path.resolve(process.cwd(), ".env.local") });
+// Load the .env file for local development
+// .env.development.local by default
+require("dotenv").config({ path: path.resolve(process.cwd(), ".env.development.local") });
 
 let backendUrl, imageDomain;
 if (process.env.BACKEND_URL === undefined) {

--- a/starters/next-drupal-starter/package.json
+++ b/starters/next-drupal-starter/package.json
@@ -16,7 +16,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "cp -n .env.example .env.local || true"
+    "postinstall": "cp -n .env.example .env.development.local || true"
   },
   "dependencies": {
     "@pantheon-systems/drupal-kit": "^1.0.2",


### PR DESCRIPTION
According to [Next.js env variable load order](https://nextjs.org/docs/basic-features/environment-variables#environment-variable-load-order), `.env.local` is loaded in production environments.  To avoid this, I've changed the local .env file to `.env.development.local` which will not be loaded in production environments.