### PR TITLE
Ignore broken release scritps

### DIFF
--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -37,10 +37,10 @@ jobs:
       - name: create and publish versions
         uses: changesets/action@v1
         with:
-          version: .github/scripts/main-release.sh
+          version: pnpm ci:version
           commit: 'Update versions'
           title: 'Update versions'
-          publish: .github/scripts/main-publish.sh
+          publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Ignore the release scripts to finish the sprint release. Still not sure what is up with them at the moment but will dig in.
For now this should let us publish our sprint 32 release
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

Don't forget to
[add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset)
if needed!
