### PR TITLE
DB-2109: Add a canary repo split for `gatsby-wordpress-starter`

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -20,6 +20,8 @@ jobs:
         include:
           - local_path: "starters/next-drupal-starter"
             split_repository: "next-drupal-starter-umami-canary"
+          - local_path: "starters/gatsby-wordpress-starter"
+            split_repository: "gatsby-wordpress-starter-default-canary"
     steps:
       - uses: actions/checkout@v2
       - uses: "symplify/monorepo-split-github-action@2.1"


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Add another canary repo split, this one for the `gatsby-wordpress-starter` using the default demo profile

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
decoupled-kit-js GitHub action

## How have the changes been tested?


## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!