### PR TITLE
DB-2295: Create helper for getStaticPaths

### DIFF
--- a/.changeset/mighty-pianos-bow.md
+++ b/.changeset/mighty-pianos-bow.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+[next-drupal-starter] Added helper function to consolidate code from getStaticPaths

--- a/starters/next-drupal-starter/lib/getPaths.js
+++ b/starters/next-drupal-starter/lib/getPaths.js
@@ -40,15 +40,15 @@ export const getPaths = async (
 
       // map over the data fetch to extract the path name
       return data.map((datum) => {
-        const regex = new RegExp(`^\/${urlAliasPrefix}\/(.*)$`);
-        const match = datum.path.alias.match(regex);
-        let path;
-        if (match[1]) {
-          path = match[1];
-        }
-
+        // remove the url prefix and split the path to handle
+        // dynamic routes like /articles/my-article and /articles/featured/my-article
+        const regex = new RegExp(`/?${urlAliasPrefix}/?`);
+        const path = datum.path.alias?.replace(regex, "").split("/");
         // return the path object.
-        return { params: { [`${dynamicRouteName}`]: [path] }, locale: locale };
+        return {
+          params: { [`${dynamicRouteName}`]: path },
+          locale: locale,
+        };
       });
     } catch (error) {
       // if set to failGracefully, return null.

--- a/starters/next-drupal-starter/lib/getPaths.js
+++ b/starters/next-drupal-starter/lib/getPaths.js
@@ -1,0 +1,75 @@
+import { getCurrentLocaleStore } from "./drupalStateContext";
+/**
+ * @description Helper function to get the current path nedded for getStaticPaths
+ * @param {import('next').GetStaticPathsContext} context - Nextjs getStaticPaths context
+ * @param {import('@pantheon-systems/drupal-kit').DrupalState} globalDrupalStateStores - Drupal state stores from drupalStateContext.js. Can be auth'd stores or non auth'd stores.
+ * @param {string} node - The node to fetch from Drupal. This will be passed to DrupalState.getObject as the objectName.
+ * @param {string} dynamicRouteName - The name of the dynamic route. For example, if using getPath in /pages/articles/[slug] then dynamicRouteName would be "slug".
+ * @param {string} urlAliasPrefix - The prefix of the path alias set in Drupal.
+ * For example, if the alias for articles are prefixed with "/articles" then urlAliasPrefix would be "articles".
+ * @param {boolean} failGracefully - If true, return an empty array which will not render any paths during the build. This is useful when using the fallback option in getStaticPaths.
+ * @see https://nextjs.org/docs/api-reference/data-fetching/get-static-paths for more information on the fallback option.
+ * @returns {Promise<{paths: {params: {dynamicRouteName: string[]}, locale: string}[]}>} an array of paths to return from getStaticPaths.
+ */
+export const getPaths = async (
+  context,
+  globalDrupalStateStores,
+  node,
+  dynamicRouteName,
+  urlAliasPrefix,
+  failGracefully = false
+) => {
+  // Get paths for each locale.
+  const pathsByLocale = context?.locales.map(async (locale) => {
+    const store = getCurrentLocaleStore(locale, globalDrupalStateStores);
+    store.params.clear();
+
+    try {
+      // fetch the node from Drupal
+      const data = await store.getObject({
+        objectName: node,
+        query: `
+            {
+              id
+              path {
+                alias
+              }
+            }
+          `,
+      });
+
+      // map over the data fetch to extract the path name
+      return data.map((datum) => {
+        const regex = new RegExp(`^\/${urlAliasPrefix}\/(.*)$`);
+        const match = datum.path.alias.match(regex);
+        let path;
+        if (match[1]) {
+          path = match[1];
+        }
+
+        // return the path object.
+        return { params: { [`${dynamicRouteName}`]: [path] }, locale: locale };
+      });
+    } catch (error) {
+      // if set to failGracefully, return null.
+      if (failGracefully) {
+        return null;
+      } else {
+        throw error;
+      }
+    }
+  });
+
+  // Resolve all promises returned as part of pathsByLocale.
+  let paths = await Promise.all(pathsByLocale).then((values) => {
+    // Flatten the array of arrays into a single array.
+    return [].concat(...values);
+  });
+
+  if (failGracefully && paths[0] === null) {
+    // clear paths to fail getStaticPaths gracefully
+    paths = [];
+  }
+
+  return paths;
+};

--- a/starters/next-drupal-starter/pages/articles/[...slug].js
+++ b/starters/next-drupal-starter/pages/articles/[...slug].js
@@ -53,7 +53,10 @@ export async function getStaticProps(context) {
     context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores
   );
 
-  const slug = `/articles/${context.params.slug[0]}`;
+  // handle nested slugs like /article/featured
+  const slug = `/articles${context.params.slug
+    .map((segment) => `/${segment}`)
+    .join("")}`;
 
   store.params.clear();
   // if preview, use preview endpoint and add to store.

--- a/starters/next-drupal-starter/pages/articles/[...slug].js
+++ b/starters/next-drupal-starter/pages/articles/[...slug].js
@@ -1,9 +1,11 @@
 import { NextSeo } from "next-seo";
 import { isMultiLanguage } from "../../lib/isMultiLanguage";
 import { getPreview } from "../../lib/getPreview";
+import { getPaths } from "../../lib/getPaths";
 import {
   getCurrentLocaleStore,
   globalDrupalStateAuthStores,
+  globalDrupalStateStores,
 } from "../../lib/drupalStateContext";
 
 import Article from "../../components/article.js";
@@ -23,50 +25,33 @@ export default function ArticleTemplate({ title, body, imgSrc, hrefLang }) {
 }
 
 export async function getStaticPaths(context) {
-  // TODO - locale increases the complexity enough here that creating a usePaths
-  // hook would be a good idea.
-  // Get paths for each locale.
-  const pathsByLocale = context.locales.map(async (locale) => {
-    const store = getCurrentLocaleStore(locale, globalDrupalStateAuthStores);
+  try {
+    const paths = await getPaths(
+      context,
+      globalDrupalStateStores,
+      "node--article",
+      "slug",
+      "articles"
+    );
 
-    const articles = await store.getObject({
-      objectName: "node--article",
-      query: `
-          {
-            id
-            path {
-              alias
-            }
-          }
-        `,
-    });
-    return articles.map((article) => {
-      // matches everything after /articles/
-      const match = article.path.alias.match(/^\/articles\/(.*)$/);
-      const slug = match[1];
-
-      return { params: { slug: [slug] }, locale: locale };
-    });
-  });
-
-  // Resolve all promises returned as part of pathsByLocale.
-  const paths = await Promise.all(pathsByLocale).then((values) => {
-    // Flatten the array of arrays into a single array.
-    return [].concat(...values);
-  });
-
-  return {
-    paths,
-    fallback: false,
-  };
+    return {
+      paths,
+      fallback: false,
+    };
+  } catch (error) {
+    console.error("Failed to fetch paths for articles:", error);
+  }
 }
 
 export async function getStaticProps(context) {
   const { locales, locale } = context;
   const multiLanguage = isMultiLanguage(locales);
   const lang = context.preview ? context.previewData.previewLang : locale;
-  
-  const store = getCurrentLocaleStore(lang, globalDrupalStateAuthStores);
+
+  const store = getCurrentLocaleStore(
+    lang,
+    context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores
+  );
 
   const slug = `/articles/${context.params.slug[0]}`;
 
@@ -106,7 +91,7 @@ export async function getStaticProps(context) {
   const paths = locales.map(async (locale) => {
     const localeStore = getCurrentLocaleStore(
       locale,
-      globalDrupalStateAuthStores
+      context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores
     );
     const { path } = await localeStore.getObject({
       objectName: "node--article",
@@ -130,7 +115,7 @@ export async function getStaticProps(context) {
     props: {
       title: article.title,
       body: article.body.value,
-      imgSrc: article.field_media_image.field_media_image.uri.url,
+      imgSrc: article.field_media_image?.field_media_image?.uri?.url || "",
       hrefLang,
       revalidate: 60,
     },

--- a/starters/next-drupal-starter/pages/articles/[...slug].js
+++ b/starters/next-drupal-starter/pages/articles/[...slug].js
@@ -119,7 +119,7 @@ export async function getStaticProps(context) {
       body: article.body.value,
       imgSrc: article.field_media_image?.field_media_image?.uri?.url || "",
       hrefLang,
-      revalidate: 60,
     },
+    revalidate: 60,
   };
 }

--- a/starters/next-drupal-starter/pages/examples/auth-api.js
+++ b/starters/next-drupal-starter/pages/examples/auth-api.js
@@ -64,8 +64,8 @@ export async function getStaticProps({ locale }) {
     return {
       props: {
         articles,
-        revalidate: 60,
       },
+      revalidate: 60,
     };
   } catch (error) {
     process.env.DEBUG_MODE &&

--- a/starters/next-drupal-starter/pages/examples/pagination/[[...page]].js
+++ b/starters/next-drupal-starter/pages/examples/pagination/[[...page]].js
@@ -118,7 +118,7 @@ export async function getStaticProps() {
   return {
     props: {
       data,
-      revalidate: 60,
     },
+    revalidate: 60,
   };
 }

--- a/starters/next-drupal-starter/pages/pages/[...alias].js
+++ b/starters/next-drupal-starter/pages/pages/[...alias].js
@@ -62,7 +62,10 @@ export async function getStaticProps(context) {
     context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores
   );
 
-  const alias = `/pages/${context.params.alias[0]}`;
+  // handle nested alias like /pages/featured
+  const alias = `/pages${context.params.alias
+    .map((segment) => `/${segment}`)
+    .join("")}`;
 
   store.params.clear();
   context.preview && (await getPreview(context, "node--page"));

--- a/starters/next-drupal-starter/pages/pages/index.js
+++ b/starters/next-drupal-starter/pages/pages/index.js
@@ -24,7 +24,7 @@ export default function PageListTemplate({ hrefLang, pages, multiLanguage }) {
             pages?.map(({ id, title, body, path }) => (
               <li className="prose justify-items-start" key={id}>
                 <h2>{title}</h2>
-                <div dangerouslySetInnerHTML={{ __html: body.summary }} />
+                <div dangerouslySetInnerHTML={{ __html: body?.summary }} />
                 <Link
                   passHref
                   href={`${multiLanguage ? `/${path.langcode}` : ""}${

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -176,8 +176,8 @@ export async function getStaticProps(context) {
       props: {
         recipe,
         hrefLang,
-        revalidate: 60,
       },
+      revalidate: 60,
     };
   } catch (error) {
     console.error("Unable to fetch recipe: ", error);

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -94,7 +94,7 @@ export async function getStaticPaths(context) {
       fallback: false,
     };
   } catch (error) {
-    console.error('Failed to fetch paths for recipes:' , error);
+    console.error("Failed to fetch paths for recipes:", error);
   }
 }
 
@@ -107,7 +107,10 @@ export async function getStaticProps(context) {
     context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores
   );
 
-  const slug = `/recipes/${context.params.slug[0]}`;
+  // handle nested slugs like /recipes/featured
+  const slug = `/recipes${context.params.slug
+    .map((segment) => `/${segment}`)
+    .join("")}`;
 
   // clear params to prevent duplicates
   store.params.clear();
@@ -137,7 +140,7 @@ export async function getStaticProps(context) {
         }
       }`,
       // if preview is true, force a fetch to Drupal
-      refresh: context.preview
+      refresh: context.preview,
     });
 
     store.params.clear();

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -1,11 +1,13 @@
 import { NextSeo } from "next-seo";
 import { IMAGE_URL } from "../../lib/constants.js";
+import { isMultiLanguage } from "../../lib/isMultiLanguage";
+import { getPreview } from "../../lib/getPreview";
+import { getPaths } from "../../lib/getPaths";
 import {
   getCurrentLocaleStore,
   globalDrupalStateAuthStores,
+  globalDrupalStateStores,
 } from "../../lib/drupalStateContext.js";
-import { isMultiLanguage } from "../../lib/isMultiLanguage";
-import { getPreview } from "../../lib/getPreview";
 import Link from "next/link";
 import Image from "next/image";
 import Layout from "../../components/layout";
@@ -77,62 +79,33 @@ export default function RecipeTemplate({ recipe, hrefLang }) {
 }
 
 export async function getStaticPaths(context) {
-  const { locales } = context;
-  // TODO - locale increases the complexity enough here that creating a usePaths
-  // hook would be a good idea.
-  // Get paths for each locale.
-  const pathsByLocale = locales.map(async (locale) => {
-    const store = getCurrentLocaleStore(locale, globalDrupalStateAuthStores);
+  try {
+    const paths = await getPaths(
+      context,
+      globalDrupalStateStores,
+      "node--recipe",
+      "slug",
+      "recipes",
+      true // failGracefully
+    );
 
-    try {
-      const recipes = await store.getObject({
-        objectName: "node--recipe",
-        query: `
-          {
-            id
-            path {
-              alias
-            }
-          }
-        `,
-      });
-
-      return recipes.map((recipe) => {
-        const match = recipe.path.alias.match(/^\/recipes\/(.*)$/);
-        const slug = match[1];
-
-        return { params: { slug: [slug] }, locale: locale };
-      });
-    } catch (error) {
-      console.error("No recipes found: ", error);
-      return null;
-    }
-  });
-
-  // Resolve all promises returned as part of pathsByLocale.
-  let paths = await Promise.all(pathsByLocale).then((values) => {
-    // Flatten the array of arrays into a single array.
-    return [].concat(...values);
-  });
-
-  if (paths[0] === null) {
-    // clear paths so if there are no
-    // recipes, no pages will attempt
-    // to render at build time.
-    paths = [];
+    return {
+      paths,
+      fallback: false,
+    };
+  } catch (error) {
+    console.error('Failed to fetch paths for recipes:' , error);
   }
-
-  return {
-    paths,
-    fallback: false,
-  };
 }
 
 export async function getStaticProps(context) {
   const { locales, locale } = context;
   const multiLanguage = isMultiLanguage(locales);
   const lang = context.preview ? context.previewData.previewLang : locale;
-  const store = getCurrentLocaleStore(lang, globalDrupalStateAuthStores);
+  const store = getCurrentLocaleStore(
+    lang,
+    context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores
+  );
 
   const slug = `/recipes/${context.params.slug[0]}`;
 
@@ -176,7 +149,7 @@ export async function getStaticProps(context) {
     const paths = locales.map(async (locale) => {
       const storeByLocales = getCurrentLocaleStore(
         locale,
-        globalDrupalStateAuthStores
+        context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores
       );
       storeByLocales.params.clear();
       const { path } = await storeByLocales.getObject({

--- a/web/docs/Frontend Starters/Next Drupal/implementing-preview.md
+++ b/web/docs/Frontend Starters/Next Drupal/implementing-preview.md
@@ -59,7 +59,8 @@ export async function getStaticProps(context) {
   // returning the data to the component.
 
   return {
-    props: { article, revalidate: 60 },
+    props: { article },
+    revalidate: 60,
   };
 }
 ```


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Added a helper function to DRY up getStaticPaths
- Implemented the helper
- Small change to these routes to use the authStore if preview is true, otherwise use the non auth'd store. This should allow builds to succeed even if credentials are incorrect.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
next-drupal-starter

## How have the changes been tested?
tested builds locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!