### PR TITLE
DB-2864: Added additional doc for git hosts or CI services example flags.

### DIFF
--- a/web/docs/Backend Starters/Decoupled Drupal/creating-new-project.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/creating-new-project.md
@@ -52,5 +52,8 @@ For example, to use GitHub actions as your CI service, you could add the followi
 `--ci=githubactions`
 
 Note: if using Github Actions, your token should have the "workflow" scope.
+Another example, to use Gitlab as your git host service & Gitlab CI/CD as your CI service, you could add the following additional flag to your `terminus build:project:create` command:
+
+`--git=gitlab --ci=gitlab-pipelines`
 
 For more information, consult the [available services section of the build tools documentation](https://github.com/pantheon-systems/terminus-build-tools-plugin#available-services)

--- a/web/docs/Backend Starters/Decoupled Drupal/creating-new-project.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/creating-new-project.md
@@ -51,9 +51,8 @@ For example, to use GitHub actions as your CI service, you could add the followi
 
 `--ci=githubactions`
 
-Note: if using Github Actions, your token should have the "workflow" scope.
-Another example, to use Gitlab as your git host service & Gitlab CI/CD as your CI service, you could add the following additional flag to your `terminus build:project:create` command:
+Other possible values are `circleci`, `gitlab-pipelines` and `bitbucket-pipelines`.
 
-`--git=gitlab --ci=gitlab-pipelines`
+Note: if using Github Actions, your token should have the "workflow" scope.
 
 For more information, consult the [available services section of the build tools documentation](https://github.com/pantheon-systems/terminus-build-tools-plugin#available-services)

--- a/web/docs/Backend Starters/Decoupled WordPress/creating-new-project.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/creating-new-project.md
@@ -39,4 +39,8 @@ For example, to use GitHub actions as your CI service, you could add the followi
 
 `--ci=githubactions`
 
+Another example, to use Gitlab as your git host service & Gitlab CI/CD as your CI service, you could add the following additional flag to your `terminus build:project:create` command:
+
+`--git=gitlab --ci=gitlab-pipelines`
+
 For more information, consult the [available services section of the build tools documentation](https://github.com/pantheon-systems/terminus-build-tools-plugin#available-services)

--- a/web/docs/Backend Starters/Decoupled WordPress/creating-new-project.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/creating-new-project.md
@@ -39,8 +39,8 @@ For example, to use GitHub actions as your CI service, you could add the followi
 
 `--ci=githubactions`
 
-Another example, to use Gitlab as your git host service & Gitlab CI/CD as your CI service, you could add the following additional flag to your `terminus build:project:create` command:
+Other possible values are `circleci`, `gitlab-pipelines` and `bitbucket-pipelines`.
 
-`--git=gitlab --ci=gitlab-pipelines`
+Note: if using Github Actions, your token should have the "workflow" scope.
 
 For more information, consult the [available services section of the build tools documentation](https://github.com/pantheon-systems/terminus-build-tools-plugin#available-services)

--- a/web/docs/Packages/wordpress-kit/classes/src_lib_ApolloClientFactory.default.md
+++ b/web/docs/Packages/wordpress-kit/classes/src_lib_ApolloClientFactory.default.md
@@ -15,14 +15,14 @@ custom_edit_url: null
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `uri` | `string` |
+| Name     | Type            |
+| :------- | :-------------- |
+| `uri`    | `string`        |
 | `cache?` | `InMemoryCache` |
 
 #### Defined in
 
-[src/lib/ApolloClientFactory.ts:15](https://github.com/backlineint/decoupled-kit-js/blob/c1e81350/packages/wordpress-kit/src/lib/ApolloClientFactory.ts#L15)
+src/lib/ApolloClientFactory.ts:15
 
 ## Properties
 
@@ -32,9 +32,9 @@ custom_edit_url: null
 
 #### Defined in
 
-[src/lib/ApolloClientFactory.ts:13](https://github.com/backlineint/decoupled-kit-js/blob/c1e81350/packages/wordpress-kit/src/lib/ApolloClientFactory.ts#L13)
+src/lib/ApolloClientFactory.ts:13
 
-___
+---
 
 ### link
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[src/lib/ApolloClientFactory.ts:12](https://github.com/backlineint/decoupled-kit-js/blob/c1e81350/packages/wordpress-kit/src/lib/ApolloClientFactory.ts#L12)
+src/lib/ApolloClientFactory.ts:12
 
 ## Methods
 
@@ -58,4 +58,4 @@ Creates an instance of ApolloClient using the specified uri and cache.
 
 #### Defined in
 
-[src/lib/ApolloClientFactory.ts:26](https://github.com/backlineint/decoupled-kit-js/blob/c1e81350/packages/wordpress-kit/src/lib/ApolloClientFactory.ts#L26)
+src/lib/ApolloClientFactory.ts:26

--- a/web/docs/Packages/wordpress-kit/classes/src_lib_ApolloClientFactory.default.md
+++ b/web/docs/Packages/wordpress-kit/classes/src_lib_ApolloClientFactory.default.md
@@ -15,14 +15,14 @@ custom_edit_url: null
 
 #### Parameters
 
-| Name     | Type            |
-| :------- | :-------------- |
-| `uri`    | `string`        |
+| Name | Type |
+| :------ | :------ |
+| `uri` | `string` |
 | `cache?` | `InMemoryCache` |
 
 #### Defined in
 
-src/lib/ApolloClientFactory.ts:15
+[src/lib/ApolloClientFactory.ts:15](https://github.com/backlineint/decoupled-kit-js/blob/c1e81350/packages/wordpress-kit/src/lib/ApolloClientFactory.ts#L15)
 
 ## Properties
 
@@ -32,9 +32,9 @@ src/lib/ApolloClientFactory.ts:15
 
 #### Defined in
 
-src/lib/ApolloClientFactory.ts:13
+[src/lib/ApolloClientFactory.ts:13](https://github.com/backlineint/decoupled-kit-js/blob/c1e81350/packages/wordpress-kit/src/lib/ApolloClientFactory.ts#L13)
 
----
+___
 
 ### link
 
@@ -42,7 +42,7 @@ src/lib/ApolloClientFactory.ts:13
 
 #### Defined in
 
-src/lib/ApolloClientFactory.ts:12
+[src/lib/ApolloClientFactory.ts:12](https://github.com/backlineint/decoupled-kit-js/blob/c1e81350/packages/wordpress-kit/src/lib/ApolloClientFactory.ts#L12)
 
 ## Methods
 
@@ -58,4 +58,4 @@ Creates an instance of ApolloClient using the specified uri and cache.
 
 #### Defined in
 
-src/lib/ApolloClientFactory.ts:26
+[src/lib/ApolloClientFactory.ts:26](https://github.com/backlineint/decoupled-kit-js/blob/c1e81350/packages/wordpress-kit/src/lib/ApolloClientFactory.ts#L26)


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Added additional doc for git hosts or CI services example flags commands.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
Docusaurus docs

## How have the changes been tested?


## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!