### PR TITLE
DB-3654: Block Editor Cover Styles

### DIFF
--- a/.changeset/gentle-pumas-compare.md
+++ b/.changeset/gentle-pumas-compare.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/wordpress-kit": minor
+---
+
+Add support for cover component from WordPress

--- a/packages/wordpress-kit/src/lib/TailwindcssPlugin.ts
+++ b/packages/wordpress-kit/src/lib/TailwindcssPlugin.ts
@@ -7,6 +7,7 @@ import {
 	TableComponent,
 	GalleryComponent,
 	AudioComponent,
+	CoverComponent,
 } from './tailwindcssPlugin/components';
 import { mergeToConfig } from './tailwindcssPlugin/Config';
 import { ColorUtilities, FontsUtilities } from './tailwindcssPlugin/utilities';
@@ -40,6 +41,10 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
 		alignFull: { minWidth: theme('screen.xl', '1280px') },
 	});
 
+	const cover = CoverComponent({
+		alignFull: { minWidth: theme('screen.xl', '1280px') },
+	});
+
 	addUtilities([
 		color.getBackgroundUtilities(),
 		color.getBorderColorUtilities(),
@@ -51,5 +56,5 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
 		quoteUtilities,
 	]);
 
-	addComponents([table, image, pullQuote, gallery, audio]);
+	addComponents([table, image, pullQuote, gallery, audio, cover]);
 }, mergeToConfig);

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/Config.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/Config.ts
@@ -40,5 +40,6 @@ export const mergeToConfig: Config = {
 		'.wp-block-image',
 		'.wp-block-gallery',
 		'.wp-block-audio',
+		'.wp-block-cover',
 	],
 };

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Cover.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Cover.ts
@@ -31,6 +31,13 @@ const innerContainer = {
 		color: '#fff',
 		p: {
 			position: 'relative',
+			'>img': {
+				height: 'auto',
+				'max-width': '100%',
+				margin: '0',
+				display: 'inline',
+				'vertical-align': 'unset',
+			},
 		},
 	},
 };
@@ -83,8 +90,6 @@ export const CoverComponent = ({
 }) => ({
 	'.wp-block-cover': {
 		'max-width': '650px',
-		'margin-left': 'auto',
-		'margin-right': 'auto',
 		position: 'relative',
 		'background-size': 'cover',
 		'background-position': '50%',
@@ -93,8 +98,9 @@ export const CoverComponent = ({
 		width: '100%',
 		'place-items': 'center',
 		padding: '1rem',
+		margin: '1rem auto',
 		'box-sizing': 'border-box',
-		img: {
+		'>img': {
 			position: 'absolute',
 			top: '0',
 			left: '0',

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Cover.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Cover.ts
@@ -1,0 +1,145 @@
+type Opacities = { [key: string]: { opacity: string } };
+
+const generateOpacity: () => Opacities = () => {
+	const opacities: Opacities = {};
+	for (let i = 0; i <= 10; i++) {
+		opacities[`&.has-background-dim-${i * 10}`] = {
+			opacity: `${i * 0.1}`,
+		};
+	}
+	return opacities;
+};
+
+const background = {
+	'.wp-block-cover__background': {
+		position: 'absolute',
+		top: '0',
+		left: '0',
+		bottom: '0',
+		right: '0',
+		'z-index': '1',
+		opacity: '0.5',
+		'background-color': '#000',
+		...generateOpacity(),
+	},
+};
+
+const innerContainer = {
+	'.wp-block-cover__inner-container': {
+		'z-index': '1',
+		width: '100%',
+		color: '#fff',
+		p: {
+			position: 'relative',
+		},
+	},
+};
+
+const contentPosition = {
+	'&.is-position-top-left': {
+		'align-items': 'flex-start',
+		'justify-content': 'flex-start',
+	},
+	'&.is-position-top-center': {
+		'align-items': 'flex-start',
+		'justify-content': 'center',
+	},
+	'&.is-position-top-right': {
+		'align-items': 'flex-start',
+		'justify-content': 'flex-end',
+	},
+	'&.is-position-center-left': {
+		'align-items': 'center',
+		'justify-content': 'flex-start',
+	},
+	'&.is-position-center-right': {
+		'align-items': 'center',
+		'justify-content': 'flex-end',
+	},
+	'&.is-position-bottom-left': {
+		'align-items': 'flex-end',
+		'justify-content': 'flex-start',
+	},
+	'&.is-position-bottom-center': {
+		'align-items': 'flex-end',
+		'justify-content': 'center',
+	},
+	'&.is-position-bottom-right': {
+		'align-items': 'flex-end',
+		'justify-content': 'flex-end',
+	},
+	'&.has-custom-content-position': {
+		'.wp-block-cover__inner-container': {
+			width: 'auto',
+			margin: '0',
+		},
+	},
+};
+
+export const CoverComponent = ({
+	alignFull: { minWidth },
+}: {
+	alignFull: { minWidth: string };
+}) => ({
+	'.wp-block-cover': {
+		'max-width': '650px',
+		'margin-left': 'auto',
+		'margin-right': 'auto',
+		position: 'relative',
+		'background-size': 'cover',
+		'background-position': '50%',
+		'min-height': '430px',
+		display: 'flex',
+		width: '100%',
+		'place-items': 'center',
+		padding: '1rem',
+		'box-sizing': 'border-box',
+		img: {
+			position: 'absolute',
+			top: '0',
+			left: '0',
+			bottom: '0',
+			right: '0',
+			margin: '0',
+			padding: '0',
+			width: '100%',
+			height: '100%',
+			'max-width': 'none',
+			'max-height': 'none',
+			'object-fit': 'cover',
+			outline: 'none',
+			border: 'none',
+			'box-shadow': 'none',
+			'z-index': '0',
+		},
+		'&.has-parallax': {
+			'background-attachment': 'fixed',
+		},
+		'&.is-repeated': {
+			'background-repeat': 'repeat',
+			'background-size': 'auto',
+		},
+		'&.alignwide': {
+			maxWidth: '850px',
+		},
+		'&.alignleft': {
+			maxWidth: '420px',
+			float: 'left',
+		},
+		'&.alignright': {
+			maxWidth: '420px',
+			float: 'right',
+		},
+		'&.alignfull': {
+			[`@media (min-width:${minWidth})`]: {
+				marginLeft: 'calc(-1 * max(1rem, 10vw))',
+				marginRight: 'calc(-1 * max(1rem, 10vw))',
+				maxWidth: 'unset',
+				width: 'unset',
+			},
+		},
+		...background,
+		...innerContainer,
+		...contentPosition,
+	},
+});

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/index.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/index.ts
@@ -4,6 +4,7 @@ import { TableComponent } from './Table';
 import { Quote } from './Quote';
 import { GalleryComponent } from './Gallery';
 import { AudioComponent } from './Audio';
+import { CoverComponent } from './Cover';
 
 export {
 	ImageComponent,
@@ -12,4 +13,5 @@ export {
 	Quote,
 	GalleryComponent,
 	AudioComponent,
+	CoverComponent,
 };

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/utilities/Colors.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/utilities/Colors.ts
@@ -146,7 +146,7 @@ export class ColorUtilities {
 			(acc, color) => ({
 				...acc,
 				[`.has-${color.name}-background-color`]: {
-					backgroundColor: this.getColor(color),
+					backgroundColor: `${this.getColor(color)} !important`,
 				},
 			}),
 			{


### PR DESCRIPTION
## What changes were made?
- Added support for Cover component
## Where were the changes made?
- WordPress-Kit

## How have the changes been tested?
- Locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
