### PR TITLE
DB-2218: Update docs for setting env vars in the gatsby-wordpress-starter

### DIFF
--- a/web/docs/Frontend Starters/Gatsby Wordpress/setting-environment-variables.md
+++ b/web/docs/Frontend Starters/Gatsby Wordpress/setting-environment-variables.md
@@ -9,20 +9,11 @@ slug: "/Frontend Starters/Gatsby Wordpress/Setting Environment Variables"
 In order to fetch data from the WordPress instance, Gatsby needs to know the endpoint
 at build time. For local development, the starter kit uses [dotenv](https://www.npmjs.com/package/dotenv).
 
-When a new project is cloned down, a `.env.local` file should be created.
-In this file, update the WPGRAPHQL_URL with your WordPress GraphQL Endpoint.
+After creating a new project with the gatsby-wordpress-starter, create a `.env.local` file at the root of the project directory.
+In this file, add a WPGRAPHQL_URL key with your WordPress GraphQL Endpoint as the value.
 
 For example:
 
 ```
 WPGRAPHQL_URL=https://my-wordpress-site.pantheon.site/wp/graphql
 ```
-
-## Multi-Dev
-
-In the Pantheon Dashboard, link your CMS site to your decoupled site and you won't need
-to set any environment variables.
-
-
-If for some reason you are unable to link your CMS site through the dashboard,
-the `WPGRAPHQL_URL` can be set manually in the __Build__ section of the dashboard.


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Updated docs for env vars in the gatsby-wordpress-starter

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
docs

## How have the changes been tested?


## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!