### PR TITLE
[next-drupal-starter] Minor bugfixes

### DIFF
--- a/starters/next-drupal-starter/components/grid.js
+++ b/starters/next-drupal-starter/components/grid.js
@@ -17,7 +17,7 @@ export const Grid = ({ cols = "3", children }) => {
 
 // a Higher Order Component to use Grid
 export const withGrid = (Component) => {
-  const GridedComponent = ({ data }, ...props) => {
+  const GridedComponent = ({ data, ...props }) => {
     return (
       <>
         {data ? (
@@ -39,12 +39,16 @@ export const withGrid = (Component) => {
 };
 
 // For use with withGrid
-export const ArticleGridItem = ({ content: article, multiLanguage }) => {
+export const ArticleGridItem = ({
+  content: article,
+  multiLanguage,
+  locale,
+}) => {
   const imgSrc = article?.field_media_image?.field_media_image?.uri?.url || "";
   return (
     <Link
       passHref
-      href={`${multiLanguage ? `/${article.path.langcode}` : ""}${
+      href={`${multiLanguage ? `/${article.path.langcode || locale}` : ""}${
         article.path.alias
       }`}
     >
@@ -77,12 +81,12 @@ export const ArticleGridItem = ({ content: article, multiLanguage }) => {
 };
 
 // For use with withGrid
-export const RecipeGridItem = ({ content: recipe, multiLanguage }) => {
+export const RecipeGridItem = ({ content: recipe, multiLanguage, locale }) => {
   const imgSrc = recipe?.field_media_image?.field_media_image?.uri?.url || "";
   return (
     <Link
       passHref
-      href={`${multiLanguage ? `/${recipe.path.langcode}` : ""}${
+      href={`${multiLanguage ? `/${recipe.path.langcode || locale}` : ""}${
         recipe.path.alias
       }`}
     >

--- a/starters/next-drupal-starter/components/paginator.js
+++ b/starters/next-drupal-starter/components/paginator.js
@@ -19,7 +19,14 @@ import { useRouter } from "next/router";
  * @see {@link https://github.com/pantheon-systems/decoupled-kit-js/tree/canary/starters/next-drupal-starter/pages/examples/pagination/[[...page]].js} for an example implementation
  * @returns Component with data rendered by the passed in Component and page buttons
  */
-const Paginator = ({ data, itemsPerPage, breakpoints, Component, routing }) => {
+const Paginator = ({
+  data,
+  itemsPerPage,
+  breakpoints,
+  Component,
+  routing,
+  ...props
+}) => {
   // configurable breakpoints
   // This value will be the start of the seperator.
   const [breakStart, setBreakStart] = useState(breakpoints?.start || null);
@@ -215,7 +222,11 @@ const Paginator = ({ data, itemsPerPage, breakpoints, Component, routing }) => {
       </h3>
       <section>
         {/* Component passed in that will render the data */}
-        {Component ? <Component currentItems={currentItems} /> : <RenderData />}
+        {Component ? (
+          <Component currentItems={currentItems} {...props} />
+        ) : (
+          <RenderData />
+        )}
       </section>
       <div className="sticky lg:bottom-12 bottom-4">
         <RenderButtons />

--- a/starters/next-drupal-starter/lib/isMultiLanguage.js
+++ b/starters/next-drupal-starter/lib/isMultiLanguage.js
@@ -1,7 +1,5 @@
 /**
- * @param {import('next').GetServerSidePropsContext.locales |
- *  import('next').GetStaticPathsContext.locales |
- *  import('next').GetStaticPropsContext.locales} locales from Nextjs context
+ * @param {import('next').GetServerSidePropsContext.locales | import('next').GetStaticPathsContext.locales | import('next').GetStaticPropsContext.locales | import('next').NextRouter.locales} locales - from Nextjs context
  * @returns {boolean} true if a site has multiple languages configured, otherwise false.
  */
 export const isMultiLanguage = (locales) => (locales.length > 1 ? true : false);

--- a/starters/next-drupal-starter/pages/articles/index.js
+++ b/starters/next-drupal-starter/pages/articles/index.js
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 import { isMultiLanguage } from "../../lib/isMultiLanguage.js";
 import {
@@ -15,6 +16,7 @@ export default function SSRArticlesListTemplate({
   hrefLang,
   multiLanguage,
 }) {
+  const { locale } = useRouter();
   const ArticleGrid = withGrid(ArticleGridItem);
   return (
     <Layout footerMenu={footerMenu}>
@@ -29,6 +31,7 @@ export default function SSRArticlesListTemplate({
           data={articles}
           contentType="articles"
           multiLanguage={multiLanguage}
+          locale={locale}
         />
       </section>
     </Layout>
@@ -38,7 +41,7 @@ export default function SSRArticlesListTemplate({
 export async function getServerSideProps(context) {
   try {
     const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
-    const { locales } = context;
+    const { locale, locales } = contest;
     // if there is more than one language in context.locales,
     // assume multilanguage is enabled.
     const multiLanguage = isMultiLanguage(locales);
@@ -49,10 +52,7 @@ export async function getServerSideProps(context) {
       };
     });
 
-    const store = getCurrentLocaleStore(
-      context.locale,
-      globalDrupalStateStores
-    );
+    const store = getCurrentLocaleStore(locale, globalDrupalStateStores);
 
     store.params.clear();
     store.params.addInclude(["field_media_image.field_media_image"]);

--- a/starters/next-drupal-starter/pages/pages/index.js
+++ b/starters/next-drupal-starter/pages/pages/index.js
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 import { isMultiLanguage } from "../../lib/isMultiLanguage.js";
 import {
@@ -15,6 +16,7 @@ export default function PageListTemplate({
   footerMenu,
   multiLanguage,
 }) {
+  const { locale } = useRouter();
   return (
     <Layout footerMenu={footerMenu}>
       <NextSeo
@@ -32,7 +34,7 @@ export default function PageListTemplate({
                 <div dangerouslySetInnerHTML={{ __html: body?.summary }} />
                 <Link
                   passHref
-                  href={`${multiLanguage ? `/${hrefLang?.langcode}` : ""}${
+                  href={`${multiLanguage ? `/${path.langcode || locale}` : ""}${
                     path.alias
                   }`}
                 >

--- a/starters/next-drupal-starter/pages/recipes/index.js
+++ b/starters/next-drupal-starter/pages/recipes/index.js
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 import { isMultiLanguage } from "../../lib/isMultiLanguage";
 import {
@@ -17,6 +18,7 @@ export default function RecipeListTemplate({
   hrefLang,
   multiLanguage,
 }) {
+  const { locale } = useRouter();
   const RecipeGrid = withGrid(RecipeGridItem);
 
   return (
@@ -32,6 +34,7 @@ export default function RecipeListTemplate({
           data={recipes}
           contentType="recipes"
           multiLanguage={multiLanguage}
+          locale={locale}
         />
       </section>
     </Layout>


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Grid was not passing props down to the child component properly
- More robust handling of langcode in hrefs for multilang sites
  - In some cases the langcode could be undefined, so fall back to locale from useRouter. Should we just default to the locale from router?

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
next-drupal-starter

## How have the changes been tested?
Tested locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!