### PR TITLE
Fix import

### DIFF
--- a/.changeset/gold-avocados-end.md
+++ b/.changeset/gold-avocados-end.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/next-drupal-starter': patch
+---
+
+Fix import in preview api route

--- a/starters/next-drupal-starter/pages/api/preview.js
+++ b/starters/next-drupal-starter/pages/api/preview.js
@@ -1,4 +1,7 @@
-import { globalDrupalStateAuthStores, getCurrentLocaleStore } from './stores';
+import {
+	globalDrupalStateAuthStores,
+	getCurrentLocaleStore,
+} from '../../lib/stores';
 import { fetchJsonapiEndpoint } from '@pantheon-systems/drupal-kit';
 /**
  *


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
The `next-drupal-starter` was not building due to a borked import. Somehow it got changed in the prettier config pr.

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
