### PR TITLE
Re-publish version release to resolve CI failure

### DIFF
--- a/packages/drupal-kit/CHANGELOG.md
+++ b/packages/drupal-kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pantheon-systems/drupal-kit
 
+## 1.1.1
+
+### Patch Changes
+
+- Re-publishing after a CI error
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/drupal-kit/package.json
+++ b/packages/drupal-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pantheon-systems/drupal-kit",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Pantheon Decoupled Kit's Drupal Kit",
   "license": "GPL-3.0-or-later",
   "homepage": "https://github.com/pantheon-systems/decoupled-kit-js#readme",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,11 +794,15 @@ packages:
     resolution: {integrity: sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.17.10
 
   /@babel/parser/7.17.8:
     resolution: {integrity: sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.17.10
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.7_@babel+core@7.17.8:
     resolution: {integrity: sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==}
@@ -4643,6 +4647,7 @@ packages:
     resolution: {integrity: sha512-eeLHFwv3jT3GmIxpLC7B8EXExGK0MFaK91HXljOMh6l8a+GlQYw27MSFQVtoXr0Olx9Uq2uvjXP1+zSsq3LQUQ==}
     engines: {node: '>= 12.0.0', parcel: ^2.4.0}
     dependencies:
+      '@parcel/core': 2.4.0
       '@parcel/diagnostic': 2.4.0
       '@parcel/plugin': 2.4.0_@parcel+core@2.4.0
       '@parcel/source-map': 2.0.2
@@ -5302,7 +5307,7 @@ packages:
     resolution: {integrity: sha512-ATA/xrS7CZ3A2WCPVY4eKdNpybq56zqlTirnHhhyOztZM/lPxJzusOBI3BsaXbu6FrUluqzvMlI4sZ6BDYMlMg==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 17.0.23
+      '@types/node': 17.0.33
     dev: false
 
   /@types/graceful-fs/4.1.5:
@@ -5383,7 +5388,7 @@ packages:
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 17.0.33
     dev: false
 
   /@types/lodash/4.14.180:
@@ -5411,13 +5416,13 @@ packages:
   /@types/mkdirp/0.5.2:
     resolution: {integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==}
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 17.0.33
     dev: false
 
   /@types/node-fetch/2.6.1:
     resolution: {integrity: sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==}
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 17.0.33
       form-data: 3.0.1
     dev: false
 
@@ -5508,7 +5513,7 @@ packages:
   /@types/responselike/1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 17.0.33
     dev: false
 
   /@types/retry/0.12.1:
@@ -5519,7 +5524,7 @@ packages:
     resolution: {integrity: sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==}
     dependencies:
       '@types/glob': 5.0.37
-      '@types/node': 17.0.23
+      '@types/node': 17.0.33
     dev: false
 
   /@types/sax/1.2.4:
@@ -5574,7 +5579,7 @@ packages:
   /@types/websocket/1.0.2:
     resolution: {integrity: sha512-B5m9aq7cbbD/5/jThEr33nUY8WEfVi6A2YKCTOvw5Ldy7mtsOkqRvGjnzy6g7iMMDsgu7xREuCzqATLDLQVKcQ==}
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 17.0.33
     dev: false
 
   /@types/ws/8.5.3:
@@ -6613,7 +6618,7 @@ packages:
     resolution: {integrity: sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==}
     dependencies:
       '@babel/helper-module-imports': 7.16.7
-      '@babel/types': 7.17.0
+      '@babel/types': 7.17.10
       glob: 7.2.0
       lodash: 4.17.21
       require-package-name: 2.0.1
@@ -10358,7 +10363,7 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: true
@@ -10406,7 +10411,7 @@ packages:
       '@babel/preset-typescript': 7.16.7_@babel+core@7.17.8
       '@babel/runtime': 7.17.8
       '@babel/template': 7.16.7
-      '@babel/types': 7.17.0
+      '@babel/types': 7.17.10
       '@types/common-tags': 1.8.1
       better-opn: 2.1.1
       boxen: 5.1.2
@@ -11357,6 +11362,8 @@ packages:
     dependencies:
       '@sindresorhus/is': 0.14.0
       '@szmarczak/http-timer': 1.1.2
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
@@ -13308,7 +13315,7 @@ packages:
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
 
   /jsonfile/6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -13501,7 +13508,7 @@ packages:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
@@ -16266,7 +16273,7 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0


### PR DESCRIPTION
---
name: Pull Request
about: Open a Pull Request
---
<!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Changes to publish drupal-kit 1.1.1

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
1.1.1 release of drupal-kit

## How have the changes been tested?
Created a new project using the starter kit on Pantheon, confirmed that the build completed successfully.

I also confirmed that this branch can be merged cleanly into the current canary.

## Additional information
<!--- Add any other context about the feature or fix here. --->
Merging this might be a little funky since it was already published. Best guess is that either the publishing workflow isn't triggered at all, or it is, but nothing is actually published to NPM because versions already exist.

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!