### PR TITLE
DB-3678: Trigger canary_split workflow on successful canary_release

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -7,7 +7,7 @@ on:
 
 # Releases a canary tagged version of the packages
 jobs:
-  version:
+  canary_release:
     name: canary version and publish
     env:
       CI: true

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -1,14 +1,17 @@
 name: "Split Canary Sites"
 
+# run this job on after canary_release has completed
 on:
-  push:
-    branches:
-      - canary
+  workflow_run:
+    workflows: [canary_release]
+    types:
+      - completed
 
 # split the starers to repos to be deployed on the platform
 # for easy QA testing
 jobs:
-  packages_split_canary:
+  # this job should only run if canary_release was successful
+  on-success:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -8,7 +8,7 @@ on:
       - "*"
 
 jobs:
-  version:
+  release:
     name: version and publish
     env:
       CI: true
@@ -46,7 +46,7 @@ jobs:
 
   packages_split:
     # only run this job after version and publish has finished
-    needs: version
+    needs: release
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Changed the `on` property of the `canary-split` workflow so that it only triggers on successful completion of the `canary-release` workflow
- Changed some job names to better reflect what they do

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
`.github/workflows`

## How have the changes been tested?
Ritualistic summoning of the GitHub Actions Octocat :octocat: , it gave me the OK.

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!