### PR TITLE
DB-4217: Add tailwindcss prefix

### DIFF
--- a/.changeset/small-eggs-work.md
+++ b/.changeset/small-eggs-work.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/nextjs-kit': minor
+---
+
+Added the prefix option in the tailwindcss config so the styles generated from
+nextjs-kit will not override default tailwindcss classes in a project

--- a/packages/nextjs-kit/package.json
+++ b/packages/nextjs-kit/package.json
@@ -38,12 +38,13 @@
 		"lint-staged": "lint-staged"
 	},
 	"devDependencies": {
-		"@pantheon-systems/eslint-config": "*",
 		"@pantheon-systems/configs": "*",
+		"@pantheon-systems/eslint-config": "*",
 		"@testing-library/react": "12.1.5",
 		"@vitejs/plugin-react": "^2.0.0",
 		"autoprefixer": "^10.4.4",
 		"c8": "^7.12.0",
+		"eslint-plugin-prettier": "^4.2.1",
 		"next": "^12.2.5",
 		"postcss": "^8.4.12",
 		"react": "17.0.2",

--- a/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/contentWithImage.test.tsx.snap
+++ b/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/contentWithImage.test.tsx.snap
@@ -3,26 +3,26 @@
 exports[`<ContentWithImage /> > should render 'contentWithImage' 1`] = `
 <DocumentFragment>
   <article
-    class="prose xs:prose-xs md:prose-md lg:prose-lg mt-10 mx-auto max-w-screen lg:max-w-screen-lg md:max-w-screen-md sm:max-w-screen-sm p-4"
+    class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-p-4"
   >
     <h1>
       Example Post with Image
     </h1>
     <p
-      class="text-sm text-gray-600"
+      class="ps-text-sm ps-text-gray-600"
     >
       8/4/2022
     </p>
     <a
-      class="font-normal cursor-pointer"
+      class="ps-font-normal ps-cursor-pointer"
     >
       Back →
     </a>
     <div
-      class="mt-12 max-w-screen mx-auto lg:max-w-screen-lg shadow-lg [&*>img]:rounded-lg"
+      class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
     >
       <div
-        class="relative mb-10 min-h-[50vh]"
+        class="ps-relative ps-mb-10 ps-min-h-[50vh]"
       >
         <span
           style="box-sizing: border-box; display: block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px;"
@@ -40,7 +40,7 @@ exports[`<ContentWithImage /> > should render 'contentWithImage' 1`] = `
       </div>
     </div>
     <div
-      class="break-words mt-12"
+      class="ps-break-words ps-mt-12"
     >
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/footer.test.tsx.snap
+++ b/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/footer.test.tsx.snap
@@ -3,28 +3,28 @@
 exports[`<Footer /> > should render 'footer' 1`] = `
 <DocumentFragment>
   <footer
-    class="w-full text-white bg-black p-4 mt-12"
+    class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
   >
     <nav
-      class="flex flex-col max-w-lg mx-auto lg:max-w-screen-lg"
+      class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
     >
       <ul>
         <ul>
           <li
-            class="list-disc text-blue-300"
+            class="ps-list-disc ps-text-blue-300"
           >
             <a
-              class="text-blue-300 hover:underline hover:text-blue-100 focus:text-purple-600 active:text-purple-300"
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
               href="/"
             >
               Home
             </a>
           </li>
           <li
-            class="list-disc text-blue-300 ml-3"
+            class="ps-list-disc ps-text-blue-300 ps-ml-3"
           >
             <a
-              class="text-blue-300 hover:underline hover:text-blue-100 focus:text-purple-600 active:text-purple-300"
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
               href="/articles"
             >
               Articles
@@ -32,10 +32,10 @@ exports[`<Footer /> > should render 'footer' 1`] = `
           </li>
         </ul>
         <li
-          class="list-disc text-blue-300"
+          class="ps-list-disc ps-text-blue-300"
         >
           <a
-            class="text-blue-300 hover:underline hover:text-blue-100 focus:text-purple-600 active:text-purple-300"
+            class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
             href="/pages"
           >
             Pages
@@ -44,7 +44,7 @@ exports[`<Footer /> > should render 'footer' 1`] = `
       </ul>
     </nav>
     <div
-      class="flex my-4 p-2"
+      class="ps-flex ps-my-4 ps-p-2"
     >
       <span
         class="mx-auto"

--- a/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/header.test.tsx.snap
+++ b/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/header.test.tsx.snap
@@ -3,37 +3,37 @@
 exports[`<Header /> > should render 'header' 1`] = `
 <DocumentFragment>
   <div
-    class="my-0 pt-10 px-5 text-xl"
+    class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
   >
     <nav>
       <ul
-        class="flex flex-row flex-wrap sm:flex-nowrap list-none justify-between max-w-screen-sm mx-auto"
+        class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
       >
         <li
-          class="mr-auto"
+          class="ps-mr-auto"
         >
           <a
-            class="hover:underline"
+            class="hover:ps-underline"
             href="/"
           >
             Home
           </a>
         </li>
         <li
-          class="mx-4"
+          class="ps-mx-4"
         >
           <a
-            class="hover:underline"
+            class="hover:ps-underline"
             href="/posts"
           >
             Posts
           </a>
         </li>
         <li
-          class="mx-4"
+          class="ps-mx-4"
         >
           <a
-            class="hover:underline"
+            class="hover:ps-underline"
             href="/pages"
           >
             Pages

--- a/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/paginator.test.tsx.snap
+++ b/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/paginator.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`<Paginator /> > check back button works 1`] = `
 <DocumentFragment>
   <div
-    class="max-w-screen-md"
+    class="ps-max-w-screen-md"
   >
     <h3
-      class="mb-8 prose-sm"
+      class="ps-mb-8 ps-prose-sm"
     >
       Page 1/18
     </h3>
@@ -155,127 +155,189 @@ Erat et...
       </article>
     </section>
     <div
-      class="sticky lg:bottom-12 bottom-4"
+      class="ps-sticky lg:ps-bottom-12 ps-bottom-4"
     >
-      <div
-        class="flex flex-row justify-center mx-auto mt-auto mb-4"
+      <nav
+        aria-label="Pagination Navigation"
+        role="navigation"
       >
-        <button
-          class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-l-2 border-t-2 border-b-2 border-black bg-white"
-          disabled=""
-          id="back-btn"
+        <ul
+          class="ps-list-none ps-flex ps-flex-row ps-justify-center ps-mx-auto ps-mt-auto ps-mb-4 [&>li]:ps-p-0"
         >
-          &lt;
-        </button>
-        <button
-          class="
-          block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-blue-700 border-2
+          <li>
+            <button
+              aria-label="Go to Previous Page"
+              class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-l-2"
+              disabled=""
+              id="back-btn"
+            >
+              &lt;
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="true"
+              aria-label="Current Page, Page 1"
+              class="
+          ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-blue-700 ps-border-2
           "
-        >
-          1
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              1
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 2"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          2
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              2
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 3"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          3
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              3
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 4"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          4
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              4
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 5"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          5
-        </button>
-        <button
-          class="hidden md:block h-16 w-12 border-2 border-black bg-slate-200 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300\\"
+            >
+              5
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Expand Hidden Buttons"
+              class="ps-hidden md:ps-block ps-h-16 ps-w-12 ps-border-2 ps-border-black ps-bg-slate-200 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300\\"
             }"
-        >
-          ...
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              ...
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 12"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          12
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              12
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 13"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          13
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              13
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 14"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          14
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              14
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 15"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          15
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              15
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 16"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          16
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              16
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 17"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          17
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              17
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 18"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          18
-        </button>
-        <button
-          class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300  border-r-2 border-t-2 border-b-2 border-black bg-white"
-          id="next-btn"
-        >
-          &gt;
-        </button>
-      </div>
+            >
+              18
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Go to Next Page"
+              class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-r-2"
+              id="next-btn"
+            >
+              &gt;
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </DocumentFragment>
@@ -284,10 +346,10 @@ Erat et...
 exports[`<Paginator /> > check next button works 1`] = `
 <DocumentFragment>
   <div
-    class="max-w-screen-md"
+    class="ps-max-w-screen-md"
   >
     <h3
-      class="mb-8 prose-sm"
+      class="ps-mb-8 ps-prose-sm"
     >
       Page 2/18
     </h3>
@@ -434,126 +496,188 @@ exports[`<Paginator /> > check next button works 1`] = `
       </article>
     </section>
     <div
-      class="sticky lg:bottom-12 bottom-4"
+      class="ps-sticky lg:ps-bottom-12 ps-bottom-4"
     >
-      <div
-        class="flex flex-row justify-center mx-auto mt-auto mb-4"
+      <nav
+        aria-label="Pagination Navigation"
+        role="navigation"
       >
-        <button
-          class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-l-2 border-t-2 border-b-2 border-black bg-white"
-          id="back-btn"
+        <ul
+          class="ps-list-none ps-flex ps-flex-row ps-justify-center ps-mx-auto ps-mt-auto ps-mb-4 [&>li]:ps-p-0"
         >
-          &lt;
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+          <li>
+            <button
+              aria-label="Go to Previous Page"
+              class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-l-2"
+              id="back-btn"
+            >
+              &lt;
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 1"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          1
-        </button>
-        <button
-          class="
-          block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-blue-700 border-2
+            >
+              1
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="true"
+              aria-label="Current Page, Page 2"
+              class="
+          ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-blue-700 ps-border-2
           "
-        >
-          2
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              2
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 3"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          3
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              3
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 4"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          4
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              4
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 5"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          5
-        </button>
-        <button
-          class="hidden md:block h-16 w-12 border-2 border-black bg-slate-200 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300\\"
+            >
+              5
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Expand Hidden Buttons"
+              class="ps-hidden md:ps-block ps-h-16 ps-w-12 ps-border-2 ps-border-black ps-bg-slate-200 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300\\"
             }"
-        >
-          ...
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              ...
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 12"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          12
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              12
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 13"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          13
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              13
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 14"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          14
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              14
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 15"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          15
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              15
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 16"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          16
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              16
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 17"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          17
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              17
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 18"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          18
-        </button>
-        <button
-          class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300  border-r-2 border-t-2 border-b-2 border-black bg-white"
-          id="next-btn"
-        >
-          &gt;
-        </button>
-      </div>
+            >
+              18
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Go to Next Page"
+              class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-r-2"
+              id="next-btn"
+            >
+              &gt;
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </DocumentFragment>
@@ -562,10 +686,10 @@ exports[`<Paginator /> > check next button works 1`] = `
 exports[`<Paginator /> > should render the paginated data 1`] = `
 <DocumentFragment>
   <div
-    class="max-w-screen-md"
+    class="ps-max-w-screen-md"
   >
     <h3
-      class="mb-8 prose-sm"
+      class="ps-mb-8 ps-prose-sm"
     >
       Page 1/18
     </h3>
@@ -714,127 +838,189 @@ Erat et...
       </article>
     </section>
     <div
-      class="sticky lg:bottom-12 bottom-4"
+      class="ps-sticky lg:ps-bottom-12 ps-bottom-4"
     >
-      <div
-        class="flex flex-row justify-center mx-auto mt-auto mb-4"
+      <nav
+        aria-label="Pagination Navigation"
+        role="navigation"
       >
-        <button
-          class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-l-2 border-t-2 border-b-2 border-black bg-white"
-          disabled=""
-          id="back-btn"
+        <ul
+          class="ps-list-none ps-flex ps-flex-row ps-justify-center ps-mx-auto ps-mt-auto ps-mb-4 [&>li]:ps-p-0"
         >
-          &lt;
-        </button>
-        <button
-          class="
-          block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-blue-700 border-2
+          <li>
+            <button
+              aria-label="Go to Previous Page"
+              class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-l-2"
+              disabled=""
+              id="back-btn"
+            >
+              &lt;
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="true"
+              aria-label="Current Page, Page 1"
+              class="
+          ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-blue-700 ps-border-2
           "
-        >
-          1
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              1
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 2"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          2
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              2
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 3"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          3
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              3
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 4"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          4
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              4
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 5"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          5
-        </button>
-        <button
-          class="hidden md:block h-16 w-12 border-2 border-black bg-slate-200 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300\\"
+            >
+              5
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Expand Hidden Buttons"
+              class="ps-hidden md:ps-block ps-h-16 ps-w-12 ps-border-2 ps-border-black ps-bg-slate-200 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300\\"
             }"
-        >
-          ...
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              ...
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 12"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          12
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              12
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 13"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          13
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              13
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 14"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          14
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              14
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 15"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          15
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              15
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 16"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          16
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              16
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 17"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          17
-        </button>
-        <button
-          class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+            >
+              17
+            </button>
+          </li>
+          <li>
+            <button
+              aria-current="false"
+              aria-label="Go to Page 18"
+              class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-        >
-          18
-        </button>
-        <button
-          class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300  border-r-2 border-t-2 border-b-2 border-black bg-white"
-          id="next-btn"
-        >
-          &gt;
-        </button>
-      </div>
+            >
+              18
+            </button>
+          </li>
+          <li>
+            <button
+              aria-label="Go to Next Page"
+              class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-r-2"
+              id="next-btn"
+            >
+              &gt;
+            </button>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </DocumentFragment>

--- a/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/recipe.test.tsx.snap
+++ b/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/recipe.test.tsx.snap
@@ -3,29 +3,29 @@
 exports[`<Recipe /> > should render 'recipe' 1`] = `
 <DocumentFragment>
   <article
-    class="prose lg:prose-xl mt-10 mx-auto h-fit p-4 sm:p-0"
+    class="ps-prose lg:ps-prose-xl ps-mt-10 ps-mx-auto h-fit ps-p-4 sm:ps-p-0"
   >
     <header>
       <h1>
         Guacamole
       </h1>
       <div
-        class="flex flex-row justify-between"
+        class="ps-flex ps-flex-row ps-justify-between"
       >
         <a
-          class="font-normal cursor-pointer"
+          class="ps-font-normal ps-cursor-pointer"
         >
           Back →
         </a>
         <span
-          class="text pb-2 pr-3 text-sm text-slate-400"
+          class="text ps-pb-2 ps-pr-3 ps-text-sm text-slate-400"
         >
           Snacks
         </span>
       </div>
     </header>
     <div
-      class="relative max-w-lg mx-auto min-w-full h-[50vh] rounded-lg shadow-lg overflow-hidden mt-12 mb-10"
+      class="ps-relative ps-max-w-lg ps-mx-auto ps-min-w-full h-[50vh] ps-rounded-lg ps-shadow-lg ps-overflow-hidden ps-mt-12 ps-mb-10"
     >
       <span
         style="box-sizing: border-box; display: block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px;"
@@ -42,10 +42,10 @@ exports[`<Recipe /> > should render 'recipe' 1`] = `
       </span>
     </div>
     <div
-      class="flex flex-col sm:flex-row"
+      class="ps-flex ps-flex-col sm:ps-flex-row"
     >
       <section
-        class="flex flex-col min-w-fit sm:border-r-2 pr-4"
+        class="ps-flex ps-flex-col min-w-fit sm:ps-border-r-2 ps-pr-4"
       >
         <h2>
           Ingredients
@@ -75,10 +75,10 @@ exports[`<Recipe /> > should render 'recipe' 1`] = `
         </ul>
       </section>
       <section
-        class="flex flex-col pl-4"
+        class="ps-flex ps-flex-col ps-pl-4"
       >
         <h2
-          class="ml-4"
+          class="ps-ml-4"
         >
           Directions
         </h2>

--- a/packages/nextjs-kit/src/components/contentWithImage.tsx
+++ b/packages/nextjs-kit/src/components/contentWithImage.tsx
@@ -36,16 +36,19 @@ const ContentWithImage: React.FC<ContentProps> = ({
 	const router = useRouter();
 
 	return (
-		<article className="prose xs:prose-xs md:prose-md lg:prose-lg mt-10 mx-auto max-w-screen lg:max-w-screen-lg md:max-w-screen-md sm:max-w-screen-sm p-4">
+		<article className="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-p-4">
 			<h1>{title}</h1>
-			{date ? <p className="text-sm text-gray-600">{date}</p> : null}
+			{date ? <p className="ps-text-sm ps-text-gray-600">{date}</p> : null}
 
-			<a onClick={() => router.back()} className="font-normal cursor-pointer">
+			<a
+				onClick={() => router.back()}
+				className="ps-font-normal ps-cursor-pointer"
+			>
 				Back &rarr;
 			</a>
-			<div className="mt-12 max-w-screen mx-auto lg:max-w-screen-lg shadow-lg [&*>img]:rounded-lg">
+			<div className="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg">
 				{imageProps ? (
-					<div className="relative mb-10 min-h-[50vh]">
+					<div className="ps-relative ps-mb-10 ps-min-h-[50vh]">
 						<Image
 							priority
 							src={imageProps.src}
@@ -58,7 +61,7 @@ const ContentWithImage: React.FC<ContentProps> = ({
 			</div>
 
 			<div
-				className="break-words mt-12"
+				className="ps-break-words ps-mt-12"
 				dangerouslySetInnerHTML={{ __html: content }}
 			/>
 		</article>

--- a/packages/nextjs-kit/src/components/footer.tsx
+++ b/packages/nextjs-kit/src/components/footer.tsx
@@ -42,16 +42,16 @@ const Footer: React.FC<FooterMenuProps> = ({
 				if (footerMenuItems[i + 1] && hasParent(footerMenuItems[i + 1])) {
 					menuArr.push(
 						<ul key={i}>
-							<li className="list-disc text-blue-300">
+							<li className="ps-list-disc ps-text-blue-300">
 								<Link href={footerMenuItems[i].href}>
-									<a className="text-blue-300 hover:underline hover:text-blue-100 focus:text-purple-600 active:text-purple-300">
+									<a className="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300">
 										{footerMenuItems[i].linkText}
 									</a>
 								</Link>
 							</li>
-							<li className="list-disc text-blue-300 ml-3">
+							<li className="ps-list-disc ps-text-blue-300 ps-ml-3">
 								<Link href={footerMenuItems[i + 1].href}>
-									<a className="text-blue-300 hover:underline hover:text-blue-100 focus:text-purple-600 active:text-purple-300">
+									<a className="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300">
 										{footerMenuItems[i + 1].linkText}
 									</a>
 								</Link>
@@ -62,9 +62,9 @@ const Footer: React.FC<FooterMenuProps> = ({
 					i++;
 				} else {
 					menuArr.push(
-						<li key={i} className="list-disc text-blue-300">
+						<li key={i} className="ps-list-disc ps-text-blue-300">
 							<Link href={footerMenuItems[i].href}>
-								<a className="text-blue-300 hover:underline hover:text-blue-100 focus:text-purple-600 active:text-purple-300">
+								<a className="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300">
 									{footerMenuItems[i].linkText}
 								</a>
 							</Link>
@@ -74,15 +74,15 @@ const Footer: React.FC<FooterMenuProps> = ({
 			}
 		}
 		return (
-			<nav className="flex flex-col max-w-lg mx-auto lg:max-w-screen-lg">
+			<nav className="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg">
 				<ul>{menuArr?.map((menu) => menu)}</ul>
 			</nav>
 		);
 	};
 	return (
-		<footer className="w-full text-white bg-black p-4 mt-12">
+		<footer className="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12">
 			<FooterMenu />
-			<div className="flex my-4 p-2">{children}</div>
+			<div className="ps-flex ps-my-4 ps-p-2">{children}</div>
 		</footer>
 	);
 };

--- a/packages/nextjs-kit/src/components/header.tsx
+++ b/packages/nextjs-kit/src/components/header.tsx
@@ -33,17 +33,17 @@ const Header: React.FC<HeaderProps> = ({
 	navItems,
 }: HeaderProps): JSX.Element => {
 	return (
-		<div className="my-0 pt-10 px-5 text-xl">
+		<div className="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl">
 			<nav>
-				<ul className="flex flex-row flex-wrap sm:flex-nowrap list-none justify-between max-w-screen-sm mx-auto">
+				<ul className="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto">
 					{navItems.map((item) => {
 						return (
 							<li
-								className={`${item.href === '/' ? 'mr-auto' : 'mx-4'}`}
+								className={`${item.href === '/' ? 'ps-mr-auto' : 'ps-mx-4'}`}
 								key={item.href}
 							>
-								<Link className="font-sans" href={item.href}>
-									<a className="hover:underline">{item.linkText}</a>
+								<Link className="ps-font-sans" href={item.href}>
+									<a className="hover:ps-underline">{item.linkText}</a>
 								</Link>
 							</li>
 						);

--- a/packages/nextjs-kit/src/components/paginator.tsx
+++ b/packages/nextjs-kit/src/components/paginator.tsx
@@ -108,10 +108,15 @@ const Paginator = <Type extends object>({
 	// track window width to appropriately hide and show buttons on small viewports
 	const [windowWidth, setWindowWidth] = useState<number>();
 	useEffect(() => {
-		setWindowWidth(window.innerWidth);
-		window.addEventListener('resize', () => {
+		const eventListener = () => {
 			setWindowWidth(window.innerWidth);
-		});
+		};
+		setWindowWidth(window.innerWidth);
+		window.addEventListener('resize', () => eventListener);
+
+		return () => {
+			window.removeEventListener('resize', eventListener);
+		};
 	}, []);
 
 	const handlePageClick: React.MouseEventHandler<HTMLButtonElement> = (
@@ -152,13 +157,25 @@ const Paginator = <Type extends object>({
 			const defaultButton = (
 				<button
 					className={`
-          ${currentPageQuery === pageNumber ? 'block' : 'hidden md:block'}
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 ${
-						currentPageQuery === pageNumber ? 'border-blue-700 border-2' : ''
+          ${
+						currentPageQuery === pageNumber
+							? 'ps-block'
+							: 'ps-hidden md:ps-block'
+					}
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ${
+						currentPageQuery === pageNumber
+							? 'ps-border-blue-700 ps-border-2'
+							: ''
 					}
           `}
 					onClick={handlePageClick}
 					key={pageNumber}
+					aria-label={
+						currentPageQuery === pageNumber
+							? `Current Page, Page ${pageNumber}`
+							: `Go to Page ${pageNumber}`
+					}
+					aria-current={currentPageQuery === pageNumber ? true : false}
 				>
 					{pageNumber}
 				</button>
@@ -174,7 +191,7 @@ const Paginator = <Type extends object>({
 				}
 				buttons.push(
 					<button
-						className={`hidden md:block h-16 w-12 border-2 border-black bg-slate-200 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300"
+						className={`ps-hidden md:ps-block ps-h-16 ps-w-12 ps-border-2 ps-border-black ps-bg-slate-200 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300"
             }`}
 						onClick={() => {
 							if (isNumber(breakAdd)) {
@@ -182,6 +199,7 @@ const Paginator = <Type extends object>({
 							}
 						}}
 						key={'...'}
+						aria-label="Expand Hidden Buttons"
 					>
 						...
 					</button>,
@@ -200,42 +218,55 @@ const Paginator = <Type extends object>({
 			}
 			buttons.push(defaultButton);
 		}
+		const sharedNextAndBackBtnStyles =
+			'ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white';
 		// returns the row of buttons
 		return (
-			<div className="flex flex-row justify-center mx-auto mt-auto mb-4">
+			<nav role="navigation" aria-label="Pagination Navigation">
 				{/* back button */}
-				<button
-					className="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-l-2 border-t-2 border-b-2 border-black bg-white"
-					id="back-btn"
-					disabled={offset === 0}
-					onClick={handlePageClick}
-				>
-					{'<'}
-				</button>
-				{/* map buttons[] */}
-				{buttons.map((btn) => btn)}
-				{/* next button */}
-				<button
-					className="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300  border-r-2 border-t-2 border-b-2 border-black bg-white"
-					id="next-btn"
-					disabled={offset >= totalItems - itemsPerPage}
-					onClick={handlePageClick}
-				>
-					{'>'}
-				</button>
-			</div>
+				<ul className="ps-list-none ps-flex ps-flex-row ps-justify-center ps-mx-auto ps-mt-auto ps-mb-4 [&>li]:ps-p-0">
+					<li key="back">
+						{/* TODO: For improved accessibility, these buttons should be refactored to anchor tags. */}
+						<button
+							className={`${sharedNextAndBackBtnStyles} ps-border-l-2`}
+							id="back-btn"
+							disabled={offset === 0}
+							onClick={handlePageClick}
+							aria-label="Go to Previous Page"
+						>
+							{'<'}
+						</button>
+					</li>
+					{/* map buttons[] */}
+					{buttons.map((btn, i) => (
+						<li key={i}>{btn}</li>
+					))}
+					{/* next button */}
+					<li key="next">
+						<button
+							className={`${sharedNextAndBackBtnStyles} ps-border-r-2`}
+							id="next-btn"
+							disabled={offset >= totalItems - itemsPerPage}
+							onClick={handlePageClick}
+							aria-label="Go to Next Page"
+						>
+							{'>'}
+						</button>
+					</li>
+				</ul>
+			</nav>
 		);
 	};
 	return (
-		<div className="max-w-screen-md">
-			<h3 className="mb-8 prose-sm">
+		<div className="ps-max-w-screen-md">
+			<h3 className="ps-mb-8 ps-prose-sm">
 				Page {currentPageQuery}/{totalPages}
 			</h3>
 			<section>
 				{/* Component passed in that will render the data */}
 				<Component currentItems={currentItems} />
 			</section>
-			<div className="sticky lg:bottom-12 bottom-4">
+			<div className="ps-sticky lg:ps-bottom-12 ps-bottom-4">
 				<RenderButtons />
 			</div>
 		</div>

--- a/packages/nextjs-kit/src/components/recipe.tsx
+++ b/packages/nextjs-kit/src/components/recipe.tsx
@@ -41,23 +41,23 @@ const Recipe: React.FC<RecipeProps> = ({
 }: RecipeProps) => {
 	const router = useRouter();
 	return (
-		<article className="prose lg:prose-xl mt-10 mx-auto h-fit p-4 sm:p-0">
+		<article className="ps-prose lg:ps-prose-xl ps-mt-10 ps-mx-auto h-fit ps-p-4 sm:ps-p-0">
 			<header>
 				<h1>{title}</h1>
-				<div className="flex flex-row justify-between">
+				<div className="ps-flex ps-flex-row ps-justify-between">
 					<a
 						onClick={() => router.back()}
-						className="font-normal cursor-pointer"
+						className="ps-font-normal ps-cursor-pointer"
 					>
 						Back &rarr;
 					</a>
-					<span className="text pb-2 pr-3 text-sm text-slate-400">
+					<span className="text ps-pb-2 ps-pr-3 ps-text-sm text-slate-400">
 						{category}
 					</span>
 				</div>
 			</header>
 			{imageProps ? (
-				<div className="relative max-w-lg mx-auto min-w-full h-[50vh] rounded-lg shadow-lg overflow-hidden mt-12 mb-10">
+				<div className="ps-relative ps-max-w-lg ps-mx-auto ps-min-w-full h-[50vh] ps-rounded-lg ps-shadow-lg ps-overflow-hidden ps-mt-12 ps-mb-10">
 					<Image
 						priority
 						src={imageProps.src}
@@ -68,14 +68,14 @@ const Recipe: React.FC<RecipeProps> = ({
 				</div>
 			) : null}
 
-			<div className="flex flex-col sm:flex-row">
-				<section className="flex flex-col min-w-fit sm:border-r-2 pr-4">
+			<div className="ps-flex ps-flex-col sm:ps-flex-row">
+				<section className="ps-flex ps-flex-col min-w-fit sm:ps-border-r-2 ps-pr-4">
 					<h2>Ingredients</h2>
 					<ul>
 						{ingredients?.map((ingredient, i) => {
 							if (ingredient.startsWith('For')) {
 								return (
-									<li className="list-none" key={i}>
+									<li className="ps-list-none" key={i}>
 										<strong>{ingredient}</strong>
 									</li>
 								);
@@ -85,8 +85,8 @@ const Recipe: React.FC<RecipeProps> = ({
 						})}
 					</ul>
 				</section>
-				<section className="flex flex-col pl-4">
-					<h2 className="ml-4">Directions</h2>
+				<section className="ps-flex ps-flex-col ps-pl-4">
+					<h2 className="ps-ml-4">Directions</h2>
 					<div
 						dangerouslySetInnerHTML={{
 							__html: instructions,

--- a/packages/nextjs-kit/tailwind.config.js
+++ b/packages/nextjs-kit/tailwind.config.js
@@ -4,5 +4,6 @@ module.exports = {
 	theme: {
 		extend: {},
 	},
+	prefix: 'ps-',
 	plugins: [require('@tailwindcss/typography')],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,7 @@ importers:
       '@vitejs/plugin-react': ^2.0.0
       autoprefixer: ^10.4.4
       c8: ^7.12.0
+      eslint-plugin-prettier: ^4.2.1
       next: ^12.2.5
       postcss: ^8.4.12
       react: 17.0.2
@@ -147,7 +148,8 @@ importers:
       '@vitejs/plugin-react': 2.0.0_vite@3.0.2
       autoprefixer: 10.4.7_postcss@8.4.14
       c8: 7.12.0
-      next: 12.2.5_sfoxds7t5ydpegc3knd667wn6m
+      eslint-plugin-prettier: 4.2.1_prettier@2.7.1
+      next: 12.2.5_oj5jbg2ldmqbgxwq3dy6abnm5a
       postcss: 8.4.14
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -9775,6 +9777,23 @@ packages:
       semver: 6.3.0
     dev: true
 
+  /eslint-plugin-prettier/4.2.1_prettier@2.7.1:
+    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      eslint: '>=7.28.0'
+      eslint-config-prettier: '*'
+      prettier: '>=2.0.0'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      eslint-config-prettier:
+        optional: true
+    dependencies:
+      prettier: 2.7.1
+      prettier-linter-helpers: 1.0.0
+    dev: true
+
   /eslint-plugin-react-hooks/4.6.0_eslint@7.32.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
@@ -10416,6 +10435,10 @@ packages:
 
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  /fast-diff/1.2.0:
+    resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
+    dev: true
 
   /fast-glob/3.2.11:
     resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
@@ -14566,7 +14589,7 @@ packages:
     dependencies:
       '@next/env': 12.2.5
       '@swc/helpers': 0.4.3
-      caniuse-lite: 1.0.30001375
+      caniuse-lite: 1.0.30001390
       postcss: 8.4.14
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -14589,7 +14612,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: false
 
   /next/12.2.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-tBdjqX5XC/oFs/6gxrZhjmiq90YWizUYU6qOWAfat7zJwrwapJ+BYgX2PmiacunXMaRpeVT4vz5MSPSLgNkrpA==}
@@ -15907,6 +15929,13 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  /prettier-linter-helpers/1.0.0:
+    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      fast-diff: 1.2.0
+    dev: true
+
   /prettier/1.19.1:
     resolution: {integrity: sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==}
     engines: {node: '>=4'}
@@ -15923,7 +15952,6 @@ packages:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-    dev: false
 
   /pretty-bytes/5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
@@ -17785,7 +17813,6 @@ packages:
     dependencies:
       '@babel/core': 7.19.0
       react: 17.0.2
-    dev: false
 
   /styled-jsx/5.0.4_react@17.0.2:
     resolution: {integrity: sha512-sDFWLbg4zR+UkNzfk5lPilyIgtpddfxXEULxhujorr5jtePTUqiPDc5BC0v1NRqTr/WaFBGQQUoYToGlF4B2KQ==}

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/pagination.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/pagination.test.jsx.snap
@@ -73,10 +73,10 @@ exports[`default <PaginationExampleTemplate /> > should render a success message
               Pagination example
             </h1>
             <div
-              class="max-w-screen-md"
+              class="ps-max-w-screen-md"
             >
               <h3
-                class="mb-8 prose-sm"
+                class="ps-mb-8 ps-prose-sm"
               >
                 Page 1/18
               </h3>
@@ -225,127 +225,189 @@ Erat et...
                 </article>
               </section>
               <div
-                class="sticky lg:bottom-12 bottom-4"
+                class="ps-sticky lg:ps-bottom-12 ps-bottom-4"
               >
-                <div
-                  class="flex flex-row justify-center mx-auto mt-auto mb-4"
+                <nav
+                  aria-label="Pagination Navigation"
+                  role="navigation"
                 >
-                  <button
-                    class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-l-2 border-t-2 border-b-2 border-black bg-white"
-                    disabled=""
-                    id="back-btn"
+                  <ul
+                    class="ps-list-none ps-flex ps-flex-row ps-justify-center ps-mx-auto ps-mt-auto ps-mb-4 [&>li]:ps-p-0"
                   >
-                    &lt;
-                  </button>
-                  <button
-                    class="
-          block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-blue-700 border-2
+                    <li>
+                      <button
+                        aria-label="Go to Previous Page"
+                        class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-l-2"
+                        disabled=""
+                        id="back-btn"
+                      >
+                        &lt;
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="true"
+                        aria-label="Current Page, Page 1"
+                        class="
+          ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-blue-700 ps-border-2
           "
-                  >
-                    1
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        1
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 2"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    2
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        2
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 3"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    3
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        3
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 4"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    4
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        4
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 5"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    5
-                  </button>
-                  <button
-                    class="hidden md:block h-16 w-12 border-2 border-black bg-slate-200 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300\\"
+                      >
+                        5
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-label="Expand Hidden Buttons"
+                        class="ps-hidden md:ps-block ps-h-16 ps-w-12 ps-border-2 ps-border-black ps-bg-slate-200 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300\\"
             }"
-                  >
-                    ...
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        ...
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 12"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    12
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        12
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 13"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    13
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        13
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 14"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    14
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        14
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 15"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    15
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        15
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 16"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    16
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        16
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 17"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    17
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        17
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 18"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    18
-                  </button>
-                  <button
-                    class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300  border-r-2 border-t-2 border-b-2 border-black bg-white"
-                    id="next-btn"
-                  >
-                    &gt;
-                  </button>
-                </div>
+                      >
+                        18
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-label="Go to Next Page"
+                        class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-r-2"
+                        id="next-btn"
+                      >
+                        &gt;
+                      </button>
+                    </li>
+                  </ul>
+                </nav>
               </div>
             </div>
           </section>

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/pagination.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/pagination.test.jsx.snap
@@ -73,10 +73,10 @@ exports[`umami <PaginationExampleTemplate /> > should render a success message i
               Pagination example
             </h1>
             <div
-              class="max-w-screen-md"
+              class="ps-max-w-screen-md"
             >
               <h3
-                class="mb-8 prose-sm"
+                class="ps-mb-8 ps-prose-sm"
               >
                 Page 1/18
               </h3>
@@ -225,127 +225,189 @@ Erat et...
                 </article>
               </section>
               <div
-                class="sticky lg:bottom-12 bottom-4"
+                class="ps-sticky lg:ps-bottom-12 ps-bottom-4"
               >
-                <div
-                  class="flex flex-row justify-center mx-auto mt-auto mb-4"
+                <nav
+                  aria-label="Pagination Navigation"
+                  role="navigation"
                 >
-                  <button
-                    class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-l-2 border-t-2 border-b-2 border-black bg-white"
-                    disabled=""
-                    id="back-btn"
+                  <ul
+                    class="ps-list-none ps-flex ps-flex-row ps-justify-center ps-mx-auto ps-mt-auto ps-mb-4 [&>li]:ps-p-0"
                   >
-                    &lt;
-                  </button>
-                  <button
-                    class="
-          block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 border-blue-700 border-2
+                    <li>
+                      <button
+                        aria-label="Go to Previous Page"
+                        class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-l-2"
+                        disabled=""
+                        id="back-btn"
+                      >
+                        &lt;
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="true"
+                        aria-label="Current Page, Page 1"
+                        class="
+          ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-blue-700 ps-border-2
           "
-                  >
-                    1
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        1
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 2"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    2
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        2
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 3"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    3
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        3
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 4"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    4
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        4
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 5"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    5
-                  </button>
-                  <button
-                    class="hidden md:block h-16 w-12 border-2 border-black bg-slate-200 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300\\"
+                      >
+                        5
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-label="Expand Hidden Buttons"
+                        class="ps-hidden md:ps-block ps-h-16 ps-w-12 ps-border-2 ps-border-black ps-bg-slate-200 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300\\"
             }"
-                  >
-                    ...
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        ...
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 12"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    12
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        12
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 13"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    13
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        13
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 14"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    14
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        14
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 15"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    15
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        15
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 16"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    16
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        16
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 17"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    17
-                  </button>
-                  <button
-                    class="
-          hidden md:block
-          h-16 w-12 border-t-2 border-b-2 border-black bg-white hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300 
+                      >
+                        17
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-current="false"
+                        aria-label="Go to Page 18"
+                        class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
           "
-                  >
-                    18
-                  </button>
-                  <button
-                    class="h-16 w-12 disabled:bg-gray-500 hover:bg-blue-300 focus:bg-blue-200 focus:border-blue-300  border-r-2 border-t-2 border-b-2 border-black bg-white"
-                    id="next-btn"
-                  >
-                    &gt;
-                  </button>
-                </div>
+                      >
+                        18
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        aria-label="Go to Next Page"
+                        class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-r-2"
+                        id="next-btn"
+                      >
+                        &gt;
+                      </button>
+                    </li>
+                  </ul>
+                </nav>
               </div>
             </div>
           </section>


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Add the `prefix` option to the tailwindcss config
- Refactor all tailwindcss classes to add the prefix
- Also took this opportunity to refactor the Paginator component a bit and increase the accessibility with proper aria labels, a nav container, and `ul>li` markup. 
- Added the eslint-prettier plugin to the nextjs kit since the lint step complains when I do not have it as a dev dependency.

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
`nextjs-kit`, updated snapshot tests for the pagination component in `next-drupal`
## How have the changes been tested?
Locally w/ a screen reader

## Additional information

### Note:
Going forward we will need to use `ps-` for all tailwind styles in the nextjs-kit. We should follow suit for any other libraries that export components. (Will ps- work for all of them, what if you import from 2 libraries with ps-, will it break?)

There is some significant effort to switch the `buttons` to `a` tags which is the better way to do things from my research. I will write something up for this.

I found this article to be very informative: https://www.a11ymatters.com/pattern/pagination/#wrap-the-pagination-links-in-a-nav-element

<!--- Add any other context about the feature or fix here. --->

Don't forget to
[add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset)
if needed!
