### PR TITLE
Downgrade gatsby@4.19.0 to 4.16.0

### DIFF
--- a/.changeset/lazy-poets-count.md
+++ b/.changeset/lazy-poets-count.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/gatsby-wordpress-starter": minor
+---
+
+[gatsby-wordpress-starter] Reverts upgrade to gatsby 4.16.0

--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
       "devcert@<1.2.1": ">=1.2.1",
       "jpeg-js@<0.4.4": ">=0.4.4",
       "got@<11.8.5": ">=11.8.5",
-      "parse-path@<5.0.0": ">=5.0.0",
-      "file-type@<16.5.4": ">=16.5.4"
+      "parse-path@<5.0.0": ">=5.0.0"
     },
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,6 @@ overrides:
   jpeg-js@<0.4.4: '>=0.4.4'
   got@<11.8.5: '>=11.8.5'
   parse-path@<5.0.0: '>=5.0.0'
-  file-type@<16.5.4: '>=16.5.4'
 
 patchedDependencies: {}
 
@@ -3791,7 +3790,7 @@ packages:
       any-base: 1.1.0
       buffer: 5.7.1
       exif-parser: 0.1.12
-      file-type: 16.5.4
+      file-type: 9.0.0
       load-bmfont: 1.4.1
       mkdirp: 0.5.6
       phin: 2.9.3
@@ -5545,6 +5544,10 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
+  /@tokenizer/token/0.1.1:
+    resolution: {integrity: sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==}
+    dev: false
+
   /@tokenizer/token/0.3.0:
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
     dev: false
@@ -6999,7 +7002,7 @@ packages:
   /axios/0.21.4_debug@3.2.7:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.1_debug@3.2.7
+      follow-redirects: 1.15.1
     transitivePeerDependencies:
       - debug
     dev: false
@@ -9807,10 +9810,10 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.30.7_eslint@8.10.0
+      '@typescript-eslint/parser': 5.30.7_eslint@8.17.0
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_iwaynwhiegrrsv6g3xp42z6p6u
+      eslint-import-resolver-typescript: 2.7.1_3yxiwxzsqipdmy4jwrlv6vgfmy
       find-up: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -10846,6 +10849,16 @@ packages:
       webpack: 5.73.0
     dev: false
 
+  /file-type/15.0.1:
+    resolution: {integrity: sha512-0LieQlSA3bWUdErNrxzxfI4rhsvNAVPBO06R8pTc1hp9SE6nhqlVyvhcaXoMmtXkBTPnQenbMPLW9X76hH76oQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      readable-web-to-node-stream: 2.0.0
+      strtok3: 6.3.0
+      token-types: 2.1.1
+      typedarray-to-buffer: 3.1.5
+    dev: false
+
   /file-type/16.5.4:
     resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
     engines: {node: '>=10'}
@@ -10853,6 +10866,11 @@ packages:
       readable-web-to-node-stream: 3.0.2
       strtok3: 6.3.0
       token-types: 4.2.0
+    dev: false
+
+  /file-type/9.0.0:
+    resolution: {integrity: sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==}
+    engines: {node: '>=6'}
     dev: false
 
   /filename-reserved-regex/2.0.0:
@@ -10984,18 +11002,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: false
-
-  /follow-redirects/1.15.1_debug@3.2.7:
-    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 3.2.7
     dev: false
 
   /for-each/0.3.3:
@@ -11668,7 +11674,7 @@ packages:
       dumper.js: 1.3.1
       execall: 2.0.0
       fast-json-stable-stringify: 2.1.0
-      file-type: 16.5.4
+      file-type: 15.0.1
       filesize: 6.4.0
       fs-extra: 10.1.0
       gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
@@ -12701,7 +12707,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.1_debug@3.2.7
+      follow-redirects: 1.15.1
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -12712,7 +12718,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.1_debug@3.2.7
+      follow-redirects: 1.15.1
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -15110,7 +15116,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 12.2.3_quymggomo7oodk3cofk2m5scyu
+      next: 12.2.3_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
@@ -17132,6 +17138,10 @@ packages:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  /readable-web-to-node-stream/2.0.0:
+    resolution: {integrity: sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA==}
+    dev: false
+
   /readable-web-to-node-stream/3.0.2:
     resolution: {integrity: sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==}
     engines: {node: '>=8'}
@@ -18786,6 +18796,14 @@ packages:
   /toidentifier/1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+    dev: false
+
+  /token-types/2.1.1:
+    resolution: {integrity: sha512-wnQcqlreS6VjthyHO3Y/kpK/emflxDBNhlNUPfh7wE39KnuDdOituXomIbyI79vBtF0Ninpkh72mcuRHo+RG3Q==}
+    engines: {node: '>=0.1.98'}
+    dependencies:
+      '@tokenizer/token': 0.1.1
+      ieee754: 1.2.1
     dev: false
 
   /token-types/4.2.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
       react-dom: ^16.8.0
       typescript: '>=3.8 <5.0'
     dependencies:
-      '@gdwc/drupal-state': 3.0.0_htoe73xbxmkeypml4jc6c2iyca
+      '@gdwc/drupal-state': 3.0.0_gqjuj6p25nmz3tdvumzfhoub34
     devDependencies:
       '@apollo/client': 3.6.9_5d33slzn54cnsyp4ta7twtp2ca
       '@types/humps': 2.0.2
@@ -120,26 +120,26 @@ importers:
 
   starters/gatsby-wordpress-starter:
     specifiers:
-      '@babel/core': ^7.18.9
-      '@tailwindcss/typography': ^0.5.4
-      autoprefixer: ^10.4.7
+      '@babel/core': '>=7.12.3 <8.0.0'
+      '@tailwindcss/typography': ^0.5.2
+      autoprefixer: ^10.4.4
       dumper.js: ^1.3.1
-      gatsby: 4.19.0
-      gatsby-plugin-image: ^2.19.0
-      gatsby-plugin-manifest: ^4.19.0
-      gatsby-plugin-offline: ^5.19.0
+      gatsby: 4.16.0
+      gatsby-plugin-image: ^2.12.1
+      gatsby-plugin-manifest: ^4.12.1
+      gatsby-plugin-offline: ^5.12.1
       gatsby-plugin-pnpm: ^1.2.10
-      gatsby-plugin-postcss: ^5.19.0
-      gatsby-plugin-react-helmet: ^5.19.0
-      gatsby-plugin-sharp: ^4.19.0
-      gatsby-source-filesystem: ^4.19.0
-      gatsby-source-wordpress: ^6.19.0
-      gatsby-transformer-sharp: ^4.19.0
-      graphql: ^16.5.0
-      html-react-parser: ^1.4.14
+      gatsby-plugin-postcss: ^5.12.1
+      gatsby-plugin-react-helmet: ^5.12.1
+      gatsby-plugin-sharp: ^4.12.1
+      gatsby-source-filesystem: ^4.12.1
+      gatsby-source-wordpress: ^6.12.1
+      gatsby-transformer-sharp: ^4.12.1
+      graphql: '>=14.2.0 <15.0.0 || >=15.0.0 <16.0.0 || >=16.0.0 <17.0.0'
+      html-react-parser: ^1.4.10
       lodash: ^4.17.21
       mitt: ^3.0.0
-      postcss: ^8.4.14
+      postcss: ^8.4.12
       prettier: 2.5.1
       react: 17.0.2
       react-dom: 17.0.2
@@ -147,21 +147,21 @@ importers:
       tailwindcss: 3.0.24
       typeface-merriweather: 1.1.13
       typeface-montserrat: 1.1.13
-      webpack: ^5.73.0
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       '@tailwindcss/typography': 0.5.4_tailwindcss@3.0.24
       autoprefixer: 10.4.7_postcss@8.4.14
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
-      gatsby-plugin-image: 2.19.0_qwbuxo3wnzxmpnnrnvhkaesqeq
-      gatsby-plugin-manifest: 4.19.0_7efqbrr4vh2unksygyphdu66x4
-      gatsby-plugin-offline: 5.19.0_6vqsztrjusvurd6jpraufykpam
-      gatsby-plugin-pnpm: 1.2.10_gatsby@4.19.0
-      gatsby-plugin-postcss: 5.19.0_77mdcgnegxo4wdozsdnqm3xwo4
-      gatsby-plugin-react-helmet: 5.19.0_yvh7r7ycpdu4toihqykndbyhmy
-      gatsby-plugin-sharp: 4.19.0_7efqbrr4vh2unksygyphdu66x4
-      gatsby-source-filesystem: 4.19.0_gatsby@4.19.0
-      gatsby-source-wordpress: 6.19.0_qesxhqernuepzfhyc2fdhg3lyy
-      gatsby-transformer-sharp: 4.19.0_62ownqrbb7ezkbmnvfnjupyvqe
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby-plugin-image: 2.19.0_irnutnl6v3bbcvna4tonbxmq5e
+      gatsby-plugin-manifest: 4.19.0_sjhkp6oelwtnvf6k6r5hdxorme
+      gatsby-plugin-offline: 5.19.0_ob3apgrvd3skfbxsyruw7t3jci
+      gatsby-plugin-pnpm: 1.2.10_gatsby@4.16.0
+      gatsby-plugin-postcss: 5.19.0_ykmjhnntseh5olbmw5qtp3f2iu
+      gatsby-plugin-react-helmet: 5.19.0_22qjo53tgtuqoiupcchhqtqqsm
+      gatsby-plugin-sharp: 4.19.0_sjhkp6oelwtnvf6k6r5hdxorme
+      gatsby-source-filesystem: 4.19.0_gatsby@4.16.0
+      gatsby-source-wordpress: 6.19.0_iauurw47l477pmne3ttx2ckxj4
+      gatsby-transformer-sharp: 4.19.0_6lheiiduvv6xb77anns5jgq4eu
       graphql: 16.5.0
       html-react-parser: 1.4.14_react@17.0.2
       lodash: 4.17.21
@@ -3069,13 +3069,13 @@ packages:
     resolution: {integrity: sha512-bprfNmYt1opFUFEtD2XfY/kEsm13bzHQgU80uMjhuK0DJ914IjolT1GytpkdM6tJ4MBvyiJPP+bTtWO+BZ7c7w==}
     dev: false
 
-  /@gatsbyjs/parcel-namer-relative-to-cwd/1.4.0_@parcel+core@2.6.2:
+  /@gatsbyjs/parcel-namer-relative-to-cwd/1.4.0_@parcel+core@2.6.0:
     resolution: {integrity: sha512-oXhiaPtYTGYqGZlazYRUabWVHWx5z6sAyBVLhUnpsKcBsK815cET+mjeWDKpmvJmFTKHC72Bvy1WIEnW3++YxA==}
     engines: {node: '>=14.15.0', parcel: 2.x}
     dependencies:
       '@babel/runtime': 7.18.9
-      '@parcel/namer-default': 2.6.2_@parcel+core@2.6.2
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/namer-default': 2.6.2_@parcel+core@2.6.0
+      '@parcel/plugin': 2.6.2_@parcel+core@2.6.0
       gatsby-core-utils: 3.19.0
     transitivePeerDependencies:
       - '@parcel/core'
@@ -3108,7 +3108,7 @@ packages:
       strip-ansi: 6.0.1
     dev: false
 
-  /@gdwc/drupal-state/3.0.0_htoe73xbxmkeypml4jc6c2iyca:
+  /@gdwc/drupal-state/3.0.0_gqjuj6p25nmz3tdvumzfhoub34:
     resolution: {integrity: sha512-IC9XB34jHK6k3mpZb8Kjrv9ICMKcgpp/cxGuR27DxCyhJk31SIsM0Lo8K288JaR577eYQIRpo4S0OPPHVGvAog==}
     requiresBuild: true
     dependencies:
@@ -3130,7 +3130,7 @@ packages:
       jsona: 1.10.1
       patch-package: 6.4.7
       qs: 6.11.0
-      ts-jest: 27.1.5_jm6546ohpm4h5jsgaz4ra4shga
+      ts-jest: 27.1.5_mqaoisgizytgigbr3gbjwvnjie
       zustand: 3.7.2_react@16.14.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -4597,30 +4597,50 @@ packages:
     resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
     dev: true
 
-  /@parcel/bundler-default/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-XIa3had/MIaTGgRFkHApXwytYs77k4geaNcmlb6nzmAABcYjW1CLYh83Zt0AbzLFsDT9ZcRY3u2UjhNf6efSaw==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/bundler-default/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-AplEdGm/odV7yGmoeOnglxnY31WlNB5EqGLFGxkgs7uwDaTWoTX/9SWPG6xfvirhjDpms8sLSiVuBdFRCCLtNA==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/diagnostic': 2.6.2
-      '@parcel/hash': 2.6.2
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
-      '@parcel/utils': 2.6.2
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/hash': 2.6.0
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/cache/2.6.2_@parcel+core@2.6.2:
+  /@parcel/cache/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-4vbD5uSuf+kRnrFesKhpn0AKnOw8u2UlvCyrplYmp1g9bNAkIooC/nDGdmkb/9SviPEbni9PEanQEHDU2+slpA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@parcel/core': ^2.6.0
+    dependencies:
+      '@parcel/core': 2.6.0
+      '@parcel/fs': 2.6.0_@parcel+core@2.6.0
+      '@parcel/logger': 2.6.0
+      '@parcel/utils': 2.6.0
+      lmdb: 2.3.10
+    dev: false
+
+  /@parcel/cache/2.6.2_@parcel+core@2.6.0:
     resolution: {integrity: sha512-hhJ6AsEGybeQZd9c/GYqfcKTgZKQXu3Xih6TlnP3gdR3KZoJOnb40ovHD1yYg4COvfcXThKP1cVJ18J6rcv3IA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
       '@parcel/core': ^2.6.2
     dependencies:
-      '@parcel/core': 2.6.2
-      '@parcel/fs': 2.6.2_@parcel+core@2.6.2
+      '@parcel/core': 2.6.0
+      '@parcel/fs': 2.6.2_@parcel+core@2.6.0
       '@parcel/logger': 2.6.2
       '@parcel/utils': 2.6.2
       lmdb: 2.5.2
+    dev: false
+
+  /@parcel/codeframe/2.6.0:
+    resolution: {integrity: sha512-yXXxrO9yyedHKpTwC+Af0+vPmQm+A9xeEhkt4f0yVg1n4t4yUIxYlTedzbM8ygZEEBtkXU9jJ+PkgXbfMf0dqw==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      chalk: 4.1.2
     dev: false
 
   /@parcel/codeframe/2.6.2:
@@ -4630,33 +4650,33 @@ packages:
       chalk: 4.1.2
     dev: false
 
-  /@parcel/compressor-raw/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-P3c8jjV5HVs+fNDjhvq7PtHXNm687nit1iwTS5VAt+ScXKhKBhoIJ56q+9opcw0jnXVjAAgZqcRZ50oAJBGdKw==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/compressor-raw/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-rtMU2mGl88bic6Xbq1u5L49bMK4s5185b0k7h3JRdS6/0rR+Xp4k/o9Wog+hHjK/s82z1eF9WmET779ZpIDIQQ==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/core/2.6.2:
-    resolution: {integrity: sha512-JlKS3Ux0ngmdooSBbzQLShHJdsapF9E7TGMo1hFaHRquZip/DaqzvysYrgMJlDuCoLArciq5ei7ZKzGeK9zexA==}
+  /@parcel/core/2.6.0:
+    resolution: {integrity: sha512-8OOWbPuxpFydpwNyKoz6d3e3O4DmxNYmMw4DXwrPSj/jyg7oa+SDtMT0/VXEhujE0HYkQPCHt4npRajkSuf99A==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       '@mischnic/json-sourcemap': 0.1.0
-      '@parcel/cache': 2.6.2_@parcel+core@2.6.2
-      '@parcel/diagnostic': 2.6.2
-      '@parcel/events': 2.6.2
-      '@parcel/fs': 2.6.2_@parcel+core@2.6.2
-      '@parcel/graph': 2.6.2
-      '@parcel/hash': 2.6.2
-      '@parcel/logger': 2.6.2
-      '@parcel/package-manager': 2.6.2_@parcel+core@2.6.2
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/cache': 2.6.0_@parcel+core@2.6.0
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/events': 2.6.0
+      '@parcel/fs': 2.6.0_@parcel+core@2.6.0
+      '@parcel/graph': 2.6.0
+      '@parcel/hash': 2.6.0
+      '@parcel/logger': 2.6.0
+      '@parcel/package-manager': 2.6.0_@parcel+core@2.6.0
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
       '@parcel/source-map': 2.1.0
-      '@parcel/types': 2.6.2_@parcel+core@2.6.2
-      '@parcel/utils': 2.6.2
-      '@parcel/workers': 2.6.2_@parcel+core@2.6.2
+      '@parcel/types': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
+      '@parcel/workers': 2.6.0_@parcel+core@2.6.0
       abortcontroller-polyfill: 1.7.3
       base-x: 3.0.9
       browserslist: 4.21.2
@@ -4669,6 +4689,14 @@ packages:
       semver: 5.7.1
     dev: false
 
+  /@parcel/diagnostic/2.6.0:
+    resolution: {integrity: sha512-+p8gC2FKxSI2veD7SoaNlP572v4kw+nafCQEPDtJuzYYRqywYUGncch25dkpgNApB4W4cXVkZu3ZbtIpCAmjQQ==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      '@mischnic/json-sourcemap': 0.1.0
+      nullthrows: 1.1.1
+    dev: false
+
   /@parcel/diagnostic/2.6.2:
     resolution: {integrity: sha512-3ODSBkKVihENU763z1/1DhGAWFhYWRxOCOShC72KXp+GFnSgGiBsxclu8NBa/N948Rzp8lqQI8U1nLcKkh0O/w==}
     engines: {node: '>= 12.0.0'}
@@ -4677,9 +4705,21 @@ packages:
       nullthrows: 1.1.1
     dev: false
 
+  /@parcel/events/2.6.0:
+    resolution: {integrity: sha512-2WaKtBs4iYwS88j4zRdyTJTgh8iuY4E32FMmjzzbheqETs6I05gWuPReGukJYxk8vc0Ir7tbzp12oAfpgo0Y+g==}
+    engines: {node: '>= 12.0.0'}
+    dev: false
+
   /@parcel/events/2.6.2:
     resolution: {integrity: sha512-IaCjOeA5ercdFVi1EZOmUHhGfIysmCUgc2Th9hMugSFO0I3GzRsBcAdP6XPfWm+TV6sQ/qZRfdk/drUxoAupnw==}
     engines: {node: '>= 12.0.0'}
+    dev: false
+
+  /@parcel/fs-search/2.6.0:
+    resolution: {integrity: sha512-1nXzM3H/cA4kzLKvDBvwmNisKCdRqlgkLXh+OR1Zu28Kn4W34KuJMcHWW8cC+WIuuKqDh5oo2WPsC5y65GXBKQ==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      detect-libc: 1.0.3
     dev: false
 
   /@parcel/fs-search/2.6.2:
@@ -4689,26 +4729,48 @@ packages:
       detect-libc: 1.0.3
     dev: false
 
-  /@parcel/fs/2.6.2_@parcel+core@2.6.2:
+  /@parcel/fs/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-6vxtx5Zy6MvDvH1EPx9JxjKGF03bR7VE1dUf4HLeX2D8YmpL5hkHJnlRCFdcH08rzOVwaJLzg1QNtblWJXQ9CA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@parcel/core': ^2.6.0
+    dependencies:
+      '@parcel/core': 2.6.0
+      '@parcel/fs-search': 2.6.0
+      '@parcel/types': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
+      '@parcel/watcher': 2.0.5
+      '@parcel/workers': 2.6.0_@parcel+core@2.6.0
+    dev: false
+
+  /@parcel/fs/2.6.2_@parcel+core@2.6.0:
     resolution: {integrity: sha512-mIhqdF3tjgeoIGqW7Nc/xfM2ClID7o8livwUe5lpQEP+ZaIBiMigXs6ckv3WToCACK+3uylrSD2A/HmlhrxMqQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
       '@parcel/core': ^2.6.2
     dependencies:
-      '@parcel/core': 2.6.2
+      '@parcel/core': 2.6.0
       '@parcel/fs-search': 2.6.2
-      '@parcel/types': 2.6.2_@parcel+core@2.6.2
+      '@parcel/types': 2.6.2_@parcel+core@2.6.0
       '@parcel/utils': 2.6.2
       '@parcel/watcher': 2.0.5
-      '@parcel/workers': 2.6.2_@parcel+core@2.6.2
+      '@parcel/workers': 2.6.2_@parcel+core@2.6.0
     dev: false
 
-  /@parcel/graph/2.6.2:
-    resolution: {integrity: sha512-DPH4G/RBFJWayIN2fnhDXqhUw75n7k15YsGzdDKiXuwwz4wMOjoL4cyrI6zOf1SIyh3guRmeTYJ4jjPzwrLYww==}
+  /@parcel/graph/2.6.0:
+    resolution: {integrity: sha512-rxrAzWm6rwbCRPbu0Z+zwMscpG8omffODniVWPlX2G0jgQGpjKsutBQ6RMfFIcfaQ4MzL3pIQOTf8bkjQOPsbg==}
     engines: {node: '>= 12.0.0'}
     dependencies:
-      '@parcel/utils': 2.6.2
+      '@parcel/utils': 2.6.0
       nullthrows: 1.1.1
+    dev: false
+
+  /@parcel/hash/2.6.0:
+    resolution: {integrity: sha512-YugWqhLxqK80Lo++3B3Kr5UPCHOdS8iI2zJ1jkzUeH9v6WUzbwWOnmPf6lN2S5m1BrIFFJd8Jc+CbEXWi8zoJA==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      detect-libc: 1.0.3
+      xxhash-wasm: 0.4.2
     dev: false
 
   /@parcel/hash/2.6.2:
@@ -4719,12 +4781,27 @@ packages:
       xxhash-wasm: 0.4.2
     dev: false
 
+  /@parcel/logger/2.6.0:
+    resolution: {integrity: sha512-J1/7kPfSGBvMKSZdi0WCNuN0fIeiWxifnDGn7W/K8KhD422YwFJA8N046ps8nkDOPIXf1osnIECNp4GIR9oSYw==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/events': 2.6.0
+    dev: false
+
   /@parcel/logger/2.6.2:
     resolution: {integrity: sha512-Sz5YGCj1DbEiX0/G8Uw97LLZ0uEK+qtWcRAkHNpJpeMiSqDiRNevxXltz42EcLo+oCh4d4wyiVzwi9mNwzhS/Q==}
     engines: {node: '>= 12.0.0'}
     dependencies:
       '@parcel/diagnostic': 2.6.2
       '@parcel/events': 2.6.2
+    dev: false
+
+  /@parcel/markdown-ansi/2.6.0:
+    resolution: {integrity: sha512-fyjkrJQQSfKTUFTTasdZ6WrAkDoQ2+DYDjj+3p+RncYyrIa9zArKx4IiRiipsvNdtMvP0/hTdK8F3BOJ3KSU/g==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      chalk: 4.1.2
     dev: false
 
   /@parcel/markdown-ansi/2.6.2:
@@ -4734,149 +4811,184 @@ packages:
       chalk: 4.1.2
     dev: false
 
-  /@parcel/namer-default/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-mp7bx/BQaIuohmZP0uE+gAmDBzzH0Yu8F4yCtE611lc6i0mou+nWRhzyKLNC/ieuI8DB3BFh2QQKeTxJn4W0qg==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/namer-default/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/diagnostic': 2.6.2
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/node-resolver-core/2.6.2:
-    resolution: {integrity: sha512-4b2L5QRYlTybvv3+TIRtwg4PPJXy+cRShCBa8eu1K0Fj297Afe8MOZrcVV+RIr2KPMIRXcIJoqDmOhyci/DynA==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      '@parcel/diagnostic': 2.6.2
-      '@parcel/utils': 2.6.2
-      nullthrows: 1.1.1
-      semver: 5.7.1
-    dev: false
-
-  /@parcel/optimizer-terser/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-ZSEVQ3G3zOiVPeHvH+BrHegZybrQj9kWQAaAA92leSqbvf6UaX4xqXbGRg2OttNFtbGYBzIl28Zm4t2SLeUIuA==}
+  /@parcel/namer-default/2.6.2_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-mp7bx/BQaIuohmZP0uE+gAmDBzzH0Yu8F4yCtE611lc6i0mou+nWRhzyKLNC/ieuI8DB3BFh2QQKeTxJn4W0qg==}
     engines: {node: '>= 12.0.0', parcel: ^2.6.2}
     dependencies:
       '@parcel/diagnostic': 2.6.2
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/plugin': 2.6.2_@parcel+core@2.6.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@parcel/core'
+    dev: false
+
+  /@parcel/node-resolver-core/2.6.0:
+    resolution: {integrity: sha512-AJDj5DZbB58plv0li8bdVSD+zpnkHE36Om3TYyNn1jgXXwgBM64Er/9p8yQn356jBqTQMh7zlJqvbdIyOiMeMg==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/utils': 2.6.0
+      nullthrows: 1.1.1
+    dev: false
+
+  /@parcel/optimizer-terser/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-oezRt6Lz/QqcVDXyMfFjzQc7n0ThJowLJ4Lyhu8rMh0ZJYzc4UCFCw/19d4nRnzE+Qg0vj3mQCpdkA9/64E44g==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
+    dependencies:
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
       '@parcel/source-map': 2.1.0
-      '@parcel/utils': 2.6.2
+      '@parcel/utils': 2.6.0
       nullthrows: 1.1.1
       terser: 5.14.2
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/package-manager/2.6.2_@parcel+core@2.6.2:
+  /@parcel/package-manager/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-AqFfdkbOw51q/3ia2mIsFTmrpYEyUb3k+2uYC5GsLMz3go6OGn7/Crz0lZLSclv5EtwpRg3TWr9yL7RekVN/Uw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@parcel/core': ^2.6.0
+    dependencies:
+      '@parcel/core': 2.6.0
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/fs': 2.6.0_@parcel+core@2.6.0
+      '@parcel/logger': 2.6.0
+      '@parcel/types': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
+      '@parcel/workers': 2.6.0_@parcel+core@2.6.0
+      semver: 5.7.1
+    dev: false
+
+  /@parcel/package-manager/2.6.2_@parcel+core@2.6.0:
     resolution: {integrity: sha512-xGMqTgnwTE3rgzYwUZMKxR8fzmP5iSYz/gj2H8FR3pEmwh/8xCMtNjTSth+hPVGuqgRZ6JxwpfdY/fXdZ61ViQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
       '@parcel/core': ^2.6.2
     dependencies:
-      '@parcel/core': 2.6.2
+      '@parcel/core': 2.6.0
       '@parcel/diagnostic': 2.6.2
-      '@parcel/fs': 2.6.2_@parcel+core@2.6.2
+      '@parcel/fs': 2.6.2_@parcel+core@2.6.0
       '@parcel/logger': 2.6.2
-      '@parcel/types': 2.6.2_@parcel+core@2.6.2
+      '@parcel/types': 2.6.2_@parcel+core@2.6.0
       '@parcel/utils': 2.6.2
-      '@parcel/workers': 2.6.2_@parcel+core@2.6.2
+      '@parcel/workers': 2.6.2_@parcel+core@2.6.0
       semver: 5.7.1
     dev: false
 
-  /@parcel/packager-js/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-fm5rKWtaExR0W+UEKWivXNPysRFxuBCdskdxDByb1J1JeGMvp7dJElbi8oXDAQM4MnM5EyG7cg47SlMZNTLm4A==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/packager-js/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-Uz3pqIFchFfKszWnNGDgIwM1uwHHJp7Dts6VzS9lf/2RbRgZT0fmce+NPgnVO5MMKBHzdvm32ShT6gFAABF5Vw==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/diagnostic': 2.6.2
-      '@parcel/hash': 2.6.2
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/hash': 2.6.0
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
       '@parcel/source-map': 2.1.0
-      '@parcel/utils': 2.6.2
+      '@parcel/utils': 2.6.0
       globals: 13.17.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/packager-raw/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-Rl3ZkMtMjb+LEvRowijDD8fibUAS6rWK0/vZQMk9cDNYCP2gCpZayLk0HZIGxneeTbosf/0sbngHq4VeRQOnQA==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/packager-raw/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-ktT6Qc/GgCq8H1+6y+AXufVzQj1s6KRoKf83qswCD0iY3MwCbJoEfc3IsB4K64FpHIL5Eu0z54IId+INvGbOYA==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/plugin/2.6.2_@parcel+core@2.6.2:
+  /@parcel/plugin/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-LzOaiK8R6eFEoov1cb3/W+o0XvXdI/VbDhMDl0L0II+/56M0UeayYtFP5QGTDn/fZqVlYfzPCtt3EMwdG7/dow==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      '@parcel/types': 2.6.0_@parcel+core@2.6.0
+    transitivePeerDependencies:
+      - '@parcel/core'
+    dev: false
+
+  /@parcel/plugin/2.6.2_@parcel+core@2.6.0:
     resolution: {integrity: sha512-wbbWsM23Pr+8xtLSvf+UopXdVYlpKCCx6PuuZaZcKo+9IcDCWoGXD4M8Kkz14qBmkFn5uM00mULUqmVdSibB2w==}
     engines: {node: '>= 12.0.0'}
     dependencies:
-      '@parcel/types': 2.6.2_@parcel+core@2.6.2
+      '@parcel/types': 2.6.2_@parcel+core@2.6.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/reporter-dev-server/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-5QtL3ETMFL161jehlIK6rjBM+Pqk5cMhr60s9yLYqE1GY4M4gMj+Act+FXViyM6gmMA38cPxDvUsxTKBYXpFCw==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/reporter-dev-server/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-VvygsCA+uzWyijIV8zqU1gFyhAWknuaY4KIWhV4kCT8afRJwsLSwt/tpdaKDPuPU45h3tTsUdXH1wjaIk+dGeQ==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
-      '@parcel/utils': 2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/resolver-default/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-Lo5sWb5QkjWvdBr+TdmAF6Mszb/sMldBBatc1osQTkHXCy679VMH+lfyiWxHbwK+F1pmdMeBJpYcMxvrgT8EsA==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/resolver-default/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-ATk9wXvy5GOHAqyHbnCnU11fUPTtf8dLjpgVqL5XylwugZnyBXbynoTWX4w8h6mffkVtdfmzTJx/o4Lresz9sA==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/node-resolver-core': 2.6.2
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/node-resolver-core': 2.6.0
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/runtime-browser-hmr/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-M4X0+7dyfdI6smwGUGjGXb8Ns3HX7ZrTemyq4Gc7zp7P/5gWjR8i9eISz46sXmF9bf01a/4dKZpoCC9un1pH1g==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/runtime-browser-hmr/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-90xvv/10cFML5dAhClBEJZ/ExiBQVPqQsZcvRmVZmc5mpZVJMKattWCQrd7pAf7FDYl4JAcvsK3DTwvRT/oLNA==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
-      '@parcel/utils': 2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/runtime-js/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-0S3JFwgvs6FmEx2dHta9R0Sfu8vCnFAm4i7Y4efGHtAcTrF2CHjyiz4/hG+RQGJ70eoWW463Q+8qt6EKbkaOBQ==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/runtime-js/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-R4tJAIT/SX7VBQ+f7WmeekREQzzLsmgP1j486uKhQNyYrpvsN0HnRbg5aqvZjEjkEmSeJR0mOlWtMK5/m+0yTA==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
-      '@parcel/utils': 2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/runtime-react-refresh/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-DJTm5D/tUAGZm0o3ndDOPbKwdYrobuvm4jvkPq31LdEUqVvyuzBAMlqQFHc1yJEJDRRWOIQwQP9Y0NQbJmXFfg==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/runtime-react-refresh/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-2sRd13gc2EbMV/O5n2NPVGGhKBasb1fDTXGEY8y7qi9xDKc+ewok/D83T+w243FhCPS9Pf3ur5GkbPlrJGcenQ==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
-      '@parcel/utils': 2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
       react-error-overlay: 6.0.9
       react-refresh: 0.9.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/runtime-service-worker/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-9jV+RwVEeDUI5+eLy8j1tapTNoHHGOY2+JUprcObQkQ8fux7KltQBJWFhpkUdGtz5LTCNXtj9tdycFtS5lmSzg==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/runtime-service-worker/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-nVlknGw5J5Bkd1Wr1TbyWHhUd9CmVVebaRg/lpfVKYhAuE/2r+3N0+J8qbEIgtTRcHaSV7wTNpg4weSWq46VeA==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
-      '@parcel/utils': 2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@parcel/core'
@@ -4889,19 +5001,19 @@ packages:
       detect-libc: 1.0.3
     dev: false
 
-  /@parcel/transformer-js/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-uhXAMTjE/Q61amflV8qVpb73mj+mIdXIMH0cSks1/gDIAxcgIvWvrE14P4TvY6zJ1q1iRJRIRUN6cFSXqjjLSA==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/transformer-js/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-4v2r3EVdMKowBziVBW9HZqvAv88HaeiezkWyMX4wAfplo9jBtWEp99KEQINzSEdbXROR81M9oJjlGF5+yoVr/w==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     peerDependencies:
-      '@parcel/core': ^2.6.2
+      '@parcel/core': ^2.6.0
     dependencies:
-      '@parcel/core': 2.6.2
-      '@parcel/diagnostic': 2.6.2
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/core': 2.6.0
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
       '@parcel/source-map': 2.1.0
-      '@parcel/utils': 2.6.2
-      '@parcel/workers': 2.6.2_@parcel+core@2.6.2
-      '@swc/helpers': 0.4.3
+      '@parcel/utils': 2.6.0
+      '@parcel/workers': 2.6.0_@parcel+core@2.6.0
+      '@swc/helpers': 0.3.17
       browserslist: 4.21.2
       detect-libc: 1.0.3
       nullthrows: 1.1.1
@@ -4909,48 +5021,87 @@ packages:
       semver: 5.7.1
     dev: false
 
-  /@parcel/transformer-json/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-QGcIIvbPF/u10ihYvQhxXqb2QMXWSzcBxJrOSIXIl74TUGrWX05D5LmjDA/rzm/n/kvRnBkFNP60R/smYb8x+Q==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/transformer-json/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-zb+TQAdHWdXijKcFhLe+5KN1O0IzXwW1gJhPr8DJEA3qhPaCsncsw5RCVjQlP3a7NXr1mMm1eMtO6bhIMqbXeA==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
       json5: 2.2.1
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/transformer-raw/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-CsofYq5g9Zj/FNmhya2R7Xp3WHlzz34mEdN69bds3azRYHCrl/TS33xXcp/9J+74SEIY1Ufh552o1cM3fnSrDQ==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/transformer-raw/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-QDirlWCS/qy0DQ3WvDIAnFP52n1TJW/uWH+4PGMNnX4/M3/2UchY8xp9CN0tx4NQ4g09S8o3gLlHvNxQqZxFrQ==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/transformer-react-refresh-wrap/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-7EE68ebISz+oAHm64ZJbz6uJQT4aOoB8QiK3PvuY6+RsP7aK4/FEHGM1afW49KrZbP4lWjloEkcJm/88DfBiGw==}
-    engines: {node: '>= 12.0.0', parcel: ^2.6.2}
+  /@parcel/transformer-react-refresh-wrap/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-G34orfvLDUTumuerqNmA8T8NUHk+R0jwUjbVPO7gpB6VCVQ5ocTABdE9vN9Uu/cUsHij40TUFwqK4R9TFEBIEQ==}
+    engines: {node: '>= 12.0.0', parcel: ^2.6.0}
     dependencies:
-      '@parcel/plugin': 2.6.2_@parcel+core@2.6.2
-      '@parcel/utils': 2.6.2
+      '@parcel/plugin': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
       react-refresh: 0.9.0
     transitivePeerDependencies:
       - '@parcel/core'
     dev: false
 
-  /@parcel/types/2.6.2_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-MV8BFpCIs2jMUvK2RHqzkoiuOQ//JIbrD1zocA2YRW3zuPL/iABvbAABJoXpoPCKikVWOoCWASgBfWQo26VvJQ==}
+  /@parcel/types/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-lAMYvOBfNEJMsPJ+plbB50305o0TwNrY1xX5RRIWBqwOa6bYmbW1ZljUk1tQvnkpIE4eAHQwnPR5Z2XWg18wGQ==}
     dependencies:
-      '@parcel/cache': 2.6.2_@parcel+core@2.6.2
-      '@parcel/diagnostic': 2.6.2
-      '@parcel/fs': 2.6.2_@parcel+core@2.6.2
-      '@parcel/package-manager': 2.6.2_@parcel+core@2.6.2
+      '@parcel/cache': 2.6.0_@parcel+core@2.6.0
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/fs': 2.6.0_@parcel+core@2.6.0
+      '@parcel/package-manager': 2.6.0_@parcel+core@2.6.0
       '@parcel/source-map': 2.1.0
-      '@parcel/workers': 2.6.2_@parcel+core@2.6.2
+      '@parcel/workers': 2.6.0_@parcel+core@2.6.0
       utility-types: 3.10.0
     transitivePeerDependencies:
       - '@parcel/core'
+    dev: false
+
+  /@parcel/types/2.6.2:
+    resolution: {integrity: sha512-MV8BFpCIs2jMUvK2RHqzkoiuOQ//JIbrD1zocA2YRW3zuPL/iABvbAABJoXpoPCKikVWOoCWASgBfWQo26VvJQ==}
+    dependencies:
+      '@parcel/cache': 2.6.2_@parcel+core@2.6.0
+      '@parcel/diagnostic': 2.6.2
+      '@parcel/fs': 2.6.2_@parcel+core@2.6.0
+      '@parcel/package-manager': 2.6.2_@parcel+core@2.6.0
+      '@parcel/source-map': 2.1.0
+      '@parcel/workers': 2.6.2_@parcel+core@2.6.0
+      utility-types: 3.10.0
+    dev: false
+
+  /@parcel/types/2.6.2_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-MV8BFpCIs2jMUvK2RHqzkoiuOQ//JIbrD1zocA2YRW3zuPL/iABvbAABJoXpoPCKikVWOoCWASgBfWQo26VvJQ==}
+    dependencies:
+      '@parcel/cache': 2.6.2_@parcel+core@2.6.0
+      '@parcel/diagnostic': 2.6.2
+      '@parcel/fs': 2.6.2_@parcel+core@2.6.0
+      '@parcel/package-manager': 2.6.2_@parcel+core@2.6.0
+      '@parcel/source-map': 2.1.0
+      '@parcel/workers': 2.6.2_@parcel+core@2.6.0
+      utility-types: 3.10.0
+    transitivePeerDependencies:
+      - '@parcel/core'
+    dev: false
+
+  /@parcel/utils/2.6.0:
+    resolution: {integrity: sha512-ElXz+QHtT1JQIucbQJBk7SzAGoOlBp4yodEQVvTKS7GA+hEGrSP/cmibl6qm29Rjtd0zgQsdd+2XmP3xvP2gQQ==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      '@parcel/codeframe': 2.6.0
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/hash': 2.6.0
+      '@parcel/logger': 2.6.0
+      '@parcel/markdown-ansi': 2.6.0
+      '@parcel/source-map': 2.1.0
+      chalk: 4.1.2
     dev: false
 
   /@parcel/utils/2.6.2:
@@ -4975,16 +5126,31 @@ packages:
       node-gyp-build: 4.5.0
     dev: false
 
-  /@parcel/workers/2.6.2_@parcel+core@2.6.2:
+  /@parcel/workers/2.6.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-3tcI2LF5fd/WZtSnSjyWdDE+G+FitdNrRgSObzSp+axHKMAM23sO0z7KY8s2SYCF40msdYbFUW8eI6JlYNJoWQ==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@parcel/core': ^2.6.0
+    dependencies:
+      '@parcel/core': 2.6.0
+      '@parcel/diagnostic': 2.6.0
+      '@parcel/logger': 2.6.0
+      '@parcel/types': 2.6.0_@parcel+core@2.6.0
+      '@parcel/utils': 2.6.0
+      chrome-trace-event: 1.0.3
+      nullthrows: 1.1.1
+    dev: false
+
+  /@parcel/workers/2.6.2_@parcel+core@2.6.0:
     resolution: {integrity: sha512-wBgUjJQm+lDd12fPRUmk09+ujTA9DgwPdqylSFK0OtI/yT6A+2kArUqjp8IwWo2tCJXoMzXBne2XQIWKqMiN4Q==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
       '@parcel/core': ^2.6.2
     dependencies:
-      '@parcel/core': 2.6.2
+      '@parcel/core': 2.6.0
       '@parcel/diagnostic': 2.6.2
       '@parcel/logger': 2.6.2
-      '@parcel/types': 2.6.2_@parcel+core@2.6.2
+      '@parcel/types': 2.6.2
       '@parcel/utils': 2.6.2
       chrome-trace-event: 1.0.3
       nullthrows: 1.1.1
@@ -5304,6 +5470,12 @@ packages:
       - supports-color
     dev: false
 
+  /@swc/helpers/0.3.17:
+    resolution: {integrity: sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
   /@swc/helpers/0.4.3:
     resolution: {integrity: sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==}
     dependencies:
@@ -5506,7 +5678,7 @@ packages:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
       '@types/eslint': 8.4.5
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.0
 
   /@types/eslint/7.29.0:
     resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==}
@@ -5530,7 +5702,6 @@ packages:
 
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
-    dev: false
 
   /@types/express-serve-static-core/4.17.29:
     resolution: {integrity: sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==}
@@ -5557,7 +5728,7 @@ packages:
     resolution: {integrity: sha512-ATA/xrS7CZ3A2WCPVY4eKdNpybq56zqlTirnHhhyOztZM/lPxJzusOBI3BsaXbu6FrUluqzvMlI4sZ6BDYMlMg==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 8.10.66
+      '@types/node': 18.0.6
     dev: false
 
   /@types/graceful-fs/4.1.5:
@@ -5665,7 +5836,7 @@ packages:
   /@types/mkdirp/0.5.2:
     resolution: {integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==}
     dependencies:
-      '@types/node': 8.10.66
+      '@types/node': 18.0.6
     dev: false
 
   /@types/ms/0.7.31:
@@ -5784,7 +5955,7 @@ packages:
     resolution: {integrity: sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==}
     dependencies:
       '@types/glob': 5.0.37
-      '@types/node': 8.10.66
+      '@types/node': 18.0.6
     dev: false
 
   /@types/sax/1.2.4:
@@ -6828,7 +6999,7 @@ packages:
   /axios/0.21.4_debug@3.2.7:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@3.2.7
     transitivePeerDependencies:
       - debug
     dev: false
@@ -6990,7 +7161,7 @@ packages:
       - supports-color
     dev: false
 
-  /babel-plugin-remove-graphql-queries/4.19.0_qvon4txjf2727hjzz6ajurh3i4:
+  /babel-plugin-remove-graphql-queries/4.19.0_gyeymhzov6ff6xm7r6vzudztmu:
     resolution: {integrity: sha512-VbxC7aZxdqQA0YiAcTD/djIW+6PP/JVODlRmCiqDyTbtI0zhE/Z6je1maCmC6J2LLBsKxhWT3UYTjRfLofK7sQ==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -6999,7 +7170,7 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/runtime': 7.18.9
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
     dev: false
 
@@ -10815,6 +10986,18 @@ packages:
         optional: true
     dev: false
 
+  /follow-redirects/1.15.1_debug@3.2.7:
+    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 3.2.7
+    dev: false
+
   /for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
@@ -11132,33 +11315,33 @@ packages:
       micromatch: 4.0.5
     dev: false
 
-  /gatsby-parcel-config/0.10.1_@parcel+core@2.6.2:
-    resolution: {integrity: sha512-KY/HgjOKY6LmG78zLATzz/xOMezPfyGeYpwg7YwmCJq+uIEZXlsSFku4uPbFSn9TM7fHNNjojqlPqAwoGjpn7A==}
+  /gatsby-parcel-config/0.7.0_@parcel+core@2.6.0:
+    resolution: {integrity: sha512-M4syRbthB0qA6IwRwHz4kGB/zSrMUvkDGWTK3nmmdfRtX+U7JITE2e1Le1IU54f1r/uaotLqH3T/e5j6tEb2sg==}
     engines: {parcel: 2.x}
     peerDependencies:
-      '@parcel/core': ^2.0.0
+      '@parcel/core': 2.6.0
     dependencies:
-      '@gatsbyjs/parcel-namer-relative-to-cwd': 1.4.0_@parcel+core@2.6.2
-      '@parcel/bundler-default': 2.6.2_@parcel+core@2.6.2
-      '@parcel/compressor-raw': 2.6.2_@parcel+core@2.6.2
-      '@parcel/core': 2.6.2
-      '@parcel/namer-default': 2.6.2_@parcel+core@2.6.2
-      '@parcel/optimizer-terser': 2.6.2_@parcel+core@2.6.2
-      '@parcel/packager-js': 2.6.2_@parcel+core@2.6.2
-      '@parcel/packager-raw': 2.6.2_@parcel+core@2.6.2
-      '@parcel/reporter-dev-server': 2.6.2_@parcel+core@2.6.2
-      '@parcel/resolver-default': 2.6.2_@parcel+core@2.6.2
-      '@parcel/runtime-browser-hmr': 2.6.2_@parcel+core@2.6.2
-      '@parcel/runtime-js': 2.6.2_@parcel+core@2.6.2
-      '@parcel/runtime-react-refresh': 2.6.2_@parcel+core@2.6.2
-      '@parcel/runtime-service-worker': 2.6.2_@parcel+core@2.6.2
-      '@parcel/transformer-js': 2.6.2_@parcel+core@2.6.2
-      '@parcel/transformer-json': 2.6.2_@parcel+core@2.6.2
-      '@parcel/transformer-raw': 2.6.2_@parcel+core@2.6.2
-      '@parcel/transformer-react-refresh-wrap': 2.6.2_@parcel+core@2.6.2
+      '@gatsbyjs/parcel-namer-relative-to-cwd': 1.4.0_@parcel+core@2.6.0
+      '@parcel/bundler-default': 2.6.0_@parcel+core@2.6.0
+      '@parcel/compressor-raw': 2.6.0_@parcel+core@2.6.0
+      '@parcel/core': 2.6.0
+      '@parcel/namer-default': 2.6.0_@parcel+core@2.6.0
+      '@parcel/optimizer-terser': 2.6.0_@parcel+core@2.6.0
+      '@parcel/packager-js': 2.6.0_@parcel+core@2.6.0
+      '@parcel/packager-raw': 2.6.0_@parcel+core@2.6.0
+      '@parcel/reporter-dev-server': 2.6.0_@parcel+core@2.6.0
+      '@parcel/resolver-default': 2.6.0_@parcel+core@2.6.0
+      '@parcel/runtime-browser-hmr': 2.6.0_@parcel+core@2.6.0
+      '@parcel/runtime-js': 2.6.0_@parcel+core@2.6.0
+      '@parcel/runtime-react-refresh': 2.6.0_@parcel+core@2.6.0
+      '@parcel/runtime-service-worker': 2.6.0_@parcel+core@2.6.0
+      '@parcel/transformer-js': 2.6.0_@parcel+core@2.6.0
+      '@parcel/transformer-json': 2.6.0_@parcel+core@2.6.0
+      '@parcel/transformer-raw': 2.6.0_@parcel+core@2.6.0
+      '@parcel/transformer-react-refresh-wrap': 2.6.0_@parcel+core@2.6.0
     dev: false
 
-  /gatsby-plugin-catch-links/4.19.0_gatsby@4.19.0:
+  /gatsby-plugin-catch-links/4.19.0_gatsby@4.16.0:
     resolution: {integrity: sha512-3eRRobMRRQr/NPvdZt3zPXJEwgw5mRZ8XirnABdryyCOOZZW7+Vk+ejB8S4FdX7Qt/4M2zJM+MjOiT4M4iQnKw==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11166,10 +11349,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.9
       escape-string-regexp: 1.0.5
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
     dev: false
 
-  /gatsby-plugin-image/2.19.0_qwbuxo3wnzxmpnnrnvhkaesqeq:
+  /gatsby-plugin-image/2.19.0_irnutnl6v3bbcvna4tonbxmq5e:
     resolution: {integrity: sha512-Eu2LY1nfkTdr5hJip5TcZNUqzWQps2Zq4KnPJmgmxpGOYIbrgu8B2kEKQM5hKoe5flu4Xu5gj+CObEMlBj5K1w==}
     peerDependencies:
       '@babel/core': ^7.12.3
@@ -11185,16 +11368,16 @@ packages:
       '@babel/runtime': 7.18.9
       '@babel/traverse': 7.18.9
       babel-jsx-utils: 1.1.0
-      babel-plugin-remove-graphql-queries: 4.19.0_qvon4txjf2727hjzz6ajurh3i4
+      babel-plugin-remove-graphql-queries: 4.19.0_gyeymhzov6ff6xm7r6vzudztmu
       camelcase: 5.3.1
       chokidar: 3.5.3
       common-tags: 1.8.2
       fs-extra: 10.1.0
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
-      gatsby-plugin-sharp: 4.19.0_7efqbrr4vh2unksygyphdu66x4
-      gatsby-plugin-utils: 3.13.0_7efqbrr4vh2unksygyphdu66x4
-      gatsby-source-filesystem: 4.19.0_gatsby@4.19.0
+      gatsby-plugin-sharp: 4.19.0_sjhkp6oelwtnvf6k6r5hdxorme
+      gatsby-plugin-utils: 3.13.0_sjhkp6oelwtnvf6k6r5hdxorme
+      gatsby-source-filesystem: 4.19.0_gatsby@4.16.0
       objectFitPolyfill: 2.3.5
       prop-types: 15.8.1
       react: 17.0.2
@@ -11204,23 +11387,23 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby-plugin-manifest/4.19.0_7efqbrr4vh2unksygyphdu66x4:
+  /gatsby-plugin-manifest/4.19.0_sjhkp6oelwtnvf6k6r5hdxorme:
     resolution: {integrity: sha512-BsZDMAUraTGff3VSSRmLkR13DDQWD8WUQ7qdXb8DCDI0Hc0/eOg+9JnxruHElBjH1BcfCppSiFTA27AmEzTcoA==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       gatsby: ^4.0.0-next
     dependencies:
       '@babel/runtime': 7.18.9
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
-      gatsby-plugin-utils: 3.13.0_7efqbrr4vh2unksygyphdu66x4
+      gatsby-plugin-utils: 3.13.0_sjhkp6oelwtnvf6k6r5hdxorme
       semver: 7.3.7
       sharp: 0.30.7
     transitivePeerDependencies:
       - graphql
     dev: false
 
-  /gatsby-plugin-offline/5.19.0_6vqsztrjusvurd6jpraufykpam:
+  /gatsby-plugin-offline/5.19.0_ob3apgrvd3skfbxsyruw7t3jci:
     resolution: {integrity: sha512-bTouKG26tqlKMCc8q9Fq3+agSv1gO7raEVdjhmtWrbLMPK1RKUv8alOnNc0inMCT/so+vSb7VBKRz0nQSv+O8A==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11230,7 +11413,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.9
       cheerio: 1.0.0-rc.12
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
       glob: 7.2.3
       idb-keyval: 3.2.0
@@ -11240,7 +11423,7 @@ packages:
       workbox-build: 4.3.1
     dev: false
 
-  /gatsby-plugin-page-creator/4.19.0_mcfju4g6ncza7p4byhulqkmpiu:
+  /gatsby-plugin-page-creator/4.19.0_m66goaehpuyykdei3jqy2zmdj4:
     resolution: {integrity: sha512-JGclCb2lniTjBdFzoiF0Px9EhVY/3uiWx7mqnvfdVO85VVey5+eCKL60Aqamjovo6C+l/0Uldt4uT1EpNLC3Xw==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11251,10 +11434,10 @@ packages:
       '@sindresorhus/slugify': 1.1.2
       chokidar: 3.5.3
       fs-exists-cached: 1.0.0
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
       gatsby-page-utils: 2.19.0
-      gatsby-plugin-utils: 3.13.0_mcfju4g6ncza7p4byhulqkmpiu
+      gatsby-plugin-utils: 3.13.0_m66goaehpuyykdei3jqy2zmdj4
       gatsby-telemetry: 3.19.0
       globby: 11.1.0
       lodash: 4.17.21
@@ -11264,17 +11447,17 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby-plugin-pnpm/1.2.10_gatsby@4.19.0:
+  /gatsby-plugin-pnpm/1.2.10_gatsby@4.16.0:
     resolution: {integrity: sha512-29xjIakNEUY42OBb3wI9Thmawr5EcUUOB3dB8nE51yr/TfKQFCREk+HAOATQHTNedG3VZhgU4wVjl2V3wgOXJA==}
     peerDependencies:
       gatsby: ~2.x.x || ~3.x.x || ~4.x.x
     dependencies:
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       lodash.get: 4.4.2
       lodash.uniq: 4.5.0
     dev: false
 
-  /gatsby-plugin-postcss/5.19.0_77mdcgnegxo4wdozsdnqm3xwo4:
+  /gatsby-plugin-postcss/5.19.0_ykmjhnntseh5olbmw5qtp3f2iu:
     resolution: {integrity: sha512-oBoZSbteJihFD4Pj1xFhlkzVXZ2AqXjQwVosoBMQa/lSBnd34cboNpZlbhVTAi8RrffNnAVfPlo4ul8liTrsvw==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11282,14 +11465,14 @@ packages:
       postcss: ^8.0.5
     dependencies:
       '@babel/runtime': 7.18.9
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       postcss: 8.4.14
       postcss-loader: 4.3.0_mepnsno3xmng6eyses4tepu7bu
     transitivePeerDependencies:
       - webpack
     dev: false
 
-  /gatsby-plugin-react-helmet/5.19.0_yvh7r7ycpdu4toihqykndbyhmy:
+  /gatsby-plugin-react-helmet/5.19.0_22qjo53tgtuqoiupcchhqtqqsm:
     resolution: {integrity: sha512-XXrJYfHqoaUe57oAF+/ljPHncrvYk0UonES3aUwynbWsR8UXhQpdbwqIOYZPGQgPsc1X55Kzdo+/3pU1gA9ajQ==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11297,11 +11480,11 @@ packages:
       react-helmet: ^5.1.3 || ^6.0.0
     dependencies:
       '@babel/runtime': 7.18.9
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       react-helmet: 6.1.0_react@17.0.2
     dev: false
 
-  /gatsby-plugin-sharp/4.19.0_7efqbrr4vh2unksygyphdu66x4:
+  /gatsby-plugin-sharp/4.19.0_sjhkp6oelwtnvf6k6r5hdxorme:
     resolution: {integrity: sha512-2wIxbCoJmZMeCw+V9ht90tmwoSF2eaEKj6j5QMLe+NlLpLOXwmsHjrauMpqd8ILmcKpZTOJr9yEplzbjxlD36A==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11314,9 +11497,9 @@ packages:
       debug: 4.3.4
       filenamify: 4.3.0
       fs-extra: 10.1.0
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
-      gatsby-plugin-utils: 3.13.0_7efqbrr4vh2unksygyphdu66x4
+      gatsby-plugin-utils: 3.13.0_sjhkp6oelwtnvf6k6r5hdxorme
       gatsby-telemetry: 3.19.0
       got: 11.8.5
       lodash: 4.17.21
@@ -11332,7 +11515,7 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby-plugin-typescript/4.19.0_gatsby@4.19.0:
+  /gatsby-plugin-typescript/4.19.0_gatsby@4.16.0:
     resolution: {integrity: sha512-f+aC4g/pTkUqFLTHo3OLdPQgdIFcEdoM5i8H4Pph5O4rmFXYHkkQKimRJmAz9cBb6/1wN7IBqI9m4k3AefaAjA==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11344,13 +11527,13 @@ packages:
       '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.18.9
       '@babel/preset-typescript': 7.18.6_@babel+core@7.18.9
       '@babel/runtime': 7.18.9
-      babel-plugin-remove-graphql-queries: 4.19.0_qvon4txjf2727hjzz6ajurh3i4
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      babel-plugin-remove-graphql-queries: 4.19.0_gyeymhzov6ff6xm7r6vzudztmu
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /gatsby-plugin-utils/3.13.0_7efqbrr4vh2unksygyphdu66x4:
+  /gatsby-plugin-utils/3.13.0_m66goaehpuyykdei3jqy2zmdj4:
     resolution: {integrity: sha512-iFFWswld/Nu8IrSCikZXC4/cud9txv3ikjkQiGLccJStS9VH2rSY4XEMNRqsKN9Spe3pFBOr/97yYUaPhZaQWg==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11359,10 +11542,10 @@ packages:
       '@babel/runtime': 7.18.9
       '@gatsbyjs/potrace': 2.2.0
       fs-extra: 10.1.0
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
       gatsby-sharp: 0.13.0
-      graphql-compose: 9.0.8_graphql@16.5.0
+      graphql-compose: 9.0.8_graphql@15.8.0
       import-from: 4.0.0
       joi: 17.6.0
       mime: 3.0.0
@@ -11372,7 +11555,7 @@ packages:
       - graphql
     dev: false
 
-  /gatsby-plugin-utils/3.13.0_mcfju4g6ncza7p4byhulqkmpiu:
+  /gatsby-plugin-utils/3.13.0_sjhkp6oelwtnvf6k6r5hdxorme:
     resolution: {integrity: sha512-iFFWswld/Nu8IrSCikZXC4/cud9txv3ikjkQiGLccJStS9VH2rSY4XEMNRqsKN9Spe3pFBOr/97yYUaPhZaQWg==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11381,10 +11564,10 @@ packages:
       '@babel/runtime': 7.18.9
       '@gatsbyjs/potrace': 2.2.0
       fs-extra: 10.1.0
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
       gatsby-sharp: 0.13.0
-      graphql-compose: 9.0.8_graphql@15.8.0
+      graphql-compose: 9.0.8_graphql@16.5.0
       import-from: 4.0.0
       joi: 17.6.0
       mime: 3.0.0
@@ -11420,6 +11603,16 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /gatsby-sharp/0.10.0:
+    resolution: {integrity: sha512-Wvtl5wfQJw7NDWI9J/xDhew1dXnI/MgkvHwrSulT00GgtTmBc7knplapfdU1E2k8PwpssqEBqWXvrxMszT5oWg==}
+    engines: {node: '>=14.15.0'}
+    requiresBuild: true
+    dependencies:
+      '@types/sharp': 0.30.4
+      sharp: 0.30.7
+    dev: false
+    optional: true
+
   /gatsby-sharp/0.13.0:
     resolution: {integrity: sha512-dGuIuWP3rC7hXl/CgkHEY4WQEW+B9Rsg8uo6u+OumuLnLBxD4vTusEIGctVKzlyIxpENEQylQ7w1JKHX9fOy9g==}
     engines: {node: '>=14.15.0'}
@@ -11428,7 +11621,7 @@ packages:
       sharp: 0.30.7
     dev: false
 
-  /gatsby-source-filesystem/4.19.0_gatsby@4.19.0:
+  /gatsby-source-filesystem/4.19.0_gatsby@4.16.0:
     resolution: {integrity: sha512-UUBEqRCKpq/rWX5K8Kizmoi2Cls9oOTEtZRUrhdtMqpz5Y6VAmd7Pwina03r0fej+AoebZWOEzPTOh+WhpIDFw==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11438,7 +11631,7 @@ packages:
       chokidar: 3.5.3
       file-type: 16.5.4
       fs-extra: 10.1.0
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
       got: 12.1.0
       md5-file: 5.0.0
@@ -11449,7 +11642,7 @@ packages:
       xstate: 4.32.1
     dev: false
 
-  /gatsby-source-wordpress/6.19.0_qesxhqernuepzfhyc2fdhg3lyy:
+  /gatsby-source-wordpress/6.19.0_iauurw47l477pmne3ttx2ckxj4:
     resolution: {integrity: sha512-z+YyXVmVrK0rI+54hFG+RSSSP2ndhUKBRjhj29iMP8TSyhLz54s3/3Uvp16KfZOnhRWo4MDUsfz0EA+OY2bNdQ==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11478,14 +11671,14 @@ packages:
       file-type: 16.5.4
       filesize: 6.4.0
       fs-extra: 10.1.0
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-core-utils: 3.19.0
-      gatsby-plugin-catch-links: 4.19.0_gatsby@4.19.0
-      gatsby-plugin-image: 2.19.0_qwbuxo3wnzxmpnnrnvhkaesqeq
-      gatsby-plugin-sharp: 4.19.0_7efqbrr4vh2unksygyphdu66x4
-      gatsby-plugin-utils: 3.13.0_7efqbrr4vh2unksygyphdu66x4
-      gatsby-source-filesystem: 4.19.0_gatsby@4.19.0
-      gatsby-transformer-sharp: 4.19.0_62ownqrbb7ezkbmnvfnjupyvqe
+      gatsby-plugin-catch-links: 4.19.0_gatsby@4.16.0
+      gatsby-plugin-image: 2.19.0_irnutnl6v3bbcvna4tonbxmq5e
+      gatsby-plugin-sharp: 4.19.0_sjhkp6oelwtnvf6k6r5hdxorme
+      gatsby-plugin-utils: 3.13.0_sjhkp6oelwtnvf6k6r5hdxorme
+      gatsby-source-filesystem: 4.19.0_gatsby@4.16.0
+      gatsby-transformer-sharp: 4.19.0_6lheiiduvv6xb77anns5jgq4eu
       glob: 7.2.3
       got: 11.8.5
       lodash: 4.17.21
@@ -11525,7 +11718,7 @@ packages:
       - encoding
     dev: false
 
-  /gatsby-transformer-sharp/4.19.0_62ownqrbb7ezkbmnvfnjupyvqe:
+  /gatsby-transformer-sharp/4.19.0_6lheiiduvv6xb77anns5jgq4eu:
     resolution: {integrity: sha512-SoY9yGNjC+C+gAfJ//+DqXGBukVKeb4HnobOmkpbugYtLGRwb4AhKOT7eqCn+AK/4+oDDB3ZNNfTUf0vRFQgzA==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -11537,9 +11730,9 @@ packages:
       bluebird: 3.7.2
       common-tags: 1.8.2
       fs-extra: 10.1.0
-      gatsby: 4.19.0_sfoxds7t5ydpegc3knd667wn6m
-      gatsby-plugin-sharp: 4.19.0_7efqbrr4vh2unksygyphdu66x4
-      gatsby-plugin-utils: 3.13.0_7efqbrr4vh2unksygyphdu66x4
+      gatsby: 4.16.0_sfoxds7t5ydpegc3knd667wn6m
+      gatsby-plugin-sharp: 4.19.0_sjhkp6oelwtnvf6k6r5hdxorme
+      gatsby-plugin-utils: 3.13.0_sjhkp6oelwtnvf6k6r5hdxorme
       probe-image-size: 7.2.3
       semver: 7.3.7
       sharp: 0.30.7
@@ -11558,8 +11751,8 @@ packages:
       - supports-color
     dev: false
 
-  /gatsby/4.19.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-Bhga6PbDRSL3J7yIcVAWwN76cK0OeFWE4f5ggh4qEjnsL20kxW+LPwAexpZ5dVxbE1gsl1k/VDSX66Wj3vGH3A==}
+  /gatsby/4.16.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-C8rmUsx8LnhtDKMOyfoXH1A27tuU+5OP/p1X0vIoOfW2pcRty5pjWRlFl/OM1BHcrdrfEXTsen30eU+S4iQG8Q==}
     engines: {node: '>=14.15.0'}
     hasBin: true
     requiresBuild: true
@@ -11587,7 +11780,7 @@ packages:
       '@graphql-tools/load': 7.7.0_graphql@15.8.0
       '@jridgewell/trace-mapping': 0.3.14
       '@nodelib/fs.walk': 1.2.8
-      '@parcel/core': 2.6.2
+      '@parcel/core': 2.6.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.3_3llpskcov67t25bxpkfgl4v274
       '@types/http-proxy': 1.17.9
       '@typescript-eslint/eslint-plugin': 4.33.0_ffi3uiz42rv3jyhs6cr7p7qqry
@@ -11601,10 +11794,11 @@ packages:
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-dynamic-import-node: 2.3.3
       babel-plugin-lodash: 3.3.4
-      babel-plugin-remove-graphql-queries: 4.19.0_qvon4txjf2727hjzz6ajurh3i4
+      babel-plugin-remove-graphql-queries: 4.19.0_gyeymhzov6ff6xm7r6vzudztmu
       babel-preset-gatsby: 2.19.0_xsr43byggyay3opejycuwch2ki
       better-opn: 2.1.1
       bluebird: 3.7.2
+      body-parser: 1.20.0
       browserslist: 4.21.2
       cache-manager: 2.11.1
       chalk: 4.1.2
@@ -11650,10 +11844,10 @@ packages:
       gatsby-legacy-polyfills: 2.19.0
       gatsby-link: 4.19.1_5s5rk5n2wfvcbdepi4w5lmrtj4
       gatsby-page-utils: 2.19.0
-      gatsby-parcel-config: 0.10.1_@parcel+core@2.6.2
-      gatsby-plugin-page-creator: 4.19.0_mcfju4g6ncza7p4byhulqkmpiu
-      gatsby-plugin-typescript: 4.19.0_gatsby@4.19.0
-      gatsby-plugin-utils: 3.13.0_mcfju4g6ncza7p4byhulqkmpiu
+      gatsby-parcel-config: 0.7.0_@parcel+core@2.6.0
+      gatsby-plugin-page-creator: 4.19.0_m66goaehpuyykdei3jqy2zmdj4
+      gatsby-plugin-typescript: 4.19.0_gatsby@4.16.0
+      gatsby-plugin-utils: 3.13.0_m66goaehpuyykdei3jqy2zmdj4
       gatsby-react-router-scroll: 5.19.0_5s5rk5n2wfvcbdepi4w5lmrtj4
       gatsby-script: 1.4.0_sfoxds7t5ydpegc3knd667wn6m
       gatsby-telemetry: 3.19.0
@@ -11665,13 +11859,14 @@ packages:
       graphql-compose: 9.0.8_graphql@15.8.0
       graphql-playground-middleware-express: 1.7.23_express@4.18.1
       hasha: 5.2.2
+      http-proxy: 1.18.1_debug@3.2.7
       invariant: 2.2.4
       is-relative: 1.0.0
       is-relative-url: 3.0.0
       joi: 17.6.0
       json-loader: 0.5.7
       latest-version: 5.1.0
-      lmdb: 2.5.3
+      lmdb: 2.3.10
       lodash: 4.17.21
       md5-file: 5.0.0
       meant: 1.0.3
@@ -11683,7 +11878,6 @@ packages:
       moment: 2.29.4
       multer: 1.4.4
       node-fetch: 2.6.7
-      node-html-parser: 5.3.3
       normalize-path: 3.0.0
       null-loader: 4.0.1_webpack@5.73.0
       opentracing: 0.14.7
@@ -11711,6 +11905,7 @@ packages:
       slugify: 1.6.5
       socket.io: 3.1.2
       socket.io-client: 3.1.3
+      source-map-support: 0.5.21
       st: 2.0.0
       stack-trace: 0.0.10
       string-similarity: 1.2.2
@@ -11730,7 +11925,7 @@ packages:
       xstate: 4.32.1
       yaml-loader: 0.6.0
     optionalDependencies:
-      gatsby-sharp: 0.13.0
+      gatsby-sharp: 0.10.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/node'
@@ -12506,7 +12701,18 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@3.2.7
+      requires-port: 1.0.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /http-proxy/1.18.1_debug@3.2.7:
+    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.15.1_debug@3.2.7
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -14010,6 +14216,73 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
+  /lmdb-darwin-arm64/2.3.10:
+    resolution: {integrity: sha512-LVXbH2MYu7/ZuQ8+P9rv+SwNyBKltxo7vHAGJS94HWyfwnCbKEYER9PImBvNBwzvgtaYk6x0RMX3oor6e6KdDQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lmdb-darwin-x64/2.3.10:
+    resolution: {integrity: sha512-gAc/1b/FZOb9yVOT+o0huA+hdW82oxLo5r22dFTLoRUFG1JMzxdTjmnW6ONVOHdqC9a5bt3vBCEY3jmXNqV26A==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lmdb-linux-arm/2.3.10:
+    resolution: {integrity: sha512-Rb8+4JjsThuEcJ7GLLwFkCFnoiwv/3hAAbELWITz70buQFF+dCZvCWWgEgmDTxwn5r+wIkdUjmFv4dqqiKQFmQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lmdb-linux-arm64/2.3.10:
+    resolution: {integrity: sha512-Ihr8mdICTK3jA4GXHxrXGK2oekn0mY6zuDSXQDNtyRSH19j3D2Y04A7SEI9S0EP/t5sjKSudYgZbiHDxRCsI5A==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lmdb-linux-x64/2.3.10:
+    resolution: {integrity: sha512-E3l3pDiCA9uvnLf+t3qkmBGRO01dp1EHD0x0g0iRnfpAhV7wYbayJGfG93BUt22Tj3fnq4HDo4dQ6ZWaDI1nuw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lmdb-win32-x64/2.3.10:
+    resolution: {integrity: sha512-gspWk34tDANhjn+brdqZstJMptGiwj4qFNVg0Zey9ds+BUlif+Lgf5szrfOVzZ8gVRkk1Lgbz7i78+V7YK7SCA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /lmdb/2.3.10:
+    resolution: {integrity: sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==}
+    requiresBuild: true
+    dependencies:
+      msgpackr: 1.6.1
+      nan: 2.16.0
+      node-addon-api: 4.3.0
+      node-gyp-build-optional-packages: 4.3.5
+      ordered-binary: 1.3.0
+      weak-lru-cache: 1.2.2
+    optionalDependencies:
+      lmdb-darwin-arm64: 2.3.10
+      lmdb-darwin-x64: 2.3.10
+      lmdb-linux-arm: 2.3.10
+      lmdb-linux-arm64: 2.3.10
+      lmdb-linux-x64: 2.3.10
+      lmdb-win32-x64: 2.3.10
+    dev: false
+
   /lmdb/2.5.2:
     resolution: {integrity: sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==}
     requiresBuild: true
@@ -14788,6 +15061,10 @@ packages:
   /mute-stream/0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
+  /nan/2.16.0:
+    resolution: {integrity: sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==}
+    dev: false
+
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -14999,6 +15276,11 @@ packages:
     engines: {node: '>= 6.13.0'}
     dev: false
 
+  /node-gyp-build-optional-packages/4.3.5:
+    resolution: {integrity: sha512-5ke7D8SiQsTQL7CkHpfR1tLwfqtKc0KYEmlnkwd40jHCASskZeS98qoZ1qDUns2aUQWikcjidRUs6PM/3iyN/w==}
+    hasBin: true
+    dev: false
+
   /node-gyp-build-optional-packages/5.0.2:
     resolution: {integrity: sha512-PiN4NWmlQPqvbEFcH/omQsswWQbe5Z9YK/zdB23irp5j2XibaA2IrGvpSWmVVG4qMZdmPdwPctSy4a86rOMn6g==}
     hasBin: true
@@ -15013,13 +15295,6 @@ packages:
   /node-gyp-build/4.5.0:
     resolution: {integrity: sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==}
     hasBin: true
-    dev: false
-
-  /node-html-parser/5.3.3:
-    resolution: {integrity: sha512-ncg1033CaX9UexbyA7e1N0aAoAYRDiV8jkTvzEnfd1GDvzFdrsXLzR4p4ik8mwLgnaKP/jyUFWDy9q3jvRT2Jw==}
-    dependencies:
-      css-select: 4.3.0
-      he: 1.2.0
     dev: false
 
   /node-int64/0.4.0:
@@ -16512,7 +16787,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      address: 1.1.2
+      address: 1.2.0
       browserslist: 4.21.2
       chalk: 4.1.2
       cross-spawn: 7.0.3
@@ -18595,7 +18870,7 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /ts-jest/27.1.5_jm6546ohpm4h5jsgaz4ra4shga:
+  /ts-jest/27.1.5_mqaoisgizytgigbr3gbjwvnjie:
     resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -18618,7 +18893,6 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.18.9
       '@types/jest': 27.5.2
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0

--- a/starters/gatsby-wordpress-starter/package-lock.json
+++ b/starters/gatsby-wordpress-starter/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@tailwindcss/typography": "^0.5.2",
         "autoprefixer": "^10.4.4",
-        "gatsby": "^4.16.0",
+        "gatsby": "4.16.0",
         "gatsby-plugin-image": "^2.12.1",
         "gatsby-plugin-manifest": "^4.12.1",
         "gatsby-plugin-offline": "^5.12.1",
@@ -1986,20 +1986,452 @@
       }
     },
     "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-1.2.0.tgz",
-      "integrity": "sha512-4iIdquFDl+b+U8Ng0dg6dCtxB/cnH27ERrlQQlxfdaWe8e9CLo8aWc6u3UeuHwNJixBFOUbOgEFaA5qCUPwLCQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-1.4.0.tgz",
+      "integrity": "sha512-oXhiaPtYTGYqGZlazYRUabWVHWx5z6sAyBVLhUnpsKcBsK815cET+mjeWDKpmvJmFTKHC72Bvy1WIEnW3++YxA==",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
-        "@parcel/plugin": "2.6.0",
-        "gatsby-core-utils": "^3.17.0"
+        "@parcel/namer-default": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "gatsby-core-utils": "^3.19.0"
       },
       "engines": {
         "node": ">=14.15.0",
         "parcel": "2.x"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/cache": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.2.tgz",
+      "integrity": "sha512-hhJ6AsEGybeQZd9c/GYqfcKTgZKQXu3Xih6TlnP3gdR3KZoJOnb40ovHD1yYg4COvfcXThKP1cVJ18J6rcv3IA==",
+      "dependencies": {
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "lmdb": "2.5.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/namer-default": "2.5.0"
+        "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/codeframe": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.2.tgz",
+      "integrity": "sha512-oFlHr6HCaYYsB4SHkU+gn9DKtbzvv3/4NdwMX0/6NAKyYVI7inEsXyPGw2Bbd2ZCFatW9QJZUETF0etvh5AEfQ==",
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.2.tgz",
+      "integrity": "sha512-JlKS3Ux0ngmdooSBbzQLShHJdsapF9E7TGMo1hFaHRquZip/DaqzvysYrgMJlDuCoLArciq5ei7ZKzGeK9zexA==",
+      "peer": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/cache": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/events": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/graph": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/package-manager": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "@parcel/source-map": "^2.0.0",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
+        "abortcontroller-polyfill": "^1.1.9",
+        "base-x": "^3.0.8",
+        "browserslist": "^4.6.6",
+        "clone": "^2.1.1",
+        "dotenv": "^7.0.0",
+        "dotenv-expand": "^5.1.0",
+        "json5": "^2.2.0",
+        "msgpackr": "^1.5.4",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/diagnostic": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.2.tgz",
+      "integrity": "sha512-3ODSBkKVihENU763z1/1DhGAWFhYWRxOCOShC72KXp+GFnSgGiBsxclu8NBa/N948Rzp8lqQI8U1nLcKkh0O/w==",
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/events": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.2.tgz",
+      "integrity": "sha512-IaCjOeA5ercdFVi1EZOmUHhGfIysmCUgc2Th9hMugSFO0I3GzRsBcAdP6XPfWm+TV6sQ/qZRfdk/drUxoAupnw==",
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/fs": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.2.tgz",
+      "integrity": "sha512-mIhqdF3tjgeoIGqW7Nc/xfM2ClID7o8livwUe5lpQEP+ZaIBiMigXs6ckv3WToCACK+3uylrSD2A/HmlhrxMqQ==",
+      "dependencies": {
+        "@parcel/fs-search": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/watcher": "^2.0.0",
+        "@parcel/workers": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/fs-search": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.2.tgz",
+      "integrity": "sha512-4STid1zqtGnmGjHD/2TG2g/zPDiCTtE3IAS24QYH3eiUAz2uoKGgEqd2tZbZ2yI96jtCuIhC1bzVu8Hbykls7w==",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/graph": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.2.tgz",
+      "integrity": "sha512-DPH4G/RBFJWayIN2fnhDXqhUw75n7k15YsGzdDKiXuwwz4wMOjoL4cyrI6zOf1SIyh3guRmeTYJ4jjPzwrLYww==",
+      "peer": true,
+      "dependencies": {
+        "@parcel/utils": "2.6.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/hash": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.2.tgz",
+      "integrity": "sha512-tFB+cJU1Wqag6WyJgsmx3nx+xhmjcNZqtWh/MtK1lHNnZdDRk6bjr7SapnygBwruz+SmSt5bbdVThcpk2dRCcA==",
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "xxhash-wasm": "^0.4.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/logger": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.2.tgz",
+      "integrity": "sha512-Sz5YGCj1DbEiX0/G8Uw97LLZ0uEK+qtWcRAkHNpJpeMiSqDiRNevxXltz42EcLo+oCh4d4wyiVzwi9mNwzhS/Q==",
+      "dependencies": {
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/events": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/markdown-ansi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.2.tgz",
+      "integrity": "sha512-N/h9J4eibhc+B+krzvPMzFUWL37GudBIZBa7XSLkcuH6MnYYfh6rrMvhIyyESwk6VkcZNVzAeZrGQqxEs0dHDQ==",
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/namer-default": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.2.tgz",
+      "integrity": "sha512-mp7bx/BQaIuohmZP0uE+gAmDBzzH0Yu8F4yCtE611lc6i0mou+nWRhzyKLNC/ieuI8DB3BFh2QQKeTxJn4W0qg==",
+      "dependencies": {
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.6.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/package-manager": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.2.tgz",
+      "integrity": "sha512-xGMqTgnwTE3rgzYwUZMKxR8fzmP5iSYz/gj2H8FR3pEmwh/8xCMtNjTSth+hPVGuqgRZ6JxwpfdY/fXdZ61ViQ==",
+      "dependencies": {
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/plugin": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.2.tgz",
+      "integrity": "sha512-wbbWsM23Pr+8xtLSvf+UopXdVYlpKCCx6PuuZaZcKo+9IcDCWoGXD4M8Kkz14qBmkFn5uM00mULUqmVdSibB2w==",
+      "dependencies": {
+        "@parcel/types": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/types": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.2.tgz",
+      "integrity": "sha512-MV8BFpCIs2jMUvK2RHqzkoiuOQ//JIbrD1zocA2YRW3zuPL/iABvbAABJoXpoPCKikVWOoCWASgBfWQo26VvJQ==",
+      "dependencies": {
+        "@parcel/cache": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/package-manager": "2.6.2",
+        "@parcel/source-map": "^2.0.0",
+        "@parcel/workers": "2.6.2",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/utils": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.2.tgz",
+      "integrity": "sha512-Ug7hpRxjgbY5AopW55nY7MmGMVmwmN+ihfCmxJkBUoESTG/3iq8uME7GjyOgW5DkQc2K7q62i8y8N0wCJT1u4Q==",
+      "dependencies": {
+        "@parcel/codeframe": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/markdown-ansi": "2.6.2",
+        "@parcel/source-map": "^2.0.0",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/workers": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.2.tgz",
+      "integrity": "sha512-wBgUjJQm+lDd12fPRUmk09+ujTA9DgwPdqylSFK0OtI/yT6A+2kArUqjp8IwWo2tCJXoMzXBne2XQIWKqMiN4Q==",
+      "dependencies": {
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/dotenv": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/lmdb": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "msgpackr": "^1.5.4",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/@gatsbyjs/potrace": {
@@ -3699,9 +4131,9 @@
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
-      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-RXwGZ/0eCqtCY8FLTM/koR60w+MXyvBUpToXiIyjOcBnC81tAlTUHrRUavCEWPI9zc9VgvpK3+cbumPyR8BSuA==",
       "cpu": [
         "arm64"
       ],
@@ -3711,9 +4143,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
-      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.3.tgz",
+      "integrity": "sha512-337dNzh5yCdNCTk8kPfoU7jR3otibSlPDGW0vKZT97rKnQMb9tNdto3RtWoGPsQ8hKmlRZpojOJtmwjncq1MoA==",
       "cpu": [
         "x64"
       ],
@@ -3723,9 +4155,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
-      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.3.tgz",
+      "integrity": "sha512-mU2HFJDGwECkoD9dHQEfeTG5mp8hNS2BCfwoiOpVPMeapjYpQz9Uw3FkUjRZ4dGHWKbin40oWHuL0bk2bCx+Sg==",
       "cpu": [
         "arm"
       ],
@@ -3735,9 +4167,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
-      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-VJw60Mdgb4n+L0fO1PqfB0C7TyEQolJAC8qpqvG3JoQwvyOv6LH7Ib/WE3wxEW9nuHmVz9jkK7lk5HfWWgoO1Q==",
       "cpu": [
         "arm64"
       ],
@@ -3747,9 +4179,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
-      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-qaReO5aV8griBDsBr8uBF/faO3ieGjY1RY4p8JvTL6Mu1ylLrTVvOONqKFlNaCwrmUjWw5jnf7VafxDAeQHTow==",
       "cpu": [
         "x64"
       ],
@@ -3759,9 +4191,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
-      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==",
       "cpu": [
         "x64"
       ],
@@ -4112,304 +4544,21 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
-      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
-      "peer": true,
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
+      "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
-      "peer": true,
-      "dependencies": {
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "lmdb": "2.2.4"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.5.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/codeframe": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
-      "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/diagnostic": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
-      "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
-      "peer": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/events": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
-      "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/fs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
-      "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
-      "peer": true,
-      "dependencies": {
-        "@parcel/fs-search": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.5.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/fs-search": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
-      "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/hash": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
-      "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "xxhash-wasm": "^0.4.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/logger": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
-      "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
-      "peer": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/markdown-ansi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
-      "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/package-manager": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
-      "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
-      "peer": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
-        "semver": "^5.7.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.5.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
-      "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
-      "peer": true,
-      "dependencies": {
-        "@parcel/types": "2.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/types": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
-      "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
-      "peer": true,
-      "dependencies": {
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.5.0",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
-      "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
-      "peer": true,
-      "dependencies": {
-        "@parcel/codeframe": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/markdown-ansi": "2.5.0",
-        "@parcel/source-map": "^2.0.0",
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/workers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
-      "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
-      "peer": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "chrome-trace-event": "^1.0.2",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.5.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/lmdb": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-      "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "msgpackr": "^1.5.4",
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3",
-        "ordered-binary": "^1.2.4",
-        "weak-lru-cache": "^1.2.2"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/@parcel/node-resolver-core": {
@@ -4505,9 +4654,9 @@
       }
     },
     "node_modules/@parcel/packager-js/node_modules/globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -4667,9 +4816,9 @@
       }
     },
     "node_modules/@parcel/source-map": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.5.tgz",
-      "integrity": "sha512-DRVlCFKLpqBSIbMxUoVlHgfiv12HTW/U7nnhzw52YgzDVXUX9OA41dXS1PU0pJ1si+D1k8msATUC+AoldN43mg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.0.tgz",
+      "integrity": "sha512-E7UOEIof2o89LrKk1agSLmwakjigmEdDp1ZaEdsLVEvq63R/bul4Ij5CT+0ZDcijGpl5tnTbQADY9EyYGtjYgQ==",
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -10626,9 +10775,9 @@
       }
     },
     "node_modules/gatsby": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.17.2.tgz",
-      "integrity": "sha512-uMNH/X/Fd0kGjelgAPTukgQhxu/aMhRj5YJ07SM4D2yBuO+c4+y1dZRz5q9EUryCeVSx1cSt0J6JMkfzOXmbyA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.16.0.tgz",
+      "integrity": "sha512-C8rmUsx8LnhtDKMOyfoXH1A27tuU+5OP/p1X0vIoOfW2pcRty5pjWRlFl/OM1BHcrdrfEXTsen30eU+S4iQG8Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.0",
@@ -10665,8 +10814,8 @@
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-lodash": "^3.3.4",
-        "babel-plugin-remove-graphql-queries": "^4.17.0",
-        "babel-preset-gatsby": "^2.17.0",
+        "babel-plugin-remove-graphql-queries": "^4.16.0",
+        "babel-preset-gatsby": "^2.16.0",
         "better-opn": "^2.1.1",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.0",
@@ -10709,20 +10858,20 @@
         "find-cache-dir": "^3.3.2",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^10.1.0",
-        "gatsby-cli": "^4.17.1",
-        "gatsby-core-utils": "^3.17.0",
-        "gatsby-graphiql-explorer": "^2.17.0",
-        "gatsby-legacy-polyfills": "^2.17.0",
-        "gatsby-link": "^4.17.0",
-        "gatsby-page-utils": "^2.17.0",
-        "gatsby-parcel-config": "0.8.0",
-        "gatsby-plugin-page-creator": "^4.17.0",
-        "gatsby-plugin-typescript": "^4.17.0",
-        "gatsby-plugin-utils": "^3.11.0",
-        "gatsby-react-router-scroll": "^5.17.0",
-        "gatsby-script": "^1.2.0",
-        "gatsby-telemetry": "^3.17.0",
-        "gatsby-worker": "^1.17.0",
+        "gatsby-cli": "^4.16.0",
+        "gatsby-core-utils": "^3.16.0",
+        "gatsby-graphiql-explorer": "^2.16.0",
+        "gatsby-legacy-polyfills": "^2.16.0",
+        "gatsby-link": "^4.16.0",
+        "gatsby-page-utils": "^2.16.0",
+        "gatsby-parcel-config": "^0.7.0",
+        "gatsby-plugin-page-creator": "^4.16.0",
+        "gatsby-plugin-typescript": "^4.16.0",
+        "gatsby-plugin-utils": "^3.10.0",
+        "gatsby-react-router-scroll": "^5.16.0",
+        "gatsby-script": "^1.1.0",
+        "gatsby-telemetry": "^3.16.0",
+        "gatsby-worker": "^1.16.0",
         "glob": "^7.2.3",
         "globby": "^11.1.0",
         "got": "^11.8.2",
@@ -10737,7 +10886,7 @@
         "joi": "^17.4.2",
         "json-loader": "^0.5.7",
         "latest-version": "5.1.0",
-        "lmdb": "2.5.2",
+        "lmdb": "2.3.10",
         "lodash": "^4.17.21",
         "md5-file": "^5.0.0",
         "meant": "^1.0.3",
@@ -10801,7 +10950,7 @@
         "node": ">=14.15.0"
       },
       "optionalDependencies": {
-        "gatsby-sharp": "^0.11.0"
+        "gatsby-sharp": "^0.10.0"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
@@ -10867,9 +11016,9 @@
       }
     },
     "node_modules/gatsby-core-utils": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.17.0.tgz",
-      "integrity": "sha512-1e0YaqTAEpSSBkpWkY703lu+Bl76ASXUvUcpnNO3CavCYZsRQxAXtMXIKIEvhm1z6zWJmY9HILo6/DjP+PHeyw==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.19.0.tgz",
+      "integrity": "sha512-cjXs9DsXkPZt+UdiLHxtq+rGMGVrcnM0KwkawlruvPchI7lqGNv9CScqlvYPxx1dBhu3zSZS26EBALMlFhyOJA==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -10877,9 +11026,9 @@
         "fastq": "^1.13.0",
         "file-type": "^16.5.3",
         "fs-extra": "^10.1.0",
-        "got": "^11.8.3",
+        "got": "^11.8.5",
         "import-from": "^4.0.0",
-        "lmdb": "2.5.2",
+        "lmdb": "2.5.3",
         "lock": "^1.1.0",
         "node-object-hash": "^2.3.10",
         "proper-lockfile": "^4.1.2",
@@ -10970,11 +11119,11 @@
       }
     },
     "node_modules/gatsby-parcel-config": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.8.0.tgz",
-      "integrity": "sha512-HzLU8uoJLuakH08T27K8GKx7rcLEVkKVClffAuVKrlcVYhNH+x1LvIwe+uMTIIdfu+YtUpUP1PpTdua6YfrVTQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.7.0.tgz",
+      "integrity": "sha512-M4syRbthB0qA6IwRwHz4kGB/zSrMUvkDGWTK3nmmdfRtX+U7JITE2e1Le1IU54f1r/uaotLqH3T/e5j6tEb2sg==",
       "dependencies": {
-        "@gatsbyjs/parcel-namer-relative-to-cwd": "^1.2.0",
+        "@gatsbyjs/parcel-namer-relative-to-cwd": "^1.1.0",
         "@parcel/bundler-default": "2.6.0",
         "@parcel/compressor-raw": "2.6.0",
         "@parcel/namer-default": "2.6.0",
@@ -10997,24 +11146,6 @@
       },
       "peerDependencies": {
         "@parcel/core": "2.6.0"
-      }
-    },
-    "node_modules/gatsby-parcel-config/node_modules/@parcel/namer-default": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
-      "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
-      "dependencies": {
-        "@parcel/diagnostic": "2.6.0",
-        "@parcel/plugin": "2.6.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/gatsby-plugin-catch-links": {
@@ -12025,10 +12156,60 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/gatsby/node_modules/gatsby-sharp": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-0.10.0.tgz",
+      "integrity": "sha512-Wvtl5wfQJw7NDWI9J/xDhew1dXnI/MgkvHwrSulT00GgtTmBc7knplapfdU1E2k8PwpssqEBqWXvrxMszT5oWg==",
+      "optional": true,
+      "dependencies": {
+        "@types/sharp": "^0.30.0",
+        "sharp": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      }
+    },
+    "node_modules/gatsby/node_modules/lmdb": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
+      "integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "msgpackr": "^1.5.4",
+        "nan": "^2.14.2",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "^4.3.2",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "lmdb-darwin-arm64": "2.3.10",
+        "lmdb-darwin-x64": "2.3.10",
+        "lmdb-linux-arm": "2.3.10",
+        "lmdb-linux-arm64": "2.3.10",
+        "lmdb-linux-x64": "2.3.10",
+        "lmdb-win32-x64": "2.3.10"
+      }
+    },
     "node_modules/gatsby/node_modules/mitt": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
+    },
+    "node_modules/gatsby/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+    },
+    "node_modules/gatsby/node_modules/node-gyp-build-optional-packages": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.5.tgz",
+      "integrity": "sha512-5ke7D8SiQsTQL7CkHpfR1tLwfqtKc0KYEmlnkwd40jHCASskZeS98qoZ1qDUns2aUQWikcjidRUs6PM/3iyN/w==",
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/gatsby/node_modules/p-limit": {
       "version": "3.1.0",
@@ -12327,9 +12508,9 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.3",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
-      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -13734,9 +13915,9 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lmdb": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
-      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.3.tgz",
+      "integrity": "sha512-iBA0cb13CobBSoGJLfZgnrykLlfJipDAnvtf+YwIqqzBEsTeQYsXrHaSBkaHd5wCWeabwrNvhjZoFMUrlo+eLw==",
       "hasInstallScript": true,
       "dependencies": {
         "msgpackr": "^1.5.4",
@@ -13746,12 +13927,12 @@
         "weak-lru-cache": "^1.2.2"
       },
       "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "2.5.2",
-        "@lmdb/lmdb-darwin-x64": "2.5.2",
-        "@lmdb/lmdb-linux-arm": "2.5.2",
-        "@lmdb/lmdb-linux-arm64": "2.5.2",
-        "@lmdb/lmdb-linux-x64": "2.5.2",
-        "@lmdb/lmdb-win32-x64": "2.5.2"
+        "@lmdb/lmdb-darwin-arm64": "2.5.3",
+        "@lmdb/lmdb-darwin-x64": "2.5.3",
+        "@lmdb/lmdb-linux-arm": "2.5.3",
+        "@lmdb/lmdb-linux-arm64": "2.5.3",
+        "@lmdb/lmdb-linux-x64": "2.5.3",
+        "@lmdb/lmdb-win32-x64": "2.5.3"
       }
     },
     "node_modules/lmdb-darwin-arm64": {
@@ -14679,9 +14860,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -21393,13 +21574,280 @@
       }
     },
     "@gatsbyjs/parcel-namer-relative-to-cwd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-1.2.0.tgz",
-      "integrity": "sha512-4iIdquFDl+b+U8Ng0dg6dCtxB/cnH27ERrlQQlxfdaWe8e9CLo8aWc6u3UeuHwNJixBFOUbOgEFaA5qCUPwLCQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-1.4.0.tgz",
+      "integrity": "sha512-oXhiaPtYTGYqGZlazYRUabWVHWx5z6sAyBVLhUnpsKcBsK815cET+mjeWDKpmvJmFTKHC72Bvy1WIEnW3++YxA==",
       "requires": {
         "@babel/runtime": "^7.18.0",
-        "@parcel/plugin": "2.6.0",
-        "gatsby-core-utils": "^3.17.0"
+        "@parcel/namer-default": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "gatsby-core-utils": "^3.19.0"
+      },
+      "dependencies": {
+        "@lmdb/lmdb-darwin-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+          "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+          "optional": true
+        },
+        "@lmdb/lmdb-darwin-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+          "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+          "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+          "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+          "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+          "optional": true
+        },
+        "@lmdb/lmdb-win32-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+          "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+          "optional": true
+        },
+        "@parcel/cache": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.2.tgz",
+          "integrity": "sha512-hhJ6AsEGybeQZd9c/GYqfcKTgZKQXu3Xih6TlnP3gdR3KZoJOnb40ovHD1yYg4COvfcXThKP1cVJ18J6rcv3IA==",
+          "requires": {
+            "@parcel/fs": "2.6.2",
+            "@parcel/logger": "2.6.2",
+            "@parcel/utils": "2.6.2",
+            "lmdb": "2.5.2"
+          }
+        },
+        "@parcel/codeframe": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.2.tgz",
+          "integrity": "sha512-oFlHr6HCaYYsB4SHkU+gn9DKtbzvv3/4NdwMX0/6NAKyYVI7inEsXyPGw2Bbd2ZCFatW9QJZUETF0etvh5AEfQ==",
+          "requires": {
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/core": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.2.tgz",
+          "integrity": "sha512-JlKS3Ux0ngmdooSBbzQLShHJdsapF9E7TGMo1hFaHRquZip/DaqzvysYrgMJlDuCoLArciq5ei7ZKzGeK9zexA==",
+          "peer": true,
+          "requires": {
+            "@mischnic/json-sourcemap": "^0.1.0",
+            "@parcel/cache": "2.6.2",
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/events": "2.6.2",
+            "@parcel/fs": "2.6.2",
+            "@parcel/graph": "2.6.2",
+            "@parcel/hash": "2.6.2",
+            "@parcel/logger": "2.6.2",
+            "@parcel/package-manager": "2.6.2",
+            "@parcel/plugin": "2.6.2",
+            "@parcel/source-map": "^2.0.0",
+            "@parcel/types": "2.6.2",
+            "@parcel/utils": "2.6.2",
+            "@parcel/workers": "2.6.2",
+            "abortcontroller-polyfill": "^1.1.9",
+            "base-x": "^3.0.8",
+            "browserslist": "^4.6.6",
+            "clone": "^2.1.1",
+            "dotenv": "^7.0.0",
+            "dotenv-expand": "^5.1.0",
+            "json5": "^2.2.0",
+            "msgpackr": "^1.5.4",
+            "nullthrows": "^1.1.1",
+            "semver": "^5.7.1"
+          }
+        },
+        "@parcel/diagnostic": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.2.tgz",
+          "integrity": "sha512-3ODSBkKVihENU763z1/1DhGAWFhYWRxOCOShC72KXp+GFnSgGiBsxclu8NBa/N948Rzp8lqQI8U1nLcKkh0O/w==",
+          "requires": {
+            "@mischnic/json-sourcemap": "^0.1.0",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/events": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.2.tgz",
+          "integrity": "sha512-IaCjOeA5ercdFVi1EZOmUHhGfIysmCUgc2Th9hMugSFO0I3GzRsBcAdP6XPfWm+TV6sQ/qZRfdk/drUxoAupnw=="
+        },
+        "@parcel/fs": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.2.tgz",
+          "integrity": "sha512-mIhqdF3tjgeoIGqW7Nc/xfM2ClID7o8livwUe5lpQEP+ZaIBiMigXs6ckv3WToCACK+3uylrSD2A/HmlhrxMqQ==",
+          "requires": {
+            "@parcel/fs-search": "2.6.2",
+            "@parcel/types": "2.6.2",
+            "@parcel/utils": "2.6.2",
+            "@parcel/watcher": "^2.0.0",
+            "@parcel/workers": "2.6.2"
+          }
+        },
+        "@parcel/fs-search": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.2.tgz",
+          "integrity": "sha512-4STid1zqtGnmGjHD/2TG2g/zPDiCTtE3IAS24QYH3eiUAz2uoKGgEqd2tZbZ2yI96jtCuIhC1bzVu8Hbykls7w==",
+          "requires": {
+            "detect-libc": "^1.0.3"
+          }
+        },
+        "@parcel/graph": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.2.tgz",
+          "integrity": "sha512-DPH4G/RBFJWayIN2fnhDXqhUw75n7k15YsGzdDKiXuwwz4wMOjoL4cyrI6zOf1SIyh3guRmeTYJ4jjPzwrLYww==",
+          "peer": true,
+          "requires": {
+            "@parcel/utils": "2.6.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/hash": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.2.tgz",
+          "integrity": "sha512-tFB+cJU1Wqag6WyJgsmx3nx+xhmjcNZqtWh/MtK1lHNnZdDRk6bjr7SapnygBwruz+SmSt5bbdVThcpk2dRCcA==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "xxhash-wasm": "^0.4.2"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.2.tgz",
+          "integrity": "sha512-Sz5YGCj1DbEiX0/G8Uw97LLZ0uEK+qtWcRAkHNpJpeMiSqDiRNevxXltz42EcLo+oCh4d4wyiVzwi9mNwzhS/Q==",
+          "requires": {
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/events": "2.6.2"
+          }
+        },
+        "@parcel/markdown-ansi": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.2.tgz",
+          "integrity": "sha512-N/h9J4eibhc+B+krzvPMzFUWL37GudBIZBa7XSLkcuH6MnYYfh6rrMvhIyyESwk6VkcZNVzAeZrGQqxEs0dHDQ==",
+          "requires": {
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/namer-default": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.2.tgz",
+          "integrity": "sha512-mp7bx/BQaIuohmZP0uE+gAmDBzzH0Yu8F4yCtE611lc6i0mou+nWRhzyKLNC/ieuI8DB3BFh2QQKeTxJn4W0qg==",
+          "requires": {
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/plugin": "2.6.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/package-manager": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.2.tgz",
+          "integrity": "sha512-xGMqTgnwTE3rgzYwUZMKxR8fzmP5iSYz/gj2H8FR3pEmwh/8xCMtNjTSth+hPVGuqgRZ6JxwpfdY/fXdZ61ViQ==",
+          "requires": {
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/fs": "2.6.2",
+            "@parcel/logger": "2.6.2",
+            "@parcel/types": "2.6.2",
+            "@parcel/utils": "2.6.2",
+            "@parcel/workers": "2.6.2",
+            "semver": "^5.7.1"
+          }
+        },
+        "@parcel/plugin": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.2.tgz",
+          "integrity": "sha512-wbbWsM23Pr+8xtLSvf+UopXdVYlpKCCx6PuuZaZcKo+9IcDCWoGXD4M8Kkz14qBmkFn5uM00mULUqmVdSibB2w==",
+          "requires": {
+            "@parcel/types": "2.6.2"
+          }
+        },
+        "@parcel/types": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.2.tgz",
+          "integrity": "sha512-MV8BFpCIs2jMUvK2RHqzkoiuOQ//JIbrD1zocA2YRW3zuPL/iABvbAABJoXpoPCKikVWOoCWASgBfWQo26VvJQ==",
+          "requires": {
+            "@parcel/cache": "2.6.2",
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/fs": "2.6.2",
+            "@parcel/package-manager": "2.6.2",
+            "@parcel/source-map": "^2.0.0",
+            "@parcel/workers": "2.6.2",
+            "utility-types": "^3.10.0"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.2.tgz",
+          "integrity": "sha512-Ug7hpRxjgbY5AopW55nY7MmGMVmwmN+ihfCmxJkBUoESTG/3iq8uME7GjyOgW5DkQc2K7q62i8y8N0wCJT1u4Q==",
+          "requires": {
+            "@parcel/codeframe": "2.6.2",
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/hash": "2.6.2",
+            "@parcel/logger": "2.6.2",
+            "@parcel/markdown-ansi": "2.6.2",
+            "@parcel/source-map": "^2.0.0",
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.2.tgz",
+          "integrity": "sha512-wBgUjJQm+lDd12fPRUmk09+ujTA9DgwPdqylSFK0OtI/yT6A+2kArUqjp8IwWo2tCJXoMzXBne2XQIWKqMiN4Q==",
+          "requires": {
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/logger": "2.6.2",
+            "@parcel/types": "2.6.2",
+            "@parcel/utils": "2.6.2",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "dotenv": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+          "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+          "peer": true
+        },
+        "lmdb": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+          "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+          "requires": {
+            "@lmdb/lmdb-darwin-arm64": "2.5.2",
+            "@lmdb/lmdb-darwin-x64": "2.5.2",
+            "@lmdb/lmdb-linux-arm": "2.5.2",
+            "@lmdb/lmdb-linux-arm64": "2.5.2",
+            "@lmdb/lmdb-linux-x64": "2.5.2",
+            "@lmdb/lmdb-win32-x64": "2.5.2",
+            "msgpackr": "^1.5.4",
+            "node-addon-api": "^4.3.0",
+            "node-gyp-build-optional-packages": "5.0.3",
+            "ordered-binary": "^1.2.4",
+            "weak-lru-cache": "^1.2.2"
+          }
+        },
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@gatsbyjs/potrace": {
@@ -22809,39 +23257,39 @@
       }
     },
     "@lmdb/lmdb-darwin-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
-      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-RXwGZ/0eCqtCY8FLTM/koR60w+MXyvBUpToXiIyjOcBnC81tAlTUHrRUavCEWPI9zc9VgvpK3+cbumPyR8BSuA==",
       "optional": true
     },
     "@lmdb/lmdb-darwin-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
-      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.3.tgz",
+      "integrity": "sha512-337dNzh5yCdNCTk8kPfoU7jR3otibSlPDGW0vKZT97rKnQMb9tNdto3RtWoGPsQ8hKmlRZpojOJtmwjncq1MoA==",
       "optional": true
     },
     "@lmdb/lmdb-linux-arm": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
-      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.3.tgz",
+      "integrity": "sha512-mU2HFJDGwECkoD9dHQEfeTG5mp8hNS2BCfwoiOpVPMeapjYpQz9Uw3FkUjRZ4dGHWKbin40oWHuL0bk2bCx+Sg==",
       "optional": true
     },
     "@lmdb/lmdb-linux-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
-      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-VJw60Mdgb4n+L0fO1PqfB0C7TyEQolJAC8qpqvG3JoQwvyOv6LH7Ib/WE3wxEW9nuHmVz9jkK7lk5HfWWgoO1Q==",
       "optional": true
     },
     "@lmdb/lmdb-linux-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
-      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-qaReO5aV8griBDsBr8uBF/faO3ieGjY1RY4p8JvTL6Mu1ylLrTVvOONqKFlNaCwrmUjWw5jnf7VafxDAeQHTow==",
       "optional": true
     },
     "@lmdb/lmdb-win32-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
-      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==",
       "optional": true
     },
     "@microsoft/fetch-event-source": {
@@ -23065,191 +23513,13 @@
       }
     },
     "@parcel/namer-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
-      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
-      "peer": true,
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
+      "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "nullthrows": "^1.1.1"
-      },
-      "dependencies": {
-        "@parcel/cache": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
-          "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
-          "peer": true,
-          "requires": {
-            "@parcel/fs": "2.5.0",
-            "@parcel/logger": "2.5.0",
-            "@parcel/utils": "2.5.0",
-            "lmdb": "2.2.4"
-          }
-        },
-        "@parcel/codeframe": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
-          "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
-          "peer": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/diagnostic": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
-          "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
-          "peer": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/events": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
-          "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
-          "peer": true
-        },
-        "@parcel/fs": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
-          "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
-          "peer": true,
-          "requires": {
-            "@parcel/fs-search": "2.5.0",
-            "@parcel/types": "2.5.0",
-            "@parcel/utils": "2.5.0",
-            "@parcel/watcher": "^2.0.0",
-            "@parcel/workers": "2.5.0"
-          }
-        },
-        "@parcel/fs-search": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
-          "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
-          "peer": true,
-          "requires": {
-            "detect-libc": "^1.0.3"
-          }
-        },
-        "@parcel/hash": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
-          "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
-          "peer": true,
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "xxhash-wasm": "^0.4.2"
-          }
-        },
-        "@parcel/logger": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
-          "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
-          "peer": true,
-          "requires": {
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/events": "2.5.0"
-          }
-        },
-        "@parcel/markdown-ansi": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
-          "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
-          "peer": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/package-manager": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
-          "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
-          "peer": true,
-          "requires": {
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/fs": "2.5.0",
-            "@parcel/logger": "2.5.0",
-            "@parcel/types": "2.5.0",
-            "@parcel/utils": "2.5.0",
-            "@parcel/workers": "2.5.0",
-            "semver": "^5.7.1"
-          }
-        },
-        "@parcel/plugin": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
-          "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
-          "peer": true,
-          "requires": {
-            "@parcel/types": "2.5.0"
-          }
-        },
-        "@parcel/types": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
-          "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
-          "peer": true,
-          "requires": {
-            "@parcel/cache": "2.5.0",
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/fs": "2.5.0",
-            "@parcel/package-manager": "2.5.0",
-            "@parcel/source-map": "^2.0.0",
-            "@parcel/workers": "2.5.0",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "@parcel/utils": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
-          "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
-          "peer": true,
-          "requires": {
-            "@parcel/codeframe": "2.5.0",
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/hash": "2.5.0",
-            "@parcel/logger": "2.5.0",
-            "@parcel/markdown-ansi": "2.5.0",
-            "@parcel/source-map": "^2.0.0",
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/workers": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
-          "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
-          "peer": true,
-          "requires": {
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/logger": "2.5.0",
-            "@parcel/types": "2.5.0",
-            "@parcel/utils": "2.5.0",
-            "chrome-trace-event": "^1.0.2",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "lmdb": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-          "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
-          "peer": true,
-          "requires": {
-            "msgpackr": "^1.5.4",
-            "nan": "^2.14.2",
-            "node-gyp-build": "^4.2.3",
-            "ordered-binary": "^1.2.4",
-            "weak-lru-cache": "^1.2.2"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "peer": true
-        }
       }
     },
     "@parcel/node-resolver-core": {
@@ -23311,9 +23581,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.15.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+          "version": "13.17.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -23400,9 +23670,9 @@
       }
     },
     "@parcel/source-map": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.5.tgz",
-      "integrity": "sha512-DRVlCFKLpqBSIbMxUoVlHgfiv12HTW/U7nnhzw52YgzDVXUX9OA41dXS1PU0pJ1si+D1k8msATUC+AoldN43mg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.0.tgz",
+      "integrity": "sha512-E7UOEIof2o89LrKk1agSLmwakjigmEdDp1ZaEdsLVEvq63R/bul4Ij5CT+0ZDcijGpl5tnTbQADY9EyYGtjYgQ==",
       "requires": {
         "detect-libc": "^1.0.3"
       }
@@ -27905,9 +28175,9 @@
       "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA=="
     },
     "gatsby": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.17.2.tgz",
-      "integrity": "sha512-uMNH/X/Fd0kGjelgAPTukgQhxu/aMhRj5YJ07SM4D2yBuO+c4+y1dZRz5q9EUryCeVSx1cSt0J6JMkfzOXmbyA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.16.0.tgz",
+      "integrity": "sha512-C8rmUsx8LnhtDKMOyfoXH1A27tuU+5OP/p1X0vIoOfW2pcRty5pjWRlFl/OM1BHcrdrfEXTsen30eU+S4iQG8Q==",
       "requires": {
         "@babel/code-frame": "^7.14.0",
         "@babel/core": "^7.15.5",
@@ -27943,8 +28213,8 @@
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-lodash": "^3.3.4",
-        "babel-plugin-remove-graphql-queries": "^4.17.0",
-        "babel-preset-gatsby": "^2.17.0",
+        "babel-plugin-remove-graphql-queries": "^4.16.0",
+        "babel-preset-gatsby": "^2.16.0",
         "better-opn": "^2.1.1",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.0",
@@ -27987,21 +28257,21 @@
         "find-cache-dir": "^3.3.2",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^10.1.0",
-        "gatsby-cli": "^4.17.1",
-        "gatsby-core-utils": "^3.17.0",
-        "gatsby-graphiql-explorer": "^2.17.0",
-        "gatsby-legacy-polyfills": "^2.17.0",
-        "gatsby-link": "^4.17.0",
-        "gatsby-page-utils": "^2.17.0",
-        "gatsby-parcel-config": "0.8.0",
-        "gatsby-plugin-page-creator": "^4.17.0",
-        "gatsby-plugin-typescript": "^4.17.0",
-        "gatsby-plugin-utils": "^3.11.0",
-        "gatsby-react-router-scroll": "^5.17.0",
-        "gatsby-script": "^1.2.0",
-        "gatsby-sharp": "^0.11.0",
-        "gatsby-telemetry": "^3.17.0",
-        "gatsby-worker": "^1.17.0",
+        "gatsby-cli": "^4.16.0",
+        "gatsby-core-utils": "^3.16.0",
+        "gatsby-graphiql-explorer": "^2.16.0",
+        "gatsby-legacy-polyfills": "^2.16.0",
+        "gatsby-link": "^4.16.0",
+        "gatsby-page-utils": "^2.16.0",
+        "gatsby-parcel-config": "^0.7.0",
+        "gatsby-plugin-page-creator": "^4.16.0",
+        "gatsby-plugin-typescript": "^4.16.0",
+        "gatsby-plugin-utils": "^3.10.0",
+        "gatsby-react-router-scroll": "^5.16.0",
+        "gatsby-script": "^1.1.0",
+        "gatsby-sharp": "^0.10.0",
+        "gatsby-telemetry": "^3.16.0",
+        "gatsby-worker": "^1.16.0",
         "glob": "^7.2.3",
         "globby": "^11.1.0",
         "got": "^11.8.2",
@@ -28016,7 +28286,7 @@
         "joi": "^17.4.2",
         "json-loader": "^0.5.7",
         "latest-version": "5.1.0",
-        "lmdb": "2.5.2",
+        "lmdb": "2.3.10",
         "lodash": "^4.17.21",
         "md5-file": "^5.0.0",
         "meant": "^1.0.3",
@@ -28117,10 +28387,49 @@
             }
           }
         },
+        "gatsby-sharp": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-0.10.0.tgz",
+          "integrity": "sha512-Wvtl5wfQJw7NDWI9J/xDhew1dXnI/MgkvHwrSulT00GgtTmBc7knplapfdU1E2k8PwpssqEBqWXvrxMszT5oWg==",
+          "optional": true,
+          "requires": {
+            "@types/sharp": "^0.30.0",
+            "sharp": "^0.30.3"
+          }
+        },
+        "lmdb": {
+          "version": "2.3.10",
+          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
+          "integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
+          "requires": {
+            "lmdb-darwin-arm64": "2.3.10",
+            "lmdb-darwin-x64": "2.3.10",
+            "lmdb-linux-arm": "2.3.10",
+            "lmdb-linux-arm64": "2.3.10",
+            "lmdb-linux-x64": "2.3.10",
+            "lmdb-win32-x64": "2.3.10",
+            "msgpackr": "^1.5.4",
+            "nan": "^2.14.2",
+            "node-addon-api": "^4.3.0",
+            "node-gyp-build-optional-packages": "^4.3.2",
+            "ordered-binary": "^1.2.4",
+            "weak-lru-cache": "^1.2.2"
+          }
+        },
         "mitt": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
           "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw=="
+        },
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+        },
+        "node-gyp-build-optional-packages": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.5.tgz",
+          "integrity": "sha512-5ke7D8SiQsTQL7CkHpfR1tLwfqtKc0KYEmlnkwd40jHCASskZeS98qoZ1qDUns2aUQWikcjidRUs6PM/3iyN/w=="
         },
         "p-limit": {
           "version": "3.1.0",
@@ -28194,9 +28503,9 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.17.0.tgz",
-      "integrity": "sha512-1e0YaqTAEpSSBkpWkY703lu+Bl76ASXUvUcpnNO3CavCYZsRQxAXtMXIKIEvhm1z6zWJmY9HILo6/DjP+PHeyw==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.19.0.tgz",
+      "integrity": "sha512-cjXs9DsXkPZt+UdiLHxtq+rGMGVrcnM0KwkawlruvPchI7lqGNv9CScqlvYPxx1dBhu3zSZS26EBALMlFhyOJA==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -28204,9 +28513,9 @@
         "fastq": "^1.13.0",
         "file-type": "^16.5.3",
         "fs-extra": "^10.1.0",
-        "got": "^11.8.3",
+        "got": "^11.8.5",
         "import-from": "^4.0.0",
-        "lmdb": "2.5.2",
+        "lmdb": "2.5.3",
         "lock": "^1.1.0",
         "node-object-hash": "^2.3.10",
         "proper-lockfile": "^4.1.2",
@@ -28275,11 +28584,11 @@
       }
     },
     "gatsby-parcel-config": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.8.0.tgz",
-      "integrity": "sha512-HzLU8uoJLuakH08T27K8GKx7rcLEVkKVClffAuVKrlcVYhNH+x1LvIwe+uMTIIdfu+YtUpUP1PpTdua6YfrVTQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.7.0.tgz",
+      "integrity": "sha512-M4syRbthB0qA6IwRwHz4kGB/zSrMUvkDGWTK3nmmdfRtX+U7JITE2e1Le1IU54f1r/uaotLqH3T/e5j6tEb2sg==",
       "requires": {
-        "@gatsbyjs/parcel-namer-relative-to-cwd": "^1.2.0",
+        "@gatsbyjs/parcel-namer-relative-to-cwd": "^1.1.0",
         "@parcel/bundler-default": "2.6.0",
         "@parcel/compressor-raw": "2.6.0",
         "@parcel/namer-default": "2.6.0",
@@ -28296,18 +28605,6 @@
         "@parcel/transformer-json": "2.6.0",
         "@parcel/transformer-raw": "2.6.0",
         "@parcel/transformer-react-refresh-wrap": "2.6.0"
-      },
-      "dependencies": {
-        "@parcel/namer-default": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
-          "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
-          "requires": {
-            "@parcel/diagnostic": "2.6.0",
-            "@parcel/plugin": "2.6.0",
-            "nullthrows": "^1.1.1"
-          }
-        }
       }
     },
     "gatsby-plugin-catch-links": {
@@ -29214,9 +29511,9 @@
       }
     },
     "got": {
-      "version": "11.8.3",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
-      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "requires": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -30248,16 +30545,16 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "lmdb": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
-      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.3.tgz",
+      "integrity": "sha512-iBA0cb13CobBSoGJLfZgnrykLlfJipDAnvtf+YwIqqzBEsTeQYsXrHaSBkaHd5wCWeabwrNvhjZoFMUrlo+eLw==",
       "requires": {
-        "@lmdb/lmdb-darwin-arm64": "2.5.2",
-        "@lmdb/lmdb-darwin-x64": "2.5.2",
-        "@lmdb/lmdb-linux-arm": "2.5.2",
-        "@lmdb/lmdb-linux-arm64": "2.5.2",
-        "@lmdb/lmdb-linux-x64": "2.5.2",
-        "@lmdb/lmdb-win32-x64": "2.5.2",
+        "@lmdb/lmdb-darwin-arm64": "2.5.3",
+        "@lmdb/lmdb-darwin-x64": "2.5.3",
+        "@lmdb/lmdb-linux-arm": "2.5.3",
+        "@lmdb/lmdb-linux-arm64": "2.5.3",
+        "@lmdb/lmdb-linux-x64": "2.5.3",
+        "@lmdb/lmdb-win32-x64": "2.5.3",
         "msgpackr": "^1.5.4",
         "node-addon-api": "^4.3.0",
         "node-gyp-build-optional-packages": "5.0.3",
@@ -30970,9 +31267,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
     },
     "node-gyp-build-optional-packages": {
       "version": "5.0.3",

--- a/starters/gatsby-wordpress-starter/package.json
+++ b/starters/gatsby-wordpress-starter/package.json
@@ -21,24 +21,24 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
   },
   "dependencies": {
-    "@tailwindcss/typography": "^0.5.4",
-    "autoprefixer": "^10.4.7",
-    "gatsby": "4.19.0",
-    "gatsby-plugin-image": "^2.19.0",
-    "gatsby-plugin-manifest": "^4.19.0",
-    "gatsby-plugin-offline": "^5.19.0",
+    "@tailwindcss/typography": "^0.5.2",
+    "autoprefixer": "^10.4.4",
+    "gatsby": "4.16.0",
+    "gatsby-plugin-image": "^2.12.1",
+    "gatsby-plugin-manifest": "^4.12.1",
+    "gatsby-plugin-offline": "^5.12.1",
     "gatsby-plugin-pnpm": "^1.2.10",
-    "gatsby-plugin-postcss": "^5.19.0",
-    "gatsby-plugin-react-helmet": "^5.19.0",
-    "gatsby-plugin-sharp": "^4.19.0",
-    "gatsby-source-filesystem": "^4.19.0",
-    "gatsby-source-wordpress": "^6.19.0",
-    "gatsby-transformer-sharp": "^4.19.0",
-    "graphql": "^16.5.0",
-    "html-react-parser": "^1.4.14",
+    "gatsby-plugin-postcss": "^5.12.1",
+    "gatsby-plugin-react-helmet": "^5.12.1",
+    "gatsby-plugin-sharp": "^4.12.1",
+    "gatsby-source-filesystem": "^4.12.1",
+    "gatsby-source-wordpress": "^6.12.1",
+    "gatsby-transformer-sharp": "^4.12.1",
+    "graphql": ">=14.2.0 <15.0.0 || >=15.0.0 <16.0.0 || >=16.0.0 <17.0.0",
+    "html-react-parser": "^1.4.10",
     "lodash": "^4.17.21",
     "mitt": "^3.0.0",
-    "postcss": "^8.4.14",
+    "postcss": "^8.4.12",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-helmet": "6.1.0",
@@ -47,9 +47,9 @@
     "typeface-montserrat": "1.1.13"
   },
   "devDependencies": {
-    "@babel/core": "^7.18.9",
+    "@babel/core": ">=7.12.3 <8.0.0",
     "dumper.js": "^1.3.1",
     "prettier": "2.5.1",
-    "webpack": "^5.73.0"
+    "webpack": "^4.0.0 || ^5.0.0"
   }
 }


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Downgrade back to gatsby 4.16.0 as there is some unknown issue when using `placeholder: TRACED_SVG`.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 


## How have the changes been tested?
starter builds locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!