### PR TITLE
Update changeset

### DIFF
--- a/.changeset/breezy-rings-wait.md
+++ b/.changeset/breezy-rings-wait.md
@@ -1,6 +1,11 @@
 ---
-"@pantheon-systems/drupal-kit": patch
-"@pantheon-systems/next-drupal-starter": patch
+'@pantheon-systems/drupal-kit': major
 ---
 
-DB-3775: Removed query option and added param filters to getObject calls that would benefit from filtered responses. 
+## Breaking Changes
+
+Removed the `query` option from `DrupalState`. This reflects the same upstream
+change in `@gdwc/drupal-state`.
+
+If you are still using a query after updating, you will receive a warning in the
+console and the full payload for the requested object.

--- a/.changeset/dig-gentle-rabbits.md
+++ b/.changeset/dig-gentle-rabbits.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/next-drupal-starter': patch
+---
+
+Removed query option and added param filters to getObject calls that would
+benefit from filtered responses.


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Didn't check the version closely on the remove query changeset and I think it should be a major version. Wanted to get this in before the canary release as it will mess with our version #s.

## Where were the changes made?
changesets.
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
