### PR TITLE
DB-3184: Enhanced Block Editor Support - Paragraph Block POC

### DIFF
--- a/.changeset/friendly-shoes-hear.md
+++ b/.changeset/friendly-shoes-hear.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/wordpress-kit": minor
+---
+
+Created a plugin for tailwind, that supports the block editor classes

--- a/.changeset/unlucky-bats-tickle.md
+++ b/.changeset/unlucky-bats-tickle.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-wordpress-starter": minor
+---
+
+Imported tailwind plugin from Wordpress-Kit

--- a/packages/wordpress-kit/index.ts
+++ b/packages/wordpress-kit/index.ts
@@ -2,4 +2,7 @@ import GraphqlClientFactory from './src/lib/GraphqlClientFactory';
 import tailwindcssPlugin from './src/lib/tailwindcssPlugin';
 import { gql } from 'graphql-request';
 
+import type { TailwindcssConfig } from './src/lib/tailwindcssPlugin';
+
 export { GraphqlClientFactory, gql, tailwindcssPlugin };
+export type { TailwindcssConfig };

--- a/packages/wordpress-kit/index.ts
+++ b/packages/wordpress-kit/index.ts
@@ -1,4 +1,5 @@
 import GraphqlClientFactory from './src/lib/GraphqlClientFactory';
+import tailwindcssPlugin from './src/lib/tailwindcssPlugin';
 import { gql } from 'graphql-request';
 
-export { GraphqlClientFactory, gql };
+export { GraphqlClientFactory, gql, tailwindcssPlugin };

--- a/packages/wordpress-kit/package.json
+++ b/packages/wordpress-kit/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "graphql-request": "^4.3.0"
+    "graphql-request": "^4.3.0",
+    "tailwindcss": "^3.1.6"
   }
 }

--- a/packages/wordpress-kit/package.json
+++ b/packages/wordpress-kit/package.json
@@ -50,7 +50,17 @@
   },
   "dependencies": {
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "graphql-request": "^4.3.0",
+    "graphql-request": "^4.3.0"
+  },
+  "devDependencies": {
     "tailwindcss": "^3.1.6"
+  },
+  "peerDependencies": {
+    "tailwindcss": "^3.1.6"
+  },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
   }
 }

--- a/packages/wordpress-kit/rollup.config.js
+++ b/packages/wordpress-kit/rollup.config.js
@@ -2,9 +2,10 @@ import typescript from '@rollup/plugin-typescript';
 
 const globals = {
   'graphql-request': 'graphqlRequest',
+  'tailwindcss/plugin': 'tailwindcssPlugin',
 };
 
-const external = ['graphql-request'];
+const external = ['graphql-request', 'tailwindcss/plugin'];
 
 export default [
   {

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
@@ -1,6 +1,161 @@
 import plugin from 'tailwindcss/plugin';
 
-const mergeToConfig = {
+import type { Config } from 'tailwindcss';
+
+type ColorConfig = {
+  primary?: string;
+  secondary?: string;
+  darkGray?: string;
+  lightGray?: string;
+  white?: string;
+};
+
+type PaddingConfig = {
+  backgroundX?: string;
+  backgroundY?: string;
+};
+
+type FontSizeConfig = {
+  '7xl'?: string;
+  '4xl'?: string;
+  xl?: string;
+  sm?: string;
+};
+
+type WordpressMapConfig = {
+  theme?: {
+    extend?: {
+      /**
+       * The colors mapped from the code editor in the WordPress admin.
+       * @example
+       * ```
+       *primary: '#0070f3',
+       *secondary: '#ff4081',
+       *darkGray: '#333',
+       *lightGray: '#fafafa',
+       *white: '#fff',
+       * ```
+       *
+       *@default
+       * ```
+       *primary: value of "blue-500" or '#0073a8',
+       *secondary: value of "gray-500" or '#005075',
+       *darkGray: value of "neutral-800" or '#333333',
+       *lightGray: value of "neutral-500" or '#666666',
+       *white: value of "white" or '#ffffff',
+       * ```
+       */
+      colors?: ColorConfig;
+      /**
+       * Padding applied when the block has a background color.
+       * @example
+       * ```
+       *backgroundX: '2rem',
+       *backgroundY: '1rem',
+       * ```
+       *
+       * @default
+       * ```
+       * backgroundX: value of p-5 or '1.25rem',
+       * backgroundY: value of p-9 or '2.35rem',
+       * ```
+       */
+      padding?: PaddingConfig;
+      /**
+       * The font size map for the code editor in the WordPress admin.
+       *
+       * ```
+       * huge: text-7xl
+       * large: text-4xl
+       * normal: text-xl
+       * small: text-sm
+       *```
+       *
+       * @example
+       * ```
+       *"7xl": 5rem;
+       *"4xl": 4rem;
+       *xl: 2rem;
+       *sm: 1rem;
+       * ```
+       *
+       * @default
+       * ```
+       * "7xl": '5rem',
+       * "4xl": '4rem',
+       * xl: '1.25rem',
+       * sm: '1rem',
+       */
+      fontSize?: FontSizeConfig;
+    };
+    /**
+     * The colors mapped from the code editor in the WordPress admin.
+     * @example
+     * ```
+     *primary: '#0070f3',
+     *secondary: '#ff4081',
+     *darkGray: '#333',
+     *lightGray: '#fafafa',
+     *white: '#fff',
+     * ```
+     *
+     *@default
+     * ```
+     *primary: value of "blue-500" or '#0073a8',
+     *secondary: value of "gray-500" or '#005075',
+     *darkGray: value of "neutral-800" or '#333333',
+     *lightGray: value of "neutral-500" or '#666666',
+     *white: value of "white" or '#ffffff',
+     * ```
+     */
+    colors?: ColorConfig;
+    /**
+     * Padding applied when the block has a background color.
+     * @example
+     * ```
+     *backgroundX: '2rem',
+     *backgroundY: '1rem',
+     * ```
+     *
+     * @default
+     * ```
+     * backgroundX: value of p-5 or '1.25rem',
+     * backgroundY: value of p-9 or '2.35rem',
+     * ```
+     */
+    padding?: PaddingConfig;
+    /**
+     * The font size map for the code editor in the WordPress admin.
+     *
+     * ```
+     * huge: text-7xl
+     * large: text-4xl
+     * normal: text-xl
+     * small: text-sm
+     *```
+     *
+     * @example
+     * ```
+     *"7xl": 5rem;
+     *"4xl": 4rem;
+     *xl: 2rem;
+     *sm: 1rem;
+     * ```
+     *
+     * @default
+     * ```
+     * "7xl": '5rem',
+     * "4xl": '4rem',
+     * xl: '1.25rem',
+     * sm: '1rem',
+     */
+    fontSize?: FontSizeConfig;
+  };
+};
+
+export type TailwindcssConfig = Config & WordpressMapConfig;
+
+const mergeToConfig: Config = {
   content: [],
   safelist: [
     '.has-primary-color',
@@ -25,7 +180,7 @@ const mergeToConfig = {
 };
 
 export default plugin(function ({ addUtilities, theme }) {
-  const fontSizeUtilties = {
+  const fontSizeUtilities = {
     '.has-huge-font-size': {
       fontSize: `${theme('fontSize.7xl', '5rem')} !important`,
     },
@@ -40,7 +195,7 @@ export default plugin(function ({ addUtilities, theme }) {
     },
   };
 
-  const colorUtilties = {
+  const colorUtilities = {
     '.has-primary-color': {
       color: theme('colors.primary') || theme('colors.blue.500') || '#0073a8',
     },
@@ -65,7 +220,7 @@ export default plugin(function ({ addUtilities, theme }) {
     theme('padding.5', '1.25em')
   )} ${theme('padding.backgroundY', theme('padding.9', '2.35em'))}`;
 
-  const backgroundUtilties = {
+  const backgroundUtilities = {
     '.has-background': {
       padding: backgroundPadding,
     },
@@ -90,7 +245,7 @@ export default plugin(function ({ addUtilities, theme }) {
     },
   };
 
-  const dropCapUtilties = {
+  const dropCapUtilities = {
     '.has-drop-cap': {
       '&:first-letter': {
         float: 'left',
@@ -105,9 +260,9 @@ export default plugin(function ({ addUtilities, theme }) {
   };
 
   addUtilities([
-    colorUtilties,
-    fontSizeUtilties,
-    backgroundUtilties,
-    dropCapUtilties,
+    colorUtilities,
+    fontSizeUtilities,
+    backgroundUtilities,
+    dropCapUtilities,
   ]);
 }, mergeToConfig);

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
@@ -1,0 +1,113 @@
+import plugin from 'tailwindcss/plugin';
+
+const mergeToConfig = {
+  content: [],
+  safelist: [
+    '.has-primary-color',
+    '.has-secondary-color',
+    '.has-dark-gray-color',
+    '.has-white-color',
+
+    '.has-background',
+    '.has-primary-background-color',
+    '.has-secondary-background-color',
+    '.has-dark-gray-background-color',
+    '.has-white-background-color',
+
+    '.has-huge-font-size',
+    '.has-large-font-size',
+    '.has-normal-font-size',
+    '.has-small-font-size',
+    '.has-light-gray-color',
+
+    '.has-drop-cap',
+  ],
+};
+
+export default plugin(function ({ addUtilities, theme }) {
+  const fontSizeUtilties = {
+    '.has-huge-font-size': {
+      fontSize: `${theme('fontSize.7xl', '5rem')} !important`,
+    },
+    '.has-large-font-size': {
+      fontSize: `${theme('fontSize.4xl', '4rem')} !important`,
+    },
+    '.has-normal-font-size': {
+      fontSize: `${theme('fontSize.xl', '1.25rem')} !important`,
+    },
+    '.has-small-font-size': {
+      fontSize: `${theme('fontSize.sm', '1rem')} !important`,
+    },
+  };
+
+  const colorUtilties = {
+    '.has-primary-color': {
+      color: theme('colors.primary') || theme('colors.blue.500') || '#0073a8',
+    },
+    '.has-secondary-color': {
+      color: theme('colors.secondary') || theme('colors.gray.500') || '#005075',
+    },
+    '.has-dark-gray-color': {
+      color:
+        theme('colors.darkGray') || theme('colors.neutral.800') || '#333333',
+    },
+    '.has-light-gray-color': {
+      color:
+        theme('colors.lightGray') || theme('colors.neutral.500') || '#666666',
+    },
+    '.has-white-color': {
+      color: theme('colors.white') || '#ffffff',
+    },
+  };
+
+  const backgroundPadding = `${theme(
+    'padding.backgroundX',
+    theme('padding.5', '1.25em')
+  )} ${theme('padding.backgroundY', theme('padding.9', '2.35em'))}`;
+
+  const backgroundUtilties = {
+    '.has-background': {
+      padding: backgroundPadding,
+    },
+    '.has-primary-background-color': {
+      backgroundColor:
+        theme('colors.primary') || theme('colors.blue.500') || '#0073a8',
+    },
+    '.has-secondary-background-color': {
+      backgroundColor:
+        theme('colors.secondary') || theme('colors.gray.500') || '#005075',
+    },
+    '.has-dark-gray-background-color': {
+      backgroundColor:
+        theme('colors.darkGray') || theme('colors.neutral.800') || '#333333',
+    },
+    '.has-light-gray-background-color': {
+      backgroundColor:
+        theme('colors.lightGray') || theme('colors.neutral.500') || '#666666',
+    },
+    '.has-white-background-color': {
+      backgroundColor: theme('colors.white') || '#ffffff',
+    },
+  };
+
+  const dropCapUtilties = {
+    '.has-drop-cap': {
+      '&:first-letter': {
+        float: 'left',
+        fontSize: '3.75rem',
+        lineHeight: '0.68',
+        fontWeight: 'bolder',
+        margin: '1rem 1rem 0 0',
+        textTransform: 'uppercase',
+        fontStyle: 'normal',
+      },
+    },
+  };
+
+  addUtilities([
+    colorUtilties,
+    fontSizeUtilties,
+    backgroundUtilties,
+    dropCapUtilties,
+  ]);
+}, mergeToConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,8 @@ overrides:
   jpeg-js@<0.4.4: '>=0.4.4'
   got@<11.8.5: '>=11.8.5'
 
+patchedDependencies: {}
+
 importers:
 
   .:
@@ -111,6 +113,7 @@ importers:
     dependencies:
       graphql: 16.5.0
       graphql-request: 4.3.0_graphql@16.5.0
+    devDependencies:
       tailwindcss: 3.1.6
 
   starters/gatsby-wordpress-starter:
@@ -4314,7 +4317,6 @@ packages:
 
   /@next/env/12.1.6:
     resolution: {integrity: sha512-Te/OBDXFSodPU6jlXYPAXpmZr/AkG6DCATAxttQxqOWaq6eDFX25Db3dK0120GZrSZmv4QCe9KsZmJKDbWs4OA==}
-    dev: false
 
   /@next/eslint-plugin-next/12.1.0:
     resolution: {integrity: sha512-WFiyvSM2G5cQmh32t/SiQuJ+I2O+FHVlK/RFw5b1565O2kEM/36EXncjt88Pa+X5oSc+1SS+tWxowWJd1lqI+g==}
@@ -4334,7 +4336,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-android-arm64/12.1.6:
@@ -4343,7 +4344,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-darwin-arm64/12.1.6:
@@ -4352,7 +4352,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-darwin-x64/12.1.6:
@@ -4361,7 +4360,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-arm-gnueabihf/12.1.6:
@@ -4370,7 +4368,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-arm64-gnu/12.1.6:
@@ -4379,7 +4376,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-arm64-musl/12.1.6:
@@ -4388,7 +4384,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-x64-gnu/12.1.6:
@@ -4397,7 +4392,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-linux-x64-musl/12.1.6:
@@ -4406,7 +4400,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-win32-arm64-msvc/12.1.6:
@@ -4415,7 +4408,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-win32-ia32-msvc/12.1.6:
@@ -4424,7 +4416,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@next/swc-win32-x64-msvc/12.1.6:
@@ -4433,7 +4424,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -14537,7 +14527,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: false
 
   /nice-try/1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -15775,7 +15764,6 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: false
 
   /prebuild-install/7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
@@ -16171,7 +16159,6 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
       scheduler: 0.19.1
-    dev: true
 
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -16182,7 +16169,6 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
-    dev: false
 
   /react-error-overlay/6.0.11:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
@@ -16344,7 +16330,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
-    dev: true
 
   /react/17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -16865,14 +16850,12 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: true
 
   /scheduler/0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: false
 
   /schema-utils/2.7.0:
     resolution: {integrity: sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==}
@@ -17704,7 +17687,6 @@ packages:
         optional: true
     dependencies:
       react: 17.0.2
-    dev: false
 
   /stylehacks/5.1.0_postcss@8.4.14:
     resolution: {integrity: sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==}
@@ -17909,7 +17891,6 @@ packages:
       resolve: 1.22.1
     transitivePeerDependencies:
       - ts-node
-    dev: true
 
   /tailwindcss/3.1.6:
     resolution: {integrity: sha512-7skAOY56erZAFQssT1xkpk+kWt2NrO45kORlxFPXUt3CiGsVPhH1smuH5XoDH6sGPXLyBv+zgCKA2HWBsgCytg==}
@@ -17940,7 +17921,7 @@ packages:
       resolve: 1.22.1
     transitivePeerDependencies:
       - ts-node
-    dev: false
+    dev: true
 
   /tapable/1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
@@ -18496,7 +18477,6 @@ packages:
     resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /ua-parser-js/0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
@@ -19668,5 +19648,3 @@ packages:
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: false
-
-patchedDependencies: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,6 @@ overrides:
   jpeg-js@<0.4.4: '>=0.4.4'
   got@<11.8.5: '>=11.8.5'
 
-patchedDependencies: {}
-
 importers:
 
   .:
@@ -109,9 +107,11 @@ importers:
     specifiers:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
       graphql-request: ^4.3.0
+      tailwindcss: ^3.1.6
     dependencies:
       graphql: 16.5.0
       graphql-request: 4.3.0_graphql@16.5.0
+      tailwindcss: 3.1.6
 
   starters/gatsby-wordpress-starter:
     specifiers:
@@ -3435,14 +3435,6 @@ packages:
     dependencies:
       graphql: 15.8.0
 
-  /@graphql-typed-document-node/core/3.1.1_graphql@16.5.0:
-    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 16.5.0
-    dev: true
-
   /@hapi/address/2.1.4:
     resolution: {integrity: sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==}
     deprecated: Moved to 'npm install @sideway/address'
@@ -4322,6 +4314,7 @@ packages:
 
   /@next/env/12.1.6:
     resolution: {integrity: sha512-Te/OBDXFSodPU6jlXYPAXpmZr/AkG6DCATAxttQxqOWaq6eDFX25Db3dK0120GZrSZmv4QCe9KsZmJKDbWs4OA==}
+    dev: false
 
   /@next/eslint-plugin-next/12.1.0:
     resolution: {integrity: sha512-WFiyvSM2G5cQmh32t/SiQuJ+I2O+FHVlK/RFw5b1565O2kEM/36EXncjt88Pa+X5oSc+1SS+tWxowWJd1lqI+g==}
@@ -4341,6 +4334,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-android-arm64/12.1.6:
@@ -4349,6 +4343,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-darwin-arm64/12.1.6:
@@ -4357,6 +4352,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-darwin-x64/12.1.6:
@@ -4365,6 +4361,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-arm-gnueabihf/12.1.6:
@@ -4373,6 +4370,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-arm64-gnu/12.1.6:
@@ -4381,6 +4379,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-arm64-musl/12.1.6:
@@ -4389,6 +4388,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-x64-gnu/12.1.6:
@@ -4397,6 +4397,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-linux-x64-musl/12.1.6:
@@ -4405,6 +4406,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-win32-arm64-msvc/12.1.6:
@@ -4413,6 +4415,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-win32-ia32-msvc/12.1.6:
@@ -4421,6 +4424,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@next/swc-win32-x64-msvc/12.1.6:
@@ -4429,6 +4433,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -11793,16 +11798,6 @@ packages:
       graphql: 15.8.0
       tslib: 2.4.0
 
-  /graphql-tag/2.12.6_graphql@16.5.0:
-    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 16.5.0
-      tslib: 2.4.0
-    dev: true
-
   /graphql-type-json/0.3.2_graphql@15.8.0:
     resolution: {integrity: sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==}
     peerDependencies:
@@ -14542,6 +14537,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    dev: false
 
   /nice-try/1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -15779,6 +15775,7 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: false
 
   /prebuild-install/7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
@@ -16174,6 +16171,7 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
       scheduler: 0.19.1
+    dev: true
 
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -16184,6 +16182,7 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
+    dev: false
 
   /react-error-overlay/6.0.11:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
@@ -16345,6 +16344,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
+    dev: true
 
   /react/17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -16865,12 +16865,14 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: true
 
   /scheduler/0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: false
 
   /schema-utils/2.7.0:
     resolution: {integrity: sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==}
@@ -17702,6 +17704,7 @@ packages:
         optional: true
     dependencies:
       react: 17.0.2
+    dev: false
 
   /stylehacks/5.1.0_postcss@8.4.14:
     resolution: {integrity: sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==}
@@ -17906,6 +17909,38 @@ packages:
       resolve: 1.22.1
     transitivePeerDependencies:
       - ts-node
+    dev: true
+
+  /tailwindcss/3.1.6:
+    resolution: {integrity: sha512-7skAOY56erZAFQssT1xkpk+kWt2NrO45kORlxFPXUt3CiGsVPhH1smuH5XoDH6sGPXLyBv+zgCKA2HWBsgCytg==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.11
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.14
+      postcss-import: 14.1.0_postcss@8.4.14
+      postcss-js: 4.0.0_postcss@8.4.14
+      postcss-load-config: 3.1.4_postcss@8.4.14
+      postcss-nested: 5.0.6_postcss@8.4.14
+      postcss-selector-parser: 6.0.10
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: false
 
   /tapable/1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
@@ -18461,6 +18496,7 @@ packages:
     resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /ua-parser-js/0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
@@ -19632,3 +19668,5 @@ packages:
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: false
+
+patchedDependencies: {}

--- a/starters/next-wordpress-starter/tailwind.config.js
+++ b/starters/next-wordpress-starter/tailwind.config.js
@@ -1,9 +1,13 @@
+const { tailwindcssPlugin } = require("@pantheon-systems/wordpress-kit");
+
+/** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
   theme: {
     extend: {},
   },
-  plugins: [
-    require('@tailwindcss/typography'),
-  ],
-}
+  plugins: [require("@tailwindcss/typography"), tailwindcssPlugin],
+};

--- a/starters/next-wordpress-starter/tailwind.config.js
+++ b/starters/next-wordpress-starter/tailwind.config.js
@@ -1,6 +1,6 @@
 const { tailwindcssPlugin } = require("@pantheon-systems/wordpress-kit");
 
-/** @type {import('tailwindcss').Config} */
+/** @type {import('@pantheon-systems/wordpress-kit').TailwindcssConfig} */
 module.exports = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## What changes were made?
- Added a plugin to WordPress-kit that extends the classes to map styles that comes from the WordPress block editor

## Where were the changes made?
- WordPress-kit
- Next-WordPress Starter

## How have the changes been tested?
- Locally and built

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!