### PR TITLE
DB-3466: Add table styles

### DIFF
--- a/.changeset/calm-years-lick.md
+++ b/.changeset/calm-years-lick.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/wordpress-kit": minor
+---
+
+Added table styles

--- a/packages/wordpress-kit/src/lib/tailwindCssPlugin/config.ts
+++ b/packages/wordpress-kit/src/lib/tailwindCssPlugin/config.ts
@@ -23,6 +23,7 @@ export const mergeToConfig: Config = {
     '.has-background',
     ...backgroundColorClasses,
     ...fontSizeClasses,
+    '.wp-block-table',
     '.has-drop-cap',
     '.has-text-align-center',
     '.has-text-align-right',

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
@@ -4,7 +4,7 @@ import { Color } from '../types/tailwindcssPlugin';
 import { mergeToConfig } from './tailwindCssPlugin/config';
 import { colorList, fontSizeList } from './tailwindCssPlugin/constants';
 
-export default plugin(function ({ addUtilities, theme }) {
+export default plugin(function ({ addUtilities, theme, addComponents }) {
   const getColor = (color: Color) =>
     theme(
       `colors.${color.themeName}`,
@@ -174,6 +174,50 @@ export default plugin(function ({ addUtilities, theme }) {
     {}
   );
 
+  const tableComponent = {
+    '.wp-block-table': {
+      td: {
+        padding: '0.5em',
+      },
+      table: {
+        thead: {
+          tr: {
+            borderColor: 'inherit',
+            th: {
+              padding: '0.5em',
+              color: 'inherit',
+            },
+          },
+          borderColor: 'inherit',
+        },
+        tbody: {
+          borderColor: 'inherit',
+          tr: {
+            borderColor: 'inherit',
+          },
+        },
+        '&.has-fixed-layout': {
+          width: '100%',
+          tableLayout: 'fixed',
+        },
+      },
+      figcaption: {
+        fontSize: '.5em',
+        textAlign: 'center',
+      },
+      '&.is-style-stripes': {
+        margin: '0',
+        table: {
+          tbody: {
+            'tr:nth-child(odd)': {
+              backgroundColor: theme('colors.stripes', '#f2f2f2'),
+            },
+          },
+        },
+      },
+    },
+  };
+
   addUtilities([
     backgroundUtilities,
     borderColorUtilities,
@@ -184,4 +228,6 @@ export default plugin(function ({ addUtilities, theme }) {
     quoteUtilities,
     textAlignUtilities,
   ]);
+
+  addComponents(tableComponent);
 }, mergeToConfig);

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
@@ -228,6 +228,8 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
           'screen.xl',
           '1280px'
         )})` as '@media(min-width:1280px)`']: {
+          // sets a negative margin to allow full width tables to span past the
+          // width its parent container
           marginLeft: 'calc(-1 * max(1rem, 10vw))',
           marginRight: 'calc(-1 * max(1rem, 10vw))',
         },

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin.ts
@@ -197,12 +197,14 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
           },
         },
         '&.has-fixed-layout': {
-          width: '100%',
+          width: 'unset',
           tableLayout: 'fixed',
         },
+        maxWidth: '650px',
+        margin: 'auto',
       },
       figcaption: {
-        fontSize: '.5em',
+        fontSize: '.9rem',
         textAlign: 'center',
       },
       '&.is-style-stripes': {
@@ -215,6 +217,28 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
           },
         },
       },
+      '&.alignwide': {
+        padding: '0 1.5rem',
+        table: {
+          maxWidth: '850px',
+        },
+      },
+      '&.alignfull': {
+        [`@media (min-width:${theme(
+          'screen.xl',
+          '1280px'
+        )})` as '@media(min-width:1280px)`']: {
+          marginLeft: 'calc(-1 * max(1rem, 10vw))',
+          marginRight: 'calc(-1 * max(1rem, 10vw))',
+        },
+        width: 'unset',
+        table: {
+          maxWidth: 'none',
+        },
+        padding: '0',
+      },
+      overflowX: 'auto',
+      padding: '0 2.5rem',
     },
   };
 

--- a/packages/wordpress-kit/src/types/tailwindcssPlugin.d.ts
+++ b/packages/wordpress-kit/src/types/tailwindcssPlugin.d.ts
@@ -18,6 +18,7 @@ export type ColorConfig = {
   darkGray?: string;
   lightGray?: string;
   white?: string;
+  stripes?: string;
 };
 
 export type PaddingConfig = {

--- a/starters/next-wordpress-starter/components/post.jsx
+++ b/starters/next-wordpress-starter/components/post.jsx
@@ -5,19 +5,16 @@ export default function Post({
   post: { title, date, featuredImage, content },
 }) {
   return (
-    <article className="prose lg:prose-xl mt-10 mx-auto">
+    <article className="prose lg:prose-xl mt-10 mx-auto max-w-screen-lg p-4">
       <h1>{title}</h1>
       <p className="text-sm text-gray-600">{new Date(date).toDateString()}</p>
 
       <Link passHref href="/">
         <a className="font-normal">Home &rarr;</a>
       </Link>
-      <div className="mt-12 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg">
-        {featuredImage && (
-          <div
-            className="relative w-full rounded-lg shadow-lg overflow-hidden mb-10"
-            style={{ height: "50vh" }}
-          >
+      {featuredImage && (
+        <div className="mt-12 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg">
+          <div className="relative rounded-lg shadow-lg overflow-hidden mb-10 w-[50vh]">
             <Image
               priority
               src={featuredImage.node.sourceUrl}
@@ -26,15 +23,13 @@ export default function Post({
               alt="Featured Image"
             />
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
-      <div className="mt-12 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg">
-        <div
-          className="break-words"
-          dangerouslySetInnerHTML={{ __html: content }}
-        />
-      </div>
+      <div
+        className="break-words mt-12"
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
     </article>
   );
 }

--- a/starters/next-wordpress-starter/components/post.jsx
+++ b/starters/next-wordpress-starter/components/post.jsx
@@ -12,19 +12,22 @@ export default function Post({
       <Link passHref href="/">
         <a className="font-normal">Home &rarr;</a>
       </Link>
-      {featuredImage && (
-        <div className="mt-12 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg">
-          <div className="relative rounded-lg shadow-lg overflow-hidden mb-10 w-[50vh]">
+      <div className="mt-12 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg">
+        {featuredImage && (
+          <div
+            className="relative w-full rounded-lg shadow-lg overflow-hidden mb-10"
+            style={{ height: "50vh" }}
+          >
             <Image
               priority
               src={featuredImage.node.sourceUrl}
               layout="fill"
               objectFit="cover"
-              alt="Featured Image"
+              alt={featuredImage.node.alt || "Featured Image"}
             />
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       <div
         className="break-words mt-12"


### PR DESCRIPTION
## What changes were made?
- Added styles to render tables

## Where were the changes made?
- Wordpress-kit

## How have the changes been tested?
- Locally

## Additional information
<!--- Add any other context about the feature or fix here. --->
- I'm not sure about the block alignment, because in the WP block editor it looks broken 
![image](https://user-images.githubusercontent.com/57777002/181843468-4996855a-b6b8-46bb-aaa3-863102ae270c.png)
but is in the PR, if we decide to don't honor it, then I can remove that behavior

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!