### PR TITLE
DB-3466: Rendering issues for quote blocks for wordpress-next starter site

### DIFF
--- a/.changeset/soft-lemons-draw.md
+++ b/.changeset/soft-lemons-draw.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/wordpress-kit": minor
+---
+
+Added text alignment classes from WP to the tailwind plugin, and fixed empty quotes

--- a/packages/wordpress-kit/src/lib/tailwindCssPlugin/config.ts
+++ b/packages/wordpress-kit/src/lib/tailwindCssPlugin/config.ts
@@ -24,7 +24,9 @@ export const mergeToConfig: Config = {
     ...backgroundColorClasses,
     ...fontSizeClasses,
     '.has-drop-cap',
-
+    '.has-text-align-center',
+    '.has-text-align-right',
+    '.has-text-align-left',
     '.wp-block-quote',
     '.is-style-plain',
     '.is-style-large',

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
@@ -53,6 +53,18 @@ export default plugin(function ({ addUtilities, theme }) {
     }
   );
 
+  const textAlignUtilities = {
+    '.has-text-align-center': {
+      textAlign: 'center',
+    },
+    '.has-text-align-right': {
+      textAlign: 'right',
+    },
+    '.has-text-align-left': {
+      textAlign: 'left',
+    },
+  };
+
   const dropCapUtilities = {
     '.has-drop-cap': {
       '&:first-letter': {
@@ -90,6 +102,18 @@ export default plugin(function ({ addUtilities, theme }) {
     },
 
     '.wp-block-quote': {
+      'p:empty': {
+        quotes: 'none',
+      },
+      '&.has-text-align-center': {
+        border: 'none',
+      },
+      '&.has-text-align-right': {
+        borderLeft: 'none',
+        paddingRight: '1.06em',
+        borderRightWidth: '0.25rem',
+        borderRightColor: '#e5e7eb',
+      },
       cite: {
         fontStyle: 'normal',
         fontSize: '0.8rem',
@@ -158,5 +182,6 @@ export default plugin(function ({ addUtilities, theme }) {
     fontSizeUtilities,
     pullQuoteUtilities,
     quoteUtilities,
+    textAlignUtilities,
   ]);
 }, mergeToConfig);


### PR DESCRIPTION
## What changes were made?
- Added text-alignment behavior to the utility classes
- Added empty quotes and border movement to quotes depending of the text alignment

![image](https://user-images.githubusercontent.com/57777002/181629205-7cbac12c-4fde-4ada-b4c9-a85a199b39ae.png)

## Where were the changes made?
- wordpress-kit

## How have the changes been tested?
- Locally and built

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!