### PR TITLE
Remove protocol from `IMAGE_DOMAIN` if it is http OR https

### DIFF
--- a/.changeset/four-pans-protect.md
+++ b/.changeset/four-pans-protect.md
@@ -1,0 +1,6 @@
+---
+"@pantheon-systems/next-drupal-starter": patch
+"@pantheon-systems/next-wordpress-starter": patch
+---
+
+Derive IMAGE_DOMAIN from the backend url when it is https or http

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -31,7 +31,7 @@ if (process.env.BACKEND_URL === undefined) {
   backendUrl = process.env.BACKEND_URL;
   imageDomain =
     process.env.IMAGE_DOMAIN ||
-    process.env.BACKEND_URL.replace(/^https:\/\//, "");
+    process.env.BACKEND_URL.replace(/^https?:\/\//, "");
 }
 // remove trailing slash if it exists
 imageDomain = imageDomain.replace(/\/$/, "");

--- a/starters/next-wordpress-starter/next.config.js
+++ b/starters/next-wordpress-starter/next.config.js
@@ -28,7 +28,12 @@ if (process.env.WPGRAPHQL_URL === undefined) {
   process.env.WPGRAPHQL_URL = `https://${process.env.PANTHEON_CMS_ENDPOINT}/wp/graphql`;
 } else {
   backendUrl = process.env.WPGRAPHQL_URL;
-  imageDomain = process.env.IMAGE_DOMAIN || process.env.WPGRAPHQL_URL;
+  imageDomain =
+    process.env.IMAGE_DOMAIN ||
+    process.env.WPGRAPHQL_URL.replace(/\/wp\/graphql$/, "").replace(
+      /^https?:\/\//,
+      ""
+    );
 }
 // remove trailing slash if it exists
 imageDomain = imageDomain.replace(/\/$/, "");


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
If using `http` for the `BACKEND_URL` in either Next.js starter, the image domain would add `https` to the begining of the url and break all images. This should make it so if a user does not set the `IMAGE_DOMAIN` and is using `http` for the `BACKEND_URL` or `WPGRAPHQL_URL`, things will not break.

## Where were the changes made?
<!--- Please add the appropriate label(s) ---> 
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label---> 
`next-drupal-starter`, `next-wordpress-starter`

## How have the changes been tested?
tested locally

## Additional information
<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!