### PR TITLE
DB-3466: Fix a problem with the spacing inside the pullquotes

### DIFF
--- a/.changeset/five-rings-compare.md
+++ b/.changeset/five-rings-compare.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/wordpress-kit": patch
+---
+
+Fix style error on large pullquotes

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
@@ -148,6 +148,7 @@ export default plugin(function ({ addUtilities, theme }) {
           fontSize: '.8em',
           fontStyle: 'normal',
         },
+        paddingRight: '1em',
         border: 'none',
         color: 'inherit',
         quotes: 'none',
@@ -159,7 +160,6 @@ export default plugin(function ({ addUtilities, theme }) {
       marginBottom: '0',
       marginTop: '0',
       padding: '2em 0',
-      textAlign: 'center',
     },
   };
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Fixed a problem that overflow text very close to the right border

## Where were the changes made?
- wordpress-kit

## How have the changes been tested?
- Locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!