### PR TITLE
Lando template decoupled drupal db 3021

### DIFF
--- a/web/docs/Backend Starters/Decoupled Drupal/lando-template-for-local-dev-backend-only.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/lando-template-for-local-dev-backend-only.md
@@ -1,0 +1,54 @@
+# Instructions for Local Development of CMS Backend using Lando
+
+## Prerequisites
+
+- Install [docker](https://docs.docker.com/get-docker/)
+- Install [lando](https://docs.lando.dev/getting-started/installation.html)
+- [Generate Pantheon Machine Token](https://pantheon.io/docs/machine-tokens#create-a-machine-token) & [Authenticate into Terminus](https://pantheon.io/docs/machine-tokens#authenticate-into-terminus)
+
+## Local Development with Lando
+
+```
+    lando init
+```
+
+- This should prompt the following selections
+
+```
+    lando init
+    ? From where should we get your app's codebase? pantheon
+    ? Select a Pantheon account <Your email-id with Pantheon>
+    ? Which site? <Name of your Pantheon site>
+    Creating landoinitcigitsite7221_init_1 ...
+```
+
+- Running `lando init` will create a .lando.yml file (or will update the file if  already present in the current directory) with your backend CMS site name and site-id
+
+- Next start your local environment
+
+```
+    lando start
+```
+
+- Next sync your code, db, and files with your local environment
+
+```
+    lando pull
+    ? Choose a Pantheon account bhaskar.jayaraman@pantheon.io
+    ? Pull code from? dev
+    ? Pull database from? dev
+    ? Pull files from? dev
+    Attempting to login via terminus...
+    [notice] Logging in via machine token.
+    [notice] Found a machine token for <Your email-id with Pantheon>.
+    [notice] Logged in via machine token.
+    Logged in as <Your email-id with Pantheon>
+    Verifying that you have access to <Name of your Pantheon site>...
+```
+
+- Run `lando start` again so your container can use the latest code, db, and files
+
+- In order to access your site running locally in a lando container, you may use any of the following urls from the 'lando start' command output on your shell to access your site in your browser
+  - APPSERVER_NGINX URLS
+  - EDGE_SSL URLS
+  - EDGE URLS

--- a/web/docs/Backend Starters/Decoupled Drupal/lando-template-for-local-dev-backend-only.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/lando-template-for-local-dev-backend-only.md
@@ -1,25 +1,18 @@
-# Instructions for Local Development of CMS Backend using Lando
+# Local Development with Lando
 
 ## Prerequisites
 
 - Install [docker](https://docs.docker.com/get-docker/)
 - Install [lando](https://docs.lando.dev/getting-started/installation.html)
-- [Generate Pantheon Machine Token](https://pantheon.io/docs/machine-tokens#create-a-machine-token) & [Authenticate into Terminus](https://pantheon.io/docs/machine-tokens#authenticate-into-terminus)
+- [Generate Pantheon Machine Token](https://pantheon.io/docs/machine-tokens#create-a-machine-token)
 
 ## Local Development with Lando
 
 ```
-    lando init
-```
-
-- This should prompt the following selections
-
-```
-    lando init
-    ? From where should we get your app's codebase? pantheon
-    ? Select a Pantheon account <Your email-id with Pantheon>
-    ? Which site? <Name of your Pantheon site>
-    Creating landoinitcigitsite7221_init_1 ...
+lando init \
+  --source pantheon \
+  --pantheon-auth "$PANTHEON_MACHINE_TOKEN" \
+  --pantheon-site "$PANTHEON_SITE_NAME"
 ```
 
 - Running `lando init` will create a .lando.yml file (or will update the file if  already present in the current directory) with your backend CMS site name and site-id
@@ -34,7 +27,7 @@
 
 ```
     lando pull
-    ? Choose a Pantheon account bhaskar.jayaraman@pantheon.io
+    ? Choose a Pantheon account <Your email-id with Pantheon>
     ? Pull code from? dev
     ? Pull database from? dev
     ? Pull files from? dev
@@ -45,8 +38,6 @@
     Logged in as <Your email-id with Pantheon>
     Verifying that you have access to <Name of your Pantheon site>...
 ```
-
-- Run `lando start` again so your container can use the latest code, db, and files
 
 - In order to access your site running locally in a lando container, you may use any of the following urls from the 'lando start' command output on your shell to access your site in your browser
   - APPSERVER_NGINX URLS

--- a/web/docs/Frontend Starters/Next Drupal/lando-template-local-dev-backend-and-frontend.md
+++ b/web/docs/Frontend Starters/Next Drupal/lando-template-local-dev-backend-and-frontend.md
@@ -4,21 +4,13 @@
 
 - Install [docker](https://docs.docker.com/get-docker/)
 - Install [lando](https://docs.lando.dev/getting-started/installation.html)
-- [Generate Pantheon Machine Token](https://pantheon.io/docs/machine-tokens#create-a-machine-token) & [Authenticate into Terminus](https://pantheon.io/docs/machine-tokens#authenticate-into-terminus)
+- [Generate Pantheon Machine Token](https://pantheon.io/docs/machine-tokens#create-a-machine-token)
 
 ## Local Development with Lando for -
 
 1. Your NextJS front end site
 
-- In your current directory create a new sub-directory e.g. "fe". Clone this front end repo into the "fe" sub-directory [next-drupal-starter](https://github.com/pantheon-systems/next-drupal-starter):
-        
-```
-mkdir fe;\
-> cd fe;\
-> git clone https://github.com/pantheon-systems/next-drupal-starter .
-```    
-
-- Create a lando file similar to the one below:
+- Create a `.lando.yml` lando file similar to the one below:
         
 ```
 name: your-lando-project-name
@@ -42,6 +34,12 @@ npm:
     service: node
 ``` 
 
+- In your current directory create a new sub-directory e.g. "fe". Clone this front end repo into the "fe" sub-directory [next-drupal-starter](https://github.com/pantheon-systems/next-drupal-starter):
+        
+```
+git clone https://github.com/pantheon-systems/next-drupal-starter fe && cd fe
+```    
+
 - Create an environment file for the lando front end node.js site, similar to the one below:
         
 ```
@@ -61,10 +59,11 @@ DEBUG_MODE=
 
 - For more details please refer to these instructions [instructions](https://github.com/pantheon-systems/next-drupal-starter#pantheon-decoupled-kit-next-drupal-starter)
 
-- Run `lando start` [Known Issues](#known-issues)
+- Run `lando start`
+    [Known Issues](#known-issues)
 
 2. Your CMS Backend
-- If your current directory is `fe`, switch into the parent directory e.g. `cd ..`
+- Switch into the directory containing the .lando.yml file
 
 - Follow these [instructions](https://github.com/pantheon-systems/decoupled-kit-js/tree/canary/web/docs/Backend%20Starters/Decoupled%20Drupal/lando-template-for-local-dev-backend-only.md)
 

--- a/web/docs/Frontend Starters/Next Drupal/lando-template-local-dev-backend-and-frontend.md
+++ b/web/docs/Frontend Starters/Next Drupal/lando-template-local-dev-backend-and-frontend.md
@@ -60,7 +60,8 @@ DEBUG_MODE=
 - For more details please refer to these instructions [instructions](https://github.com/pantheon-systems/next-drupal-starter#pantheon-decoupled-kit-next-drupal-starter)
 
 - Run `lando start`
-    [Known Issues](#known-issues)
+
+- [Known Issues](#known-issues)
 
 2. Your CMS Backend
 - Switch into the directory containing the .lando.yml file

--- a/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
+++ b/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
@@ -11,50 +11,53 @@
 1. Your NextJS front end site
 
 - In your current directory create a new sub-directory e.g. "fe". Clone this front end repo into the "fe" sub-directory [next-drupal-starter](https://github.com/pantheon-systems/next-drupal-starter):
-        ```
-        mkdir fe;\
-         > cd fe;\
-         > git clone https://github.com/pantheon-systems/next-drupal-starter .
-        ```    
+        
+```
+mkdir fe;\
+> cd fe;\
+> git clone https://github.com/pantheon-systems/next-drupal-starter .
+```    
 
 - Create a lando file similar to the one below:
-        ```
-        name: your-lando-project-name
-        services:
-        node:
-            type: 'node:16'
-            build:
-            - npm install -g pnpm@7.1.0
-            - pnpm install --prefix ./fe
-            port: 3000
-            command: npm run dev --prefix ./fe
-        proxy:
-        node:
-            - 'your-decoupled-frontend-site.lndo.site:3000'
-        tooling:
-        yarn:
-            service: node
-        node:
-            service: node
-        npm:
-            service: node
-        ``` 
+        
+```
+name: your-lando-project-name
+services:
+node:
+    type: 'node:16'
+    build:
+    - npm install -g pnpm@7.1.0
+    - pnpm install --prefix ./fe
+    port: 3000
+    command: npm run dev --prefix ./fe
+proxy:
+node:
+    - 'your-decoupled-frontend-site.lndo.site:3000'
+tooling:
+yarn:
+    service: node
+node:
+    service: node
+npm:
+    service: node
+``` 
 
 - Create an environment file for the lando front end node.js site, similar to the one below:
-        ```
-        # Copy as .env.development.local to override envars for local development
-        BACKEND_URL=https://your-pantheon-CMS-backend-site.pantheonsite.io
-        #FRONTEND_URL=
-        IMAGE_DOMAIN=your-pantheon-CMS-backend-site.pantheonsite.io
-        CLIENT_ID=
-        CLIENT_SECRET=
-        PREVIEW_SECRET=
-        #NEXT_PUBLIC_FRONTEND_URL=$FRONTEND_URL
+        
+```
+# Copy as .env.development.local to override envars for local development
+BACKEND_URL=https://your-pantheon-CMS-backend-site.pantheonsite.io
+#FRONTEND_URL=
+IMAGE_DOMAIN=your-pantheon-CMS-backend-site.pantheonsite.io
+CLIENT_ID=
+CLIENT_SECRET=
+PREVIEW_SECRET=
+#NEXT_PUBLIC_FRONTEND_URL=$FRONTEND_URL
 
-        # Sets debug mode for instance of DrupalState.
-        # Leave empty to turn off debug mode
-        DEBUG_MODE=
-        ```
+# Sets debug mode for instance of DrupalState.
+# Leave empty to turn off debug mode
+DEBUG_MODE=
+```
 
 - For more details please refer to these instructions [instructions](https://github.com/pantheon-systems/next-drupal-starter#pantheon-decoupled-kit-next-drupal-starter)
 

--- a/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
+++ b/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
@@ -15,7 +15,7 @@
         mkdir fe;\
          > cd fe;\
          > git clone https://github.com/pantheon-systems/next-drupal-starter .
-      ```   
+         
 
 - Create a lando file similar to the one below:
         ```
@@ -38,10 +38,11 @@
             service: node
         npm:
             service: node
-        ```
+        
 
 - Create an environment file for the lando front end node.js site, similar to the one below:
-    ```# Copy as .env.development.local to override envars for local development
+    ```
+        # Copy as .env.development.local to override envars for local development
         BACKEND_URL=https://your-pantheon-CMS-backend-site.pantheonsite.io
         #FRONTEND_URL=
         IMAGE_DOMAIN=your-pantheon-CMS-backend-site.pantheonsite.io
@@ -52,7 +53,8 @@
 
         # Sets debug mode for instance of DrupalState.
         # Leave empty to turn off debug mode
-        DEBUG_MODE=```
+        DEBUG_MODE=
+    
 
 - For more details please refer to these instructions [instructions](https://github.com/pantheon-systems/next-drupal-starter#pantheon-decoupled-kit-next-drupal-starter)
 

--- a/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
+++ b/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
@@ -61,7 +61,7 @@ DEBUG_MODE=
 
 - For more details please refer to these instructions [instructions](https://github.com/pantheon-systems/next-drupal-starter#pantheon-decoupled-kit-next-drupal-starter)
 
-- Run `lando start` [known-issues]
+- Run `lando start` [known-issues](#known-issues)
 
 2. Your CMS Backend
 - If your current directory is `fe`, switch into the parent directory e.g. `cd ..`

--- a/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
+++ b/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
@@ -61,7 +61,7 @@ DEBUG_MODE=
 
 - For more details please refer to these instructions [instructions](https://github.com/pantheon-systems/next-drupal-starter#pantheon-decoupled-kit-next-drupal-starter)
 
-- Run `lando start` [known-issues](#known-issues)
+- Run `lando start` [Known Issues](#known-issues)
 
 2. Your CMS Backend
 - If your current directory is `fe`, switch into the parent directory e.g. `cd ..`

--- a/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
+++ b/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
@@ -11,11 +11,11 @@
 1. Your NextJS front end site
 
 - In your current directory create a new sub-directory e.g. "fe". Clone this front end repo into the "fe" sub-directory [next-drupal-starter](https://github.com/pantheon-systems/next-drupal-starter):
-    ```
+        ```
         mkdir fe;\
          > cd fe;\
          > git clone https://github.com/pantheon-systems/next-drupal-starter .
-         
+        ```    
 
 - Create a lando file similar to the one below:
         ```
@@ -38,10 +38,10 @@
             service: node
         npm:
             service: node
-        
+        ``` 
 
 - Create an environment file for the lando front end node.js site, similar to the one below:
-    ```
+        ```
         # Copy as .env.development.local to override envars for local development
         BACKEND_URL=https://your-pantheon-CMS-backend-site.pantheonsite.io
         #FRONTEND_URL=
@@ -54,7 +54,7 @@
         # Sets debug mode for instance of DrupalState.
         # Leave empty to turn off debug mode
         DEBUG_MODE=
-    
+        ```
 
 - For more details please refer to these instructions [instructions](https://github.com/pantheon-systems/next-drupal-starter#pantheon-decoupled-kit-next-drupal-starter)
 

--- a/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
+++ b/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
@@ -1,0 +1,72 @@
+# Instructions for Local Development of Decoupled Front End and CMS Backend using Lando
+
+## Prerequisites
+
+- Install [docker](https://docs.docker.com/get-docker/)
+- Install [lando](https://docs.lando.dev/getting-started/installation.html)
+- [Generate Pantheon Machine Token](https://pantheon.io/docs/machine-tokens#create-a-machine-token) & [Authenticate into Terminus](https://pantheon.io/docs/machine-tokens#authenticate-into-terminus)
+
+## Local Development with Lando for -
+
+1. Your NextJS front end site
+
+- In your current directory create a new sub-directory e.g. "fe". Clone this front end repo into the "fe" sub-directory [next-drupal-starter](https://github.com/pantheon-systems/next-drupal-starter):
+    - ```mkdir fe;\
+         > cd fe;\
+         > git clone https://github.com/pantheon-systems/next-drupal-starter .
+      ```   
+
+- Create a lando file similar to the one below:
+     ```name: your-lando-project-name
+        services:
+        node:
+            type: 'node:16'
+            build:
+            - npm install -g pnpm@7.1.0
+            - pnpm install --prefix ./fe
+            port: 3000
+            command: npm run dev --prefix ./fe
+        proxy:
+        node:
+            - 'your-decoupled-frontend-site.lndo.site:3000'
+        tooling:
+        yarn:
+            service: node
+        node:
+            service: node
+        npm:
+            service: node```
+
+- Create an environment file for the lando front end node.js site, similar to the one below:
+    ```# Copy as .env.development.local to override envars for local development
+        BACKEND_URL=https://your-pantheon-CMS-backend-site.pantheonsite.io
+        #FRONTEND_URL=
+        IMAGE_DOMAIN=your-pantheon-CMS-backend-site.pantheonsite.io
+        CLIENT_ID=
+        CLIENT_SECRET=
+        PREVIEW_SECRET=
+        #NEXT_PUBLIC_FRONTEND_URL=$FRONTEND_URL
+
+        # Sets debug mode for instance of DrupalState.
+        # Leave empty to turn off debug mode
+        DEBUG_MODE=```
+
+- For more details please refer to these instructions [instructions](https://github.com/pantheon-systems/next-drupal-starter#pantheon-decoupled-kit-next-drupal-starter)
+
+- Run `lando start` [known-issues]
+
+2. Your CMS Backend
+- If your current directory is `fe`, switch into the parent directory e.g. `cd ..`
+
+- Follow these [instructions](https://github.com/pantheon-systems/decoupled-kit-js/tree/canary/web/docs/Backend%20Starters/Decoupled%20Drupal/lando-template-for-local-dev-backend-only.md)
+
+- lando will update your previously created `.lando.yml` file in step 1. with the backend CMS site name and site id
+
+3. Now you should be able to preview both the backend and front end sites in the same lando environment
+
+### Known Issues
+
+- If your lando site is inaccessible after step 1, it could be because `npm install` didn't run inside your container. Follow these steps -
+    - Log into your container by running `lando ssh`
+    - Switch into the `fe` directory inside the container and run `npm install`
+    - Exit the container and run `lando start` again

--- a/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
+++ b/web/docs/Frontend Starters/lando-template-local-dev-backend-and-frontend.md
@@ -11,13 +11,15 @@
 1. Your NextJS front end site
 
 - In your current directory create a new sub-directory e.g. "fe". Clone this front end repo into the "fe" sub-directory [next-drupal-starter](https://github.com/pantheon-systems/next-drupal-starter):
-    - ```mkdir fe;\
+    ```
+        mkdir fe;\
          > cd fe;\
          > git clone https://github.com/pantheon-systems/next-drupal-starter .
       ```   
 
 - Create a lando file similar to the one below:
-     ```name: your-lando-project-name
+        ```
+        name: your-lando-project-name
         services:
         node:
             type: 'node:16'
@@ -35,7 +37,8 @@
         node:
             service: node
         npm:
-            service: node```
+            service: node
+        ```
 
 - Create an environment file for the lando front end node.js site, similar to the one below:
     ```# Copy as .env.development.local to override envars for local development


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Added two new lando files for enable local development for frontend and backend sites

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
Files added:
lando-template-for-local-dev-backend-only.md
lando-template-local-dev-backend-and-frontend.md

## How have the changes been tested?
Yes by following the instructions and installing the lando environment locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!