### PR TITLE
DB-3597: [next-wordpress] Automatic CMS config

### DIFF
--- a/starters/next-wordpress-starter/next.config.js
+++ b/starters/next-wordpress-starter/next.config.js
@@ -6,15 +6,26 @@ require("dotenv").config({
   path: path.resolve(process.cwd(), ".env.development.local"),
 });
 
+let backendUrl, imageDomain;
+if (process.env.WPGRAPHQL_URL === undefined) {
+  backendUrl = `https://${process.env.PANTHEON_CMS_ENDPOINT}/wp/graphql`;
+  imageDomain = process.env.IMAGE_DOMAIN || process.env.PANTHEON_CMS_ENDPOINT;
+} else {
+  backendUrl = process.env.WPGRAPHQL_URL;
+  imageDomain = process.env.IMAGE_DOMAIN || process.env.WPGRAPHQL_URL;
+}
+// remove trailing slash if it exists
+imageDomain = imageDomain.replace(/\/$/, "");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   env: {
-    backendUrl: process.env.WPGRAPHQL_URL,
-    imageUrl: `https://${process.env.IMAGE_DOMAIN}`,
+    backendUrl: backendUrl,
+    imageUrl: `https://${imageDomain}`,
   },
   images: {
-    domains: [process.env.IMAGE_DOMAIN],
+    domains: [imageDomain],
   },
 };
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Updated config logic so that importing a site made with the next-wordpress-starter into the dashboard and linking a cms results in a successful build without setting any env vars.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
next-wordpress-starter

## How have the changes been tested?
Successfully deployed a site using the next-wordpress-starter without setting any environment variables.

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!