### PR TITLE
DB-3002: Clear stored params to prevent failed buils

### DIFF
--- a/starters/next-drupal-starter/components/grid.js
+++ b/starters/next-drupal-starter/components/grid.js
@@ -26,13 +26,11 @@ export const withGrid = (Component) => {
               return <Component key={i} content={content} {...props} />;
             })}
           </Grid>
-        ) : (
-          props.contentType ? (
-            <h2 className="text-xl text-center mt-14">
-              No {props.contentType} found 🏜
-            </h2>
-          ) : null
-        )}
+        ) : props.contentType ? (
+          <h2 className="text-xl text-center mt-14">
+            No {props.contentType} found 🏜
+          </h2>
+        ) : null}
       </>
     );
   };
@@ -42,7 +40,7 @@ export const withGrid = (Component) => {
 
 // For use with withGrid
 export const ArticleGridItem = ({ content: article, multiLanguage }) => {
-  const imgSrc = article.field_media_image.field_media_image.uri.url || "";
+  const imgSrc = article?.field_media_image?.field_media_image?.uri?.url || "";
   return (
     <Link
       passHref
@@ -80,7 +78,7 @@ export const ArticleGridItem = ({ content: article, multiLanguage }) => {
 
 // For use with withGrid
 export const RecipeGridItem = ({ content: recipe, multiLanguage }) => {
-  const imgSrc = recipe.field_media_image.field_media_image.uri.url || "";
+  const imgSrc = recipe?.field_media_image?.field_media_image?.uri?.url || "";
   return (
     <Link
       passHref
@@ -110,9 +108,11 @@ export const RecipeGridItem = ({ content: recipe, multiLanguage }) => {
           <h2 className="my-4 mx-6 text-xl leading-7 font-semibold text-gray-900">
             {recipe.title} &rarr;
           </h2>
-          <span className="text-right pb-2 pr-3 text-sm text-slate-400">
-            {recipe.field_recipe_category[0].name}
-          </span>
+          {recipe?.field_recipe_category?.length > 0 ? (
+            <span className="text-right pb-2 pr-3 text-sm text-slate-400">
+              {recipe?.field_recipe_category[0].name}
+            </span>
+          ) : null}
         </div>
       </a>
     </Link>

--- a/starters/next-drupal-starter/pages/articles/[...slug].js
+++ b/starters/next-drupal-starter/pages/articles/[...slug].js
@@ -100,7 +100,7 @@ export async function getStaticProps(context) {
       resourceVersion: `id:${context.previewData.resourceVersionId}`,
     });
   }
-
+  store.params.clear();
   store.params.addInclude(["field_media_image.field_media_image"]);
   // If preview mode, get the preview data from the store, other wise fetch from the api.
   const article = await store.getObjectByPath({
@@ -126,6 +126,8 @@ export async function getStaticProps(context) {
         }
       `,
   });
+
+  store.params.clear();
 
   const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
   // Load all the paths for the current article.

--- a/starters/next-drupal-starter/pages/articles/index.js
+++ b/starters/next-drupal-starter/pages/articles/index.js
@@ -60,38 +60,13 @@ export async function getServerSideProps(context) {
       objectName: "node--article",
       res: context.res,
     });
+    store.params.clear();
 
     if (!articles) {
       throw new Error(
         "No articles returned. Make sure the objectName and store.params are valid!"
       );
     }
-
-    // The calls below are unnecessary for rendering the page, but demonstrates
-    // both that surrogate keys are de-duped when added to the response, and also
-    // that they are bubbled up for GraphQL link queries.
-
-    // A duplicate resource to ensure that keys are de-duped.
-    await store.getObject({
-      objectName: "node--article",
-      id: articles[0].id,
-      query: `{
-        id
-        title
-      }`,
-      res: context.res,
-    });
-    store.params.clear();
-
-    // A new resource to ensure that keys are bubbled up.
-    await store.getObject({
-      objectName: "node--page",
-      query: `{
-        id
-        title
-      }`,
-      res: context.res,
-    });
 
     return {
       props: {

--- a/starters/next-drupal-starter/pages/pages/[...alias].js
+++ b/starters/next-drupal-starter/pages/pages/[...alias].js
@@ -8,9 +8,6 @@ import {
 import Link from "next/link";
 import Layout from "../../components/layout";
 
-const drupalUrl = process.env.backendUrl;
-
-// TODO - Much of this is duplicated in the article/[id].js file. Abstract this out into modules and components.
 export default function PageTemplate({ page, hrefLang }) {
   return (
     <Layout>
@@ -63,7 +60,6 @@ export async function getStaticPaths(context) {
       return { params: { alias: [alias] }, locale: locale };
     });
   });
-
   // Resolve all promises returned as part of pathsByLocale.
   const paths = await Promise.all(pathsByLocale).then((values) => {
     // Flatten the array of arrays into a single array.

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -173,6 +173,7 @@ export async function getStaticProps(context) {
         locale,
         globalDrupalStateStores
       );
+      storeByLocales.params.clear();
       const { path } = await storeByLocales.getObject({
         objectName: "node--recipe",
         id: recipe.id,

--- a/starters/next-drupal-starter/pages/recipes/index.js
+++ b/starters/next-drupal-starter/pages/recipes/index.js
@@ -69,6 +69,7 @@ export async function getStaticProps(context) {
         path
       }`,
     });
+    store.params.clear();
 
     return {
       props: {


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Clear params after each DrupalState call to ensure subsequent calls are not polluted with unusable query params.
- Removed some examples that showed surrogate keys are deduped

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
next-drupal-starter

## How have the changes been tested?
Tested locally - site now builds consistently

## Additional information
<!--- Add any other context about the feature or fix here. --->
Once we have a better solution for managing params in DrupalState, this should be revisited and cleaned up.

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!