### PR TITLE
DB-2114: [next-drupal] Remove postinstall script

### DIFF
--- a/.changeset/friendly-cars-jump.md
+++ b/.changeset/friendly-cars-jump.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+[next-drupal] Remove postinstall script, refine readme for .env configuration

--- a/.changeset/thirty-chairs-compete.md
+++ b/.changeset/thirty-chairs-compete.md
@@ -1,5 +1,0 @@
----
-"@pantheon-systems/next-drupal-starter": patch
----
-
-[next-drupal] Change .env.local to .env.development.local so it does not load in production

--- a/starters/next-drupal-starter/.env.example
+++ b/starters/next-drupal-starter/.env.example
@@ -1,4 +1,4 @@
-# Copy as .env.local to override envars for local development
+# Copy as .env.development.local to override envars for local development
 BACKEND_URL=http://my-backend-site.pantheonsite.io
 FRONTEND_URL=http://my-frontend-site.pantheonsite.io
 IMAGE_DOMAIN=my-frontend-site.pantheonsite.io

--- a/starters/next-drupal-starter/CHANGELOG.md
+++ b/starters/next-drupal-starter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pantheon-systems/next-drupal-starter
 
+## 1.0.3
+
+### Patch Changes
+
+- 9f7bc9a: [next-drupal] Change .env.local to .env.development.local so it does not load in production
+
 ## 1.0.2
 
 ### Patch Changes

--- a/starters/next-drupal-starter/README.md
+++ b/starters/next-drupal-starter/README.md
@@ -23,22 +23,25 @@ git clone git@github.com:pantheon-systems/next-drupal-starter.git
 2. Install node modules
 
 ```bash
-cd decoupled-drupal-frontend-demo && npm install
+cd next-drupal-starter && npm install
 ```
 
-For either option, update following lines in `.env.local`
+For either option, create a `.env.development.local` file and update it with the following:
+(See .env.example for an example)
 
 ```
 BACKEND_URL=
-FRONTEND_URL=
 IMAGE_DOMAIN=
-PREVIEW_SECRET=
-CLIENT_ID=
-CLIENT_SECRET=
+
 # this value can also bet set in the command line
 # before running commands for example
 # FRONTEND_URL=example.com npm run build
 FRONTEND_URL=
+
+# These variables are needed to enable Preview
+PREVIEW_SECRET=
+CLIENT_ID=
+CLIENT_SECRET=
 ```
 
 4. Run `lando start`

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -3,7 +3,9 @@ const getLocales = require("./scripts/get-locales");
 
 // Load the .env file for local development
 // .env.development.local by default
-require("dotenv").config({ path: path.resolve(process.cwd(), ".env.development.local") });
+require("dotenv").config({
+  path: path.resolve(process.cwd(), ".env.development.local"),
+});
 
 let backendUrl, imageDomain;
 if (process.env.BACKEND_URL === undefined) {

--- a/starters/next-drupal-starter/package.json
+++ b/starters/next-drupal-starter/package.json
@@ -15,8 +15,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "postinstall": "cp -n .env.example .env.development.local || true"
+    "lint": "next lint"
   },
   "dependencies": {
     "@pantheon-systems/drupal-kit": "^1.0.2",

--- a/starters/next-drupal-starter/package.json
+++ b/starters/next-drupal-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantheon-systems/next-drupal-starter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "Pantheon Decoupled Kit's Next Drupal Starter",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
It seems Next.js loads some .env files in production.
- Remove the postinstall script so we don't have to worry about .env files in prod
- Update README with instructions on creating a `.env.development.local` file