### PR TITLE
DB-3315: Fix preview revisions

### DIFF
--- a/.changeset/good-mugs-brake.md
+++ b/.changeset/good-mugs-brake.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+[next-drupal-starter] Fixed a bug with previewing revisions

--- a/starters/next-drupal-starter/lib/getPreview.js
+++ b/starters/next-drupal-starter/lib/getPreview.js
@@ -39,26 +39,31 @@ export async function getPreview(context, node, params) {
           console.log(
             `Adding resource version ID param ${context?.previewData?.resourceVersionId}...`
           );
+        if (params === undefined) {
+          params = "";
+        }
         const leadingChar = params ? "&" : "";
         params += `${leadingChar}resourceVersion=id:${context.previewData.resourceVersionId}`;
       }
 
       // Only fetch preview data if it is not a revision
       else {
-      const fetchedPreviewData = await fetchJsonapiEndpoint(
-        `${store.apiRoot}decoupled-preview/${context.previewData.key}${
-          params ? `?${params}` : ""
-        }`,
-        requestInit
-      );
+        const fetchedPreviewData = await fetchJsonapiEndpoint(
+          `${store.apiRoot}decoupled-preview/${context.previewData.key}${
+            params ? `?${params}` : ""
+          }`,
+          requestInit
+        );
 
-      if (fetchedPreviewData.errors) {
-        throw fetchedPreviewData?.errors.forEach(({ detail }) => detail);
-      }
-      const uuid = fetchedPreviewData.data.id;
+        if (fetchedPreviewData.errors) {
+          throw fetchedPreviewData?.errors.forEach(({ detail }) => detail);
+        }
+        const uuid = fetchedPreviewData.data.id;
 
-      // set the preview data in the store
-      store.setState({ [`${node}Resources`]: { [uuid]: fetchedPreviewData } });
+        // set the preview data in the store
+        store.setState({
+          [`${node}Resources`]: { [uuid]: fetchedPreviewData },
+        });
       }
     }
     return params;

--- a/starters/next-drupal-starter/lib/getPreview.js
+++ b/starters/next-drupal-starter/lib/getPreview.js
@@ -43,6 +43,8 @@ export async function getPreview(context, node, params) {
         params += `${leadingChar}resourceVersion=id:${context.previewData.resourceVersionId}`;
       }
 
+      // Only fetch preview data if it is not a revision
+      else {
       const fetchedPreviewData = await fetchJsonapiEndpoint(
         `${store.apiRoot}decoupled-preview/${context.previewData.key}${
           params ? `?${params}` : ""
@@ -57,6 +59,7 @@ export async function getPreview(context, node, params) {
 
       // set the preview data in the store
       store.setState({ [`${node}Resources`]: { [uuid]: fetchedPreviewData } });
+      }
     }
     return params;
   } catch (error) {

--- a/starters/next-drupal-starter/pages/articles/[...slug].js
+++ b/starters/next-drupal-starter/pages/articles/[...slug].js
@@ -87,8 +87,8 @@ export async function getStaticProps(context) {
           }
         }
       `,
-    // if preview is true, force a fetch to Drupal
-    refresh: context.preview,
+    // if previewing a revision, force a fetch to Drupal
+    refresh: context?.previewData?.resourceVersionId ? true : false,
     params: context.preview ? previewParams : params,
   });
 

--- a/starters/next-drupal-starter/pages/pages/[...alias].js
+++ b/starters/next-drupal-starter/pages/pages/[...alias].js
@@ -109,8 +109,8 @@ export async function getStaticProps(context) {
               }
             }
           `,
-      // if preview is true, force a fetch to Drupal
-      refresh: context.preview,
+      // if previewing a revision, force a fetch to Drupal
+      refresh: context?.previewData?.resourceVersionId ? true : false,
       params: context.preview && previewParams,
     });
   }

--- a/starters/next-drupal-starter/pages/pages/[...alias].js
+++ b/starters/next-drupal-starter/pages/pages/[...alias].js
@@ -88,8 +88,8 @@ export async function getStaticProps(context) {
             }
           }
         `,
-      // if preview is true, force a fetch to Drupal
-      refresh: context.preview,
+      // if previewing a revision, force a fetch to Drupal
+      refresh: context?.previewData?.resourceVersionId ? true : false,
       params: context.preview && previewParams,
     });
   } catch (error) {

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -136,8 +136,8 @@ export async function getStaticProps(context) {
           langcode
         }
       }`,
-      // if preview is true, force a fetch to Drupal
-      refresh: context.preview,
+      // if previewing a revision, force a fetch to Drupal
+      refresh: context?.previewData?.resourceVersionId ? true : false,
       params: context.preview ? previewParams : params,
     });
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- `getPreview` helper only fetches preview data if NOT preview a revision, as revisions do not use the `decoupled_preview/` endpoint.
- Use the `refresh` parameter to force fetch to Drupal when previewing a revision in `getStaticProps` for previewable content.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
next-drupal-starter

## How have the changes been tested?
Tested locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!