### PR TITLE
DB-2818: Remove linked packages in changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,16 +3,7 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [
-    [
-      "@pantheon-systems/drupal-kit",
-      "@pantheon-systems/next-drupal-starter"
-    ],
-    [
-      "@pantheon-systems/wordpress-kit",
-      "@pantheon-systems/gatsby-wordpress-starter"
-    ]
-  ],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.github/scripts/update-lockfiles.sh
+++ b/.github/scripts/update-lockfiles.sh
@@ -1,5 +1,4 @@
-# This script will update the package-lock.json files in the starter kits before
-# publishing
+# This script will update the package-lock.json files in the starter kits before publishing
 pnpm ci:version
 
 for dir in ./starters/*


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Remove linked packages from changesets so that new versions of the starters do not publish new versions of the npm packages.
Note: any releases which bump a starter and a package at the same time will still fail the sync script, however we shouldn't need the package-lock.json to be around for much longer anyway.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
decoupled-kit

## How have the changes been tested?
locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!