### PR TITLE
DB-3188: Add next-wordpress-starter canary site

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -24,6 +24,8 @@ jobs:
             split_repository: "next-drupal-starter-default-canary"
           - local_path: "starters/gatsby-wordpress-starter"
             split_repository: "gatsby-wordpress-starter-default-canary"
+          - local_path: "starters/next-wordpress-starter"
+            split_repository: "next-wordpress-starter-default-canary"
     steps:
       - uses: actions/checkout@v2
       - uses: "symplify/monorepo-split-github-action@2.1"


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Add the `next-wordpress-starter` to the canary-sites-split workflow. Expediting this a bit so that we can get a stable domain on it sooner than later. 

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
changes to GitHub action workflow

## How have the changes been tested?
n/a

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!