### PR TITLE
DB-2241: Add canary split for next-drupal with default data

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -20,6 +20,8 @@ jobs:
         include:
           - local_path: "starters/next-drupal-starter"
             split_repository: "next-drupal-starter-umami-canary"
+          - local_path: "starters/next-drupal-starter"
+            split_repository: "next-drupal-starter-default-canary"
           - local_path: "starters/gatsby-wordpress-starter"
             split_repository: "gatsby-wordpress-starter-default-canary"
     steps:


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Adding another canary site, this time for the default Drupal install profile.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
decoupled-kit

## How have the changes been tested?


## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!