### PR TITLE
DB-3168: Fix initial props

### DIFF
--- a/.changeset/eleven-jobs-care.md
+++ b/.changeset/eleven-jobs-care.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+[next-drupal-starter] Remove query from getPaths call to store.getObject to prevent subsequent calls from getting incorrect data from the store

--- a/starters/next-drupal-starter/lib/getPaths.js
+++ b/starters/next-drupal-starter/lib/getPaths.js
@@ -26,14 +26,6 @@ export const getPaths = async (
       // fetch the node from Drupal
       const data = await store.getObject({
         objectName: node,
-        query: `
-            {
-              id
-              path {
-                alias
-              }
-            }
-          `,
       });
 
       // map over the data fetch to extract the path name

--- a/starters/next-drupal-starter/pages/articles/[...slug].js
+++ b/starters/next-drupal-starter/pages/articles/[...slug].js
@@ -106,6 +106,8 @@ export async function getStaticProps(context) {
     const { path } = await localeStore.getObject({
       objectName: "node--article",
       id: article.id,
+    params: context.preview ? previewParams : params,
+
     });
     return path;
   });

--- a/starters/next-drupal-starter/pages/articles/index.js
+++ b/starters/next-drupal-starter/pages/articles/index.js
@@ -56,6 +56,21 @@ export async function getServerSideProps(context) {
 
     const articles = await store.getObject({
       objectName: "node--article",
+      query: `{
+        id
+        title
+        path {
+          alias
+          langcode
+        }
+        field_media_image {
+          field_media_image {
+            uri {
+              url
+            }
+          }
+        }
+      }`,
       res: context.res,
       params: "include=field_media_image.field_media_image",
     });
@@ -82,7 +97,6 @@ export async function getServerSideProps(context) {
     console.error("Unable to fetch data for article page: ", error);
     return {
       notFound: true,
-      revalidate: 5,
     };
   }
 }

--- a/starters/next-drupal-starter/pages/index.js
+++ b/starters/next-drupal-starter/pages/index.js
@@ -85,6 +85,21 @@ export async function getStaticProps(context) {
 
     const articles = await store.getObject({
       objectName: "node--article",
+      query: `{
+        id
+        title
+        path {
+          alias
+          langcode
+        }
+        field_media_image {
+          field_media_image {
+            uri {
+              url
+            }
+          }
+        }
+      }`,
       params: "include=field_media_image.field_media_image",
     });
 

--- a/starters/next-drupal-starter/pages/pages/[...alias].js
+++ b/starters/next-drupal-starter/pages/pages/[...alias].js
@@ -129,6 +129,7 @@ export async function getStaticProps(context) {
     const { path } = await storeByLocales.getObject({
       objectName: "node--page",
       id: page.id,
+      params: context.preview && previewParams,
     });
     return path;
   });

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -15,7 +15,7 @@ import Layout from "../../components/layout";
 // This file can safely be removed if the Drupal
 // instance is not sourcing Umami data
 export default function RecipeTemplate({ recipe, footerMenu, hrefLang }) {
-  const imgSrc = recipe?.field_media_image?.field_media_image?.uri?.url || "";
+  const imgSrc = recipe?.field_media_image?.field_media_image?.uri?.url;
 
   return (
     <Layout footerMenu={footerMenu}>
@@ -159,6 +159,7 @@ export async function getStaticProps(context) {
       const { path } = await storeByLocales.getObject({
         objectName: "node--recipe",
         id: recipe.id,
+        params: context.preview ? previewParams : params,
       });
       return path;
     });


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Remove the query from the `store.getObject` call in `getPaths` so that subsequent calls can fetch from Drupal instead of the store. This should fix the initial props missing on the infra.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
next-drupal-starter

## How have the changes been tested?
Locally and on the infra with a separate repo

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!