### PR TITLE
DB-3453: [next-wordpress] Invalid href passed to next/router

### DIFF
--- a/.changeset/neat-frogs-dress.md
+++ b/.changeset/neat-frogs-dress.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-wordpress-starter": patch
+---
+
+Add a URI formatter in lib/Menus to fix a problem with WP6 implementation

--- a/.changeset/neat-frogs-dress.md
+++ b/.changeset/neat-frogs-dress.md
@@ -2,4 +2,4 @@
 "@pantheon-systems/next-wordpress-starter": patch
 ---
 
-Add a URI formatter in lib/Menus to fix a problem with WP6 implementation
+Change from URI property to path in FooterMenuQuery

--- a/starters/next-wordpress-starter/components/footer.jsx
+++ b/starters/next-wordpress-starter/components/footer.jsx
@@ -4,13 +4,13 @@ export default function Footer({ menuItems = [] }) {
   const FooterMenu = () => (
     <nav className="flex flex-col max-w-lg mx-auto lg:max-w-screen-lg">
       <ul>
-        {menuItems.map(({ label, uri, id }) => {
+        {menuItems.map(({ label, path, id }) => {
           return (
             <li
               key={id}
               className="list-disc text-blue-300 hover:text-blue-100 ml-3"
             >
-              <Link href={`/posts${uri}`}>
+              <Link href={`/posts${path}`}>
                 <a className="hover:underline focus:text-purple-600  active:text-purple-300">
                   {label}
                 </a>

--- a/starters/next-wordpress-starter/lib/Menus.js
+++ b/starters/next-wordpress-starter/lib/Menus.js
@@ -9,7 +9,7 @@ export async function getFooterMenu() {
           edges {
             node {
               id
-              uri
+              path
               label
             }
           }
@@ -24,10 +24,5 @@ export async function getFooterMenu() {
     },
   } = await client.request(query);
 
-  return edges.map(({ node }) => ({
-    ...node,
-    uri: node.uri.startsWith("http") ? formatUri(node.uri) : node.uri,
-  }));
+  return edges.map(({ node }) => node);
 }
-
-const formatUri = (uri) => new URL(uri).pathname;

--- a/starters/next-wordpress-starter/lib/Menus.js
+++ b/starters/next-wordpress-starter/lib/Menus.js
@@ -24,5 +24,10 @@ export async function getFooterMenu() {
     },
   } = await client.request(query);
 
-  return edges.map(({ node }) => node);
+  return edges.map(({ node }) => ({
+    ...node,
+    uri: node.uri.startsWith("http") ? formatUri(node.uri) : node.uri,
+  }));
 }
+
+const formatUri = (uri) => new URL(uri).pathname;


### PR DESCRIPTION

## What changes were made?
- Added a formatter to the lib/Menus.js that take the URI and returns the pathname, and is applied when the URI starts with HTTP to fix the console error

## Where were the changes made?
- next-wordpress-starter


## How have the changes been tested?
- locally and built
- with the older QA WP site and the new with WP6

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!