### PR TITLE
DB-2719: Document removal of recipes pages

### DIFF
--- a/starters/next-drupal-starter/README.md
+++ b/starters/next-drupal-starter/README.md
@@ -2,7 +2,7 @@
 
 There are two ways to get started with the Next Drupal Starter:
 
-__Option 1__: Use `create-next-app`
+**Option 1**: Use `create-next-app`
 
 1. In your terminal, run the following command:
 
@@ -12,8 +12,8 @@ npx create-next-app -e https://github.com/pantheon-systems/next-drupal-starter -
 
 2. Follow the prompts in your terminal to complete the setup.
 
+**Option 2**: Clone the repo
 
-__Option 2__: Clone the repo
 1. Clone this repo:
 
 ```bash
@@ -69,5 +69,8 @@ Full documentation can be found at: https://github.com/pantheon-systems/decouple
 - examples/pagination - an example that sources paged data from JSON:API and paginates it client side.
 
 ## Customizing the Starter
+
+The `pages/recipes` directory can be safely removed if you are using a Drupal instance that does not
+source the Umami demo data
 
 For a guide on creating your first Next Drupal customization, see [Your First Drupal Customization](https://github.com/pantheon-systems/decoupled-kit-js/blob/canary/web/docs/Frontend%20Starters/Next%20Drupal/your-first-customization.md)

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -10,6 +10,8 @@ import Link from "next/link";
 import Image from "next/image";
 import Layout from "../../components/layout";
 
+// This file can safely be removed if the Drupal
+// instance is not sourcing Umami data
 export default function Recipe({ recipe, hrefLang }) {
   const imgSrc = recipe?.field_media_image?.field_media_image?.uri?.url || "";
 

--- a/starters/next-drupal-starter/pages/recipes/index.js
+++ b/starters/next-drupal-starter/pages/recipes/index.js
@@ -9,6 +9,8 @@ import Link from "next/link";
 import Image from "next/image";
 import Layout from "../../components/layout";
 
+// This file can safely be removed if the Drupal
+// instance is not sourcing Umami data
 export default function Recipes({ recipes, hrefLang }) {
   function RecipesList() {
     return (


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Added comments and some documentation regarding the safe removal of `pages/recipes` if the Drupal backend is not sourcing Umami data

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
`next-drupal-starter`

## How have the changes been tested?
n/a

## Additional information
<!--- Add any other context about the feature or fix here. --->
The work to prevent builds from failing if there is no recipe data was done in DB-2113

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!