### PR TITLE
DB-2278: Fix regressions with 'page' paths

### DIFF
--- a/.changeset/dull-experts-provide.md
+++ b/.changeset/dull-experts-provide.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+[next-drupal-starter] Bugfixes to page path

--- a/starters/next-drupal-starter/lib/getPaths.js
+++ b/starters/next-drupal-starter/lib/getPaths.js
@@ -42,7 +42,8 @@ export const getPaths = async (
       return data.map((datum) => {
         // remove the url prefix and split the path to handle
         // dynamic routes like /articles/my-article and /articles/featured/my-article
-        const regex = new RegExp(`/?${urlAliasPrefix}/?`);
+        // will also work for content that is not prefixed
+        const regex = new RegExp(`/?(${urlAliasPrefix})?/?`);
         const path = datum.path.alias?.replace(regex, "").split("/");
         // return the path object.
         return {

--- a/starters/next-drupal-starter/pages/pages/[...alias].js
+++ b/starters/next-drupal-starter/pages/pages/[...alias].js
@@ -41,7 +41,8 @@ export async function getStaticPaths(context) {
       globalDrupalStateStores,
       "node--page",
       "alias",
-      "pages"
+      // basic pages are not prefixed by default
+       "pages"
     );
 
     return {
@@ -63,7 +64,7 @@ export async function getStaticProps(context) {
   );
 
   // handle nested alias like /pages/featured
-  const alias = `/pages${context.params.alias
+  const alias = `${context.params.alias
     .map((segment) => `/${segment}`)
     .join("")}`;
 
@@ -72,6 +73,7 @@ export async function getStaticProps(context) {
 
   const page = await store.getObjectByPath({
     objectName: "node--page",
+    // note: pages are not prefixed by default.
     path: `${multiLanguage ? lang : ""}${alias}`,
     query: `
         {

--- a/starters/next-drupal-starter/pages/pages/index.js
+++ b/starters/next-drupal-starter/pages/pages/index.js
@@ -34,7 +34,7 @@ export default function PageListTemplate({
                 <div dangerouslySetInnerHTML={{ __html: body?.summary }} />
                 <Link
                   passHref
-                  href={`${multiLanguage ? `/${path.langcode || locale}` : ""}${
+                  href={`${multiLanguage ? `/${path?.langcode || locale}` : ""}${path.alias.includes('/pages') ? '' : '/pages'}${
                     path.alias
                   }`}
                 >

--- a/starters/next-drupal-starter/pages/pages/index.js
+++ b/starters/next-drupal-starter/pages/pages/index.js
@@ -34,7 +34,7 @@ export default function PageListTemplate({
                 <div dangerouslySetInnerHTML={{ __html: body?.summary }} />
                 <Link
                   passHref
-                  href={`${multiLanguage ? `/${path?.langcode || locale}` : ""}/pages${
+                  href={`${multiLanguage ? `/${path?.langcode || locale}` : ""}${path.alias.includes('/pages') ? '' : '/pages'}${
                     path.alias
                   }`}
                 >

--- a/starters/next-drupal-starter/pages/pages/index.js
+++ b/starters/next-drupal-starter/pages/pages/index.js
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 import { isMultiLanguage } from "../../lib/isMultiLanguage.js";
 import {
@@ -15,6 +16,7 @@ export default function PageListTemplate({
   footerMenu,
   multiLanguage,
 }) {
+  const { locale } = useRouter();
   return (
     <Layout footerMenu={footerMenu}>
       <NextSeo
@@ -32,7 +34,7 @@ export default function PageListTemplate({
                 <div dangerouslySetInnerHTML={{ __html: body?.summary }} />
                 <Link
                   passHref
-                  href={`${multiLanguage ? `/${hrefLang?.langcode}` : ""}${
+                  href={`${multiLanguage ? `/${path?.langcode || locale}` : ""}/pages${
                     path.alias
                   }`}
                 >


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Make urlAliasPrefix optional in the regex in `getPaths` to handle content that is not prefixed like pages.
- Handle cases where some pages could be prefixed with `/pages` and some are not.
- Update the href locale in `pages/[...alias]` to fallback to the router locale if the `page.path.langcode` is undefined.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
next-drupal-starter

## How have the changes been tested?
Locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!