### PR TITLE
DB-3593: Don't use refresh while building

### DIFF
--- a/.changeset/witty-pugs-cough.md
+++ b/.changeset/witty-pugs-cough.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+---
+
+Add BUILD_MODE constant as a switch for DrupalState's refresh option

--- a/starters/next-drupal-starter/lib/constants.js
+++ b/starters/next-drupal-starter/lib/constants.js
@@ -1,7 +1,4 @@
-const DRUPAL_URL = process.env.backendUrl;
-const IMAGE_URL = process.env.imageUrl || DRUPAL_URL;
-
-module.exports = {
-  DRUPAL_URL,
-  IMAGE_URL,
-};
+export const DRUPAL_URL = process.env.backendUrl;
+export const IMAGE_URL = process.env.imageUrl || DRUPAL_URL;
+export const BUILD_MODE =
+  process.env.npm_lifecycle_script?.includes("next build");

--- a/starters/next-drupal-starter/pages/examples/auth-api.jsx
+++ b/starters/next-drupal-starter/pages/examples/auth-api.jsx
@@ -59,12 +59,12 @@ export async function getServerSideProps(context) {
   try {
     const articles = await authStore.getObject({
       objectName: "node--article",
-      refresh: true,
+      refresh: !BUILD_MODE,
       res: context.res,
     });
     const footerMenu = await authStore.getObject({
       objectName: "menu_items--main",
-      refresh: true,
+      refresh: !BUILD_MODE,
       res: context.res,
     });
     return {

--- a/starters/next-drupal-starter/pages/examples/index.jsx
+++ b/starters/next-drupal-starter/pages/examples/index.jsx
@@ -6,6 +6,7 @@ import {
   getCurrentLocaleStore,
   globalDrupalStateStores,
 } from "../../lib/drupalStateContext";
+import { BUILD_MODE } from "../../lib/constants";
 
 export default function ExamplesPageTemplate({ footerMenu }) {
   return (
@@ -36,9 +37,10 @@ export default function ExamplesPageTemplate({ footerMenu }) {
               Drupal&apos;s API.
             </li>
             <li>
-              <Link href="/examples/ssg-isr">SSG and ISR</Link> - by default, this starter kit is optimized for SSR and
-              Edge Caching on Pantheon. This example is provided for cases where
-              Next.js static generation options would be beneficial.
+              <Link href="/examples/ssg-isr">SSG and ISR</Link> - by default,
+              this starter kit is optimized for SSR and Edge Caching on
+              Pantheon. This example is provided for cases where Next.js static
+              generation options would be beneficial.
             </li>
             <li>
               <Link href="/examples/pagination">Pagination</Link> - a paginated
@@ -58,6 +60,7 @@ export async function getStaticProps(context) {
   try {
     const footerMenu = await store.getObject({
       objectName: "menu_items--main",
+      refresh: !BUILD_MODE,
     });
 
     return {
@@ -70,4 +73,3 @@ export async function getStaticProps(context) {
     console.error(error);
   }
 }
-

--- a/starters/next-drupal-starter/pages/examples/pagination/[[...page]].jsx
+++ b/starters/next-drupal-starter/pages/examples/pagination/[[...page]].jsx
@@ -4,6 +4,7 @@ import {
   getCurrentLocaleStore,
   globalDrupalStateStores,
 } from "../../../lib/drupalStateContext";
+import { BUILD_MODE } from "../../../lib/constants";
 
 import Paginator from "../../../components/paginator";
 import Head from "next/head";
@@ -118,6 +119,7 @@ export async function getStaticProps(context) {
       }
     }`,
     all: true,
+    refresh: !BUILD_MODE,
   });
 
   const store = getCurrentLocaleStore(context.locale, globalDrupalStateStores);

--- a/starters/next-drupal-starter/pages/examples/ssg-isr.jsx
+++ b/starters/next-drupal-starter/pages/examples/ssg-isr.jsx
@@ -4,6 +4,7 @@ import {
   getCurrentLocaleStore,
   globalDrupalStateStores,
 } from "../../lib/drupalStateContext";
+import { BUILD_MODE } from "../../lib/constants";
 
 import { ArticleGridItem, withGrid } from "../../components/grid";
 import Layout from "../../components/layout";
@@ -70,7 +71,7 @@ export async function getStaticProps(context) {
     const articles = await store.getObject({
       objectName: "node--article",
       params: "include=field_media_image.field_media_image",
-      refresh: true,
+      refresh: !BUILD_MODE,
     });
 
     if (!articles) {
@@ -81,7 +82,7 @@ export async function getStaticProps(context) {
 
     const footerMenu = await store.getObject({
       objectName: "menu_items--main",
-      refresh: true,
+      refresh: !BUILD_MODE,
     });
 
     return {


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Add a new constant, `BUILD_MODE` to the `next-drupal-starter` which determines if the last command was `next build`
- Flip the `refresh` parameter on `DrupalState.getObject` on or off depending on the `BUILD_MODE` for SSG/ISR routes

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
`next-drupal-starter`

## How have the changes been tested?
locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!