### PR TITLE
Fix next wp starter

### DIFF
--- a/.changeset/cuddly-terms-explode.md
+++ b/.changeset/cuddly-terms-explode.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-wordpress-starter": patch
+---
+
+Fix file name for WordPressClient

--- a/starters/next-wordpress-starter/lib/WordPressClient.js
+++ b/starters/next-wordpress-starter/lib/WordPressClient.js
@@ -1,0 +1,3 @@
+import { GraphqlClientFactory } from "@pantheon-systems/wordpress-kit";
+
+export const client = new GraphqlClientFactory(process.env.backendUrl).create();

--- a/starters/next-wordpress-starter/lib/WordpressClient.js
+++ b/starters/next-wordpress-starter/lib/WordpressClient.js
@@ -1,3 +1,0 @@
-import { GraphqlClientFactory } from "@pantheon-systems/wordpress-kit";
-
-export const client = new GraphqlClientFactory(process.env.backendUrl).create();


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
GitHub doesn't respect changing case of a filename unless you commit the deletion of the file, then recommit it as a 'new file'. It seems to understand the rename after that. 🙃

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 


## How have the changes been tested?
TBD on our canary site

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!