### PR TITLE
DB-1020: Create canary site for next-drupal-starter

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -1,0 +1,54 @@
+name: "Split Canary Sites"
+
+on:
+  push:
+    branches:
+      - canary
+
+# split the starers to repos to be deployed on the platform
+# for easy QA testing
+jobs:
+  packages_split_canary:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # define package to repository map
+        include:
+          - local_path: "starters/next-drupal-starter"
+            split_repository: "next-drupal-starter-umami-canary"
+    steps:
+      - uses: actions/checkout@v2
+
+      # no tag
+      - if: "!startsWith(github.ref, 'refs/tags/')"
+        uses: "symplify/monorepo-split-github-action@2.1"
+        with:
+          # ↓ split <local_path> directory
+          package_directory: "${{ matrix.local_path }}"
+
+          # ↓ into https://github.com/org/split_repository repository
+          repository_organization: "pantheon-systems"
+          repository_name: "${{ matrix.split_repository }}"
+
+          # ↓ the user signed under the split commit
+          user_name: "brian-ci"
+          user_email: "brian.perry@pantheon.io"
+
+      # with tag
+      - if: "startsWith(github.ref, 'refs/tags/')"
+        uses: "symplify/monorepo-split-github-action@2.1"
+        with:
+          tag: ${GITHUB_REF#refs/tags/}
+
+          package_directory: "${{ matrix.local_path }}"
+
+          repository_organization: "pantheon-systems"
+          repository_name: "${{ matrix.split_repository }}"
+
+          # ↓ the user signed under the split commit
+          user_name: "brian-ci"
+          user_email: "brian.perry@pantheon.io"

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -22,30 +22,12 @@ jobs:
             split_repository: "next-drupal-starter-umami-canary"
     steps:
       - uses: actions/checkout@v2
-
-      # no tag
-      - if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: "symplify/monorepo-split-github-action@2.1"
+      - uses: "symplify/monorepo-split-github-action@2.1"
         with:
           # ↓ split <local_path> directory
           package_directory: "${{ matrix.local_path }}"
 
           # ↓ into https://github.com/org/split_repository repository
-          repository_organization: "pantheon-systems"
-          repository_name: "${{ matrix.split_repository }}"
-
-          # ↓ the user signed under the split commit
-          user_name: "brian-ci"
-          user_email: "brian.perry@pantheon.io"
-
-      # with tag
-      - if: "startsWith(github.ref, 'refs/tags/')"
-        uses: "symplify/monorepo-split-github-action@2.1"
-        with:
-          tag: ${GITHUB_REF#refs/tags/}
-
-          package_directory: "${{ matrix.local_path }}"
-
           repository_organization: "pantheon-systems"
           repository_name: "${{ matrix.split_repository }}"
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
GitHub Action workflow added that runs on pushes to the canary branch. This will mirror the starter for each push to canary so it will be available to QA on.

We could configure the workflow we already have and do some fancy logic to build the strategy matrix based on the branch, but I think this is more straightforward although perhaps bit clunkier.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
added a new workflow in `.github/workflows`

## How have the changes been tested?


## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!