### PR TITLE
DB-4062: Block editor button styles

### DIFF
--- a/.changeset/shaggy-walls-talk.md
+++ b/.changeset/shaggy-walls-talk.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/wordpress-kit': minor
+---
+
+Added buttons component, and a function to get color by name in the Color
+utility class

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/Config.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/Config.ts
@@ -48,6 +48,7 @@ export const mergeToConfig: Config = {
 		'.wp-block-audio',
 		'.wp-block-cover',
 		'.wp-block-media-text',
+		'.wp-block-buttons',
 	],
 	...proseOverride,
 };

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Buttons.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Buttons.ts
@@ -1,0 +1,96 @@
+const justifications = {
+	'&.is-content-justification-left': {
+		justifyContent: 'flex-start',
+	},
+	'&.is-content-justification-center': {
+		justifyContent: 'center',
+	},
+	'&.is-content-justification-right': {
+		justifyContent: 'flex-end',
+	},
+	'&.is-content-justification-space-between': {
+		justifyContent: 'space-between',
+	},
+};
+
+const buttonWidths = {
+	'&.wp-block-button__width-25': {
+		width: 'calc(25% - 1.5rem * .75)',
+	},
+	'&.wp-block-button__width-50': {
+		width: 'calc(50% - 1.5rem * 0.5)',
+	},
+	'&.wp-block-button__width-75': {
+		width: 'calc(75% - 1.5rem * 0.25)',
+	},
+	'&.wp-block-button__width-100': {
+		width: '100%',
+		'flex-basis': '100%',
+	},
+};
+
+export const ButtonsComponent = ({
+	defaultColor,
+}: {
+	defaultColor: string;
+}) => ({
+	'.wp-block-buttons': {
+		display: 'flex',
+		gap: '1.5rem',
+		flexWrap: 'wrap',
+		alignItems: 'center',
+		'justify-content': 'flex-start',
+		...justifications,
+		'max-width': '650px',
+		'&.alignwide': {
+			maxWidth: '850px',
+		},
+		'&.alignfull': {
+			'@media (min-width:720px)': {
+				// sets a negative margin to allow full width elements to span past the
+				// width its parent container
+				marginLeft: 'calc(-1 * max(1rem, 10vw))',
+				marginRight: 'calc(-1 * max(1rem, 10vw))',
+				maxWidth: 'unset',
+			},
+		},
+		'&.is-vertical': {
+			flexDirection: 'column',
+			'align-items': 'flex-start',
+			'&.is-content-justification-center': {
+				'align-items': 'center',
+			},
+			'&.is-content-justification-right': {
+				'align-items': 'flex-end',
+			},
+		},
+		margin: '0 auto',
+		'>.wp-block-button': {
+			display: 'inline-block',
+			margin: '0',
+			...buttonWidths,
+			'&.is-style-outline': {
+				'>.wp-block-button__link': {
+					border: '2px solid',
+					'background-color': 'transparent',
+					color: 'inherit',
+				},
+			},
+			'>.wp-block-button__link': {
+				width: '100%',
+				display: 'inline-block',
+				padding: 'calc(0.667em + 2px) calc(1.333em + 2px)',
+				textDecoration: 'none',
+				textAlign: 'center',
+				'font-weight': 'unset',
+				color: '#fff',
+				cursor: 'pointer',
+				'box-sizing': 'border-box',
+				backgroundColor: defaultColor,
+				'&:hover': {
+					opacity: '0.9',
+				},
+			},
+		},
+	},
+});

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/index.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/index.ts
@@ -6,6 +6,7 @@ import { GalleryComponent } from './Gallery';
 import { AudioComponent } from './Audio';
 import { CoverComponent } from './Cover';
 import { mediaAndText } from './MediaAndText';
+import { ButtonsComponent } from './Buttons';
 
 export {
 	ImageComponent,
@@ -16,4 +17,5 @@ export {
 	AudioComponent,
 	CoverComponent,
 	mediaAndText,
+	ButtonsComponent,
 };

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/index.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/index.ts
@@ -8,6 +8,7 @@ import {
 	AudioComponent,
 	CoverComponent,
 	mediaAndText,
+	ButtonsComponent,
 } from './components';
 import { mergeToConfig } from './Config';
 import { ColorUtilities, FontsUtilities } from './utilities';
@@ -48,6 +49,10 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
 		alignFull: { minWidth: theme('screen.xl', '1280px') },
 	});
 
+	const buttons = ButtonsComponent({
+		defaultColor: color.getColorByName('primary'),
+	});
+
 	addUtilities([
 		color.getBackgroundUtilities(),
 		color.getBorderColorUtilities(),
@@ -59,5 +64,14 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
 		quoteUtilities,
 	]);
 
-	addComponents([table, image, pullQuote, gallery, audio, cover, mediaAndText]);
+	addComponents([
+		table,
+		image,
+		pullQuote,
+		gallery,
+		audio,
+		cover,
+		mediaAndText,
+		buttons,
+	]);
 }, mergeToConfig);

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/utilities/Colors.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/utilities/Colors.ts
@@ -100,7 +100,7 @@ export class ColorUtilities {
 			(acc, color) => ({
 				...acc,
 				[`.has-${color.name}-color`]: {
-					color: this.getColor(color),
+					color: `${this.getColor(color)} !important`,
 				},
 			}),
 			{
@@ -223,4 +223,8 @@ export class ColorUtilities {
 			}),
 			{},
 		);
+	getColorByName = (colorName: string) => {
+		const color = this.findColor(colorName);
+		return this.getColor(color);
+	};
 }


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Added button component
- Added getColorByName to the color class

## Where were the changes made?
- WordPress-Kit

## How have the changes been tested?
- With Next-WP-Starter

## Additional information
- Looks like alignment is bugged from WP, doesn't work on WP preview, and doesn't add any class to the produced HTML

Don't forget to
[add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset)
if needed!
