### PR TITLE
[next-drupal] Expose Next FRONTEND_URL

### DIFF
--- a/.changeset/fast-rules-occur.md
+++ b/.changeset/fast-rules-occur.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+Expose FRONTEND_URL to properly set hrefLang

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -23,6 +23,9 @@ if (process.env.BACKEND_URL === undefined) {
 // remove trailing slash if it exists
 imageDomain = imageDomain.replace(/\/$/, "");
 
+// expose FRONTEND_URL to properly set hrefLang
+process.env.NEXT_PUBLIC_FRONTEND_URL = process.env.FRONTEND_URL;
+
 module.exports = async () => {
   const nextConfig = {
     env: {

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -24,7 +24,8 @@ if (process.env.BACKEND_URL === undefined) {
 imageDomain = imageDomain.replace(/\/$/, "");
 
 // expose FRONTEND_URL to properly set hrefLang
-process.env.NEXT_PUBLIC_FRONTEND_URL = process.env.FRONTEND_URL;
+// and remove trailing slash
+process.env.NEXT_PUBLIC_FRONTEND_URL = process.env.FRONTEND_URL.replace(/\/$/, "");;
 
 module.exports = async () => {
   const nextConfig = {

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -25,7 +25,9 @@ imageDomain = imageDomain.replace(/\/$/, "");
 
 // expose FRONTEND_URL to properly set hrefLang
 // and remove trailing slash
-process.env.NEXT_PUBLIC_FRONTEND_URL = process.env.FRONTEND_URL.replace(/\/$/, "");;
+process.env.NEXT_PUBLIC_FRONTEND_URL = process.env.FRONTEND_URL
+  ? process.env.FRONTEND_URL?.replace(/\/$/, "")
+  : "";
 
 module.exports = async () => {
   const nextConfig = {

--- a/starters/next-drupal-starter/pages/articles/[...slug].js
+++ b/starters/next-drupal-starter/pages/articles/[...slug].js
@@ -155,7 +155,7 @@ export async function getStaticProps(context) {
       `,
   });
 
-  const origin = process.env.FRONTEND_URL;
+  const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
   const { locales } = context;
   // Load all the paths for the current article.
   const paths = locales.map(async (locale) => {

--- a/starters/next-drupal-starter/pages/index.js
+++ b/starters/next-drupal-starter/pages/index.js
@@ -92,7 +92,7 @@ export default function Home({ articles, hrefLang, multiLanguage }) {
 }
 
 export async function getStaticProps(context) {
-  const origin = process.env.FRONTEND_URL;
+  const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
   const { locales } = context;
   // if there is more than one language in context.locales,
   // assume multilanguage is enabled.

--- a/starters/next-drupal-starter/pages/pages/[alias].js
+++ b/starters/next-drupal-starter/pages/pages/[alias].js
@@ -97,7 +97,7 @@ export async function getStaticProps(context) {
       `,
   });
 
-  const origin = process.env.FRONTEND_URL;
+  const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
   const { locales } = context;
   // Load all the paths for the current page content type.
   const paths = locales.map(async (locale) => {

--- a/starters/next-drupal-starter/pages/pages/index.js
+++ b/starters/next-drupal-starter/pages/pages/index.js
@@ -38,7 +38,7 @@ export default function PagesList({ hrefLang, pages }) {
 }
 
 export async function getStaticProps(context) {
-  const origin = process.env.FRONTEND_URL;
+  const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
   const { locales, locale } = context;
   const multiLanguage = isMultiLanguage(locales);
 

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -155,7 +155,7 @@ export async function getStaticProps(context) {
       );
     }
 
-    const origin = process.env.FRONTEND_URL;
+    const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
     // Load all the paths for the current recipe.
     const paths = locales.map(async (locale) => {
       const storeByLocales = new DrupalState({

--- a/starters/next-drupal-starter/pages/recipes/index.js
+++ b/starters/next-drupal-starter/pages/recipes/index.js
@@ -6,7 +6,6 @@ import { isMultiLanguage } from "../../lib/isMultiLanguage";
 import Layout from "../../components/layout";
 import { DRUPAL_URL, IMAGE_URL } from "../../lib/constants.js";
 
-
 export default function Recipes({ recipes, hrefLang }) {
   function RecipesList() {
     return (
@@ -89,7 +88,7 @@ export default function Recipes({ recipes, hrefLang }) {
 }
 
 export async function getStaticProps(context) {
-  const origin = process.env.FRONTEND_URL;
+  const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
   const { locales, locale } = context;
   const multiLanguage = isMultiLanguage(locales);
 


### PR DESCRIPTION
Previously this was done in the .env file but it makes sense to move it to the config. Currently setting FRONTEND_URL won't have the intended effect, but this change should make it work.

- Strip trailing slash from FRONTEND_URL and set it to NEXT_PUBLIC_FRONTEND_URL
- Uses NEXT_PUBLIC_FRONTEND_URL for setting the hrefLang to avoid double slashes