### PR TITLE
DB-2818: Fix script path and permissions

### DIFF
--- a/.github/scripts/update-lockfiles.sh
+++ b/.github/scripts/update-lockfiles.sh
@@ -8,4 +8,3 @@ for dir in ./starters/*
     npm i --package-lock-only
     cd ../../
   done
-  

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -32,10 +32,12 @@ jobs:
         run: pnpm config set store-dir $PNPM_CACHE_FOLDER
       - name: install dependencies
         run: pnpm install
+      - name: make script runnable
+      - run: chmod +x ".github/scripts/update-lockfiles.sh"
       - name: create and publish versions
         uses: changesets/action@v1
         with:
-          version: ./update-lockfiles.sh
+          version: .github/scripts/update-lockfiles.sh
           commit: "Update versions"
           title: "Update versions"
           publish: pnpm ci:publish


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Fix the update-lockfiles permissions and path so it will run properly in GitHub Actions 🤞 

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
decoupled-kit

## How have the changes been tested?


## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!