### PR TITLE
DB-2793: Add note and options to reduce concurrency for gatsby-source-wordpress

### DIFF
--- a/starters/gatsby-wordpress-starter/gatsby-config.js
+++ b/starters/gatsby-wordpress-starter/gatsby-config.js
@@ -38,6 +38,14 @@ module.exports = {
       options: {
         // the only required plugin option for WordPress is the GraphQL url.
         url,
+        // If your WordPress server is overloaded during a build,
+        // try the following settings to reduce concurrency.
+        // see https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/plugin-options.md#schemarequestconcurrency
+        // schema: {
+        //   perPage: 20, // default 100
+        //   requestConcurrency: 5, // default 15
+        //   previewRequestConcurrency: 2, // default 5
+        // },
       },
     },
 


### PR DESCRIPTION
Document how to reduce concurrency for gatsby-source-wordpress
in case the WordPress server is overloaded

 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Added a comment and commented out options for reducing concurrent requests made by gatsby-source-wordpress in case the WordPress server is being overloaded.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
gatsby-wordpress-starter

## How have the changes been tested?


## Additional information
<!--- Add any other context about the feature or fix here. --->
@backlineint Willing to add a proper doc to the documentation if needed, but I wasn't sure it was necessary here at this time.

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!