### PR TITLE
DB-3183: Split next-wordpress-starter to standalone repo in ci

### DIFF
--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -60,6 +60,8 @@ jobs:
             split_repository: "gatsby-wordpress-starter"
           - local_path: "starters/next-drupal-starter"
             split_repository: "next-drupal-starter"
+          - local_path: "starters/next-wordpress-starter"
+            split_repository: "next-wordpress-starter"
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Like our other starters, this change will make the `next-wordpress-starter` available at https://github.com/pantheon-systems/next-wordpress-starter for easy cloning and using with `create-next-app`.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
decoupled-kit, ci

## How have the changes been tested?


## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!