### PR TITLE
DB-2876: Use `req.query.objectName` in preview api route

### DIFF
--- a/.changeset/calm-mails-attack.md
+++ b/.changeset/calm-mails-attack.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+[next-drupal-starter] Use objectName from the req.query in /api/preview

--- a/.changeset/good-mugs-brake.md
+++ b/.changeset/good-mugs-brake.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+[next-drupal-starter] Fixed a bug with previewing revisions

--- a/starters/next-drupal-starter/lib/getPreview.js
+++ b/starters/next-drupal-starter/lib/getPreview.js
@@ -39,26 +39,31 @@ export async function getPreview(context, node, params) {
           console.log(
             `Adding resource version ID param ${context?.previewData?.resourceVersionId}...`
           );
+        if (params === undefined) {
+          params = "";
+        }
         const leadingChar = params ? "&" : "";
         params += `${leadingChar}resourceVersion=id:${context.previewData.resourceVersionId}`;
       }
 
       // Only fetch preview data if it is not a revision
       else {
-      const fetchedPreviewData = await fetchJsonapiEndpoint(
-        `${store.apiRoot}decoupled-preview/${context.previewData.key}${
-          params ? `?${params}` : ""
-        }`,
-        requestInit
-      );
+        const fetchedPreviewData = await fetchJsonapiEndpoint(
+          `${store.apiRoot}decoupled-preview/${context.previewData.key}${
+            params ? `?${params}` : ""
+          }`,
+          requestInit
+        );
 
-      if (fetchedPreviewData.errors) {
-        throw fetchedPreviewData?.errors.forEach(({ detail }) => detail);
-      }
-      const uuid = fetchedPreviewData.data.id;
+        if (fetchedPreviewData.errors) {
+          throw fetchedPreviewData?.errors.forEach(({ detail }) => detail);
+        }
+        const uuid = fetchedPreviewData.data.id;
 
-      // set the preview data in the store
-      store.setState({ [`${node}Resources`]: { [uuid]: fetchedPreviewData } });
+        // set the preview data in the store
+        store.setState({
+          [`${node}Resources`]: { [uuid]: fetchedPreviewData },
+        });
       }
     }
     return params;

--- a/starters/next-drupal-starter/lib/getPreview.js
+++ b/starters/next-drupal-starter/lib/getPreview.js
@@ -43,6 +43,8 @@ export async function getPreview(context, node, params) {
         params += `${leadingChar}resourceVersion=id:${context.previewData.resourceVersionId}`;
       }
 
+      // Only fetch preview data if it is not a revision
+      else {
       const fetchedPreviewData = await fetchJsonapiEndpoint(
         `${store.apiRoot}decoupled-preview/${context.previewData.key}${
           params ? `?${params}` : ""
@@ -57,6 +59,7 @@ export async function getPreview(context, node, params) {
 
       // set the preview data in the store
       store.setState({ [`${node}Resources`]: { [uuid]: fetchedPreviewData } });
+      }
     }
     return params;
   } catch (error) {

--- a/starters/next-drupal-starter/package-lock.json
+++ b/starters/next-drupal-starter/package-lock.json
@@ -8102,6 +8102,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.2.tgz",
+      "integrity": "sha512-JUnXB+2xfxqsAvhFLPJpU1NeyDsvJrKoOjpV7g3Dxbno2Riu4tDKn3kKF886yleAuD/1qNTUCpqubTvbbT2VoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -14034,6 +14049,12 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
       "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
       "requires": {}
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.2.tgz",
+      "integrity": "sha512-JUnXB+2xfxqsAvhFLPJpU1NeyDsvJrKoOjpV7g3Dxbno2Riu4tDKn3kKF886yleAuD/1qNTUCpqubTvbbT2VoA==",
+      "optional": true
     }
   }
 }

--- a/starters/next-drupal-starter/pages/api/preview.js
+++ b/starters/next-drupal-starter/pages/api/preview.js
@@ -13,25 +13,12 @@ const preview = async (req, res) => {
     const regex = new RegExp(`/${defaultLocale}/`);
     return defaultLocale ? regex.test(req.url) : true;
   });
-
-  // get the object name from the slug
-  const regex = new RegExp(
-    `^(?:/${store.defaultLocale}/|/)(?<objectName>.*)/.*$`
-  );
-
-  const matches = req.query.slug.match(regex);
-  let objectName = matches.groups.objectName.replace(/s$/, ""); // remove plural
-  // SERIOUS ASSUMPTIONS BEGIN HERE:
-  // objectName will match `en` if previewing a page like about-umami
-  // so the getObjectByPath and the redirect will fail.
-  // This is a temporary workaround:
-  objectName = objectName === store.defaultLocale ? "page" : objectName;
-
+  const objectName = req.query.objectName;
   // verify the content exists
   let content;
   try {
     content = await store.getObjectByPath({
-      objectName: `node--${objectName}`,
+      objectName: objectName,
       path: req.query.slug,
     });
   } catch (error) {
@@ -61,7 +48,7 @@ const preview = async (req, res) => {
 
   // Redirect to the path from the fetched content
   res.redirect(
-    objectName === "page"
+    objectName === "node--page"
       ? `/${content.path.langcode}/pages/${content.path.alias}`
       : content.path.alias
   );

--- a/starters/next-drupal-starter/pages/articles/[...slug].js
+++ b/starters/next-drupal-starter/pages/articles/[...slug].js
@@ -87,8 +87,8 @@ export async function getStaticProps(context) {
           }
         }
       `,
-    // if preview is true, force a fetch to Drupal
-    refresh: context.preview,
+    // if previewing a revision, force a fetch to Drupal
+    refresh: context?.previewData?.resourceVersionId ? true : false,
     params: context.preview ? previewParams : params,
   });
 

--- a/starters/next-drupal-starter/pages/pages/[...alias].js
+++ b/starters/next-drupal-starter/pages/pages/[...alias].js
@@ -109,8 +109,8 @@ export async function getStaticProps(context) {
               }
             }
           `,
-      // if preview is true, force a fetch to Drupal
-      refresh: context.preview,
+      // if previewing a revision, force a fetch to Drupal
+      refresh: context?.previewData?.resourceVersionId ? true : false,
       params: context.preview && previewParams,
     });
   }

--- a/starters/next-drupal-starter/pages/pages/[...alias].js
+++ b/starters/next-drupal-starter/pages/pages/[...alias].js
@@ -88,8 +88,8 @@ export async function getStaticProps(context) {
             }
           }
         `,
-      // if preview is true, force a fetch to Drupal
-      refresh: context.preview,
+      // if previewing a revision, force a fetch to Drupal
+      refresh: context?.previewData?.resourceVersionId ? true : false,
       params: context.preview && previewParams,
     });
   } catch (error) {

--- a/starters/next-drupal-starter/pages/recipes/[...slug].js
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].js
@@ -136,8 +136,8 @@ export async function getStaticProps(context) {
           langcode
         }
       }`,
-      // if preview is true, force a fetch to Drupal
-      refresh: context.preview,
+      // if previewing a revision, force a fetch to Drupal
+      refresh: context?.previewData?.resourceVersionId ? true : false,
       params: context.preview ? previewParams : params,
     });
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->
‼️ To be merged AFTER #168
## What changes were made?
Update the `/api/preview` route to use the objectName that is now provided in the `req.query`.
This allows us to remove some highly assumptive regex for getting the proper objectName.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
next-drupal-starter

## How have the changes been tested?
Tested preview from umami profile and default profile. Paths

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!