### PR TITLE
Enter pre mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,15 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@pantheon-systems/eslint-config": "0.0.0",
+    "@pantheon-systems/drupal-kit": "3.0.1",
+    "@pantheon-systems/nextjs-kit": "1.2.0",
+    "@pantheon-systems/wordpress-kit": "2.6.0",
+    "@pantheon-systems/gatsby-wordpress-starter": "2.2.0",
+    "@pantheon-systems/next-drupal-starter": "3.2.0",
+    "@pantheon-systems/next-wordpress-starter": "0.8.0",
+    "web": "1.0.0"
+  },
+  "changesets": []
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,5 @@
 
 <!--- Add any other context about the feature or fix here. --->
 
-Don't forget to
-[add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset)
-if needed!
+<!-- prettier-ignore -->
+Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Enter prerelease mode
- Fix formatting for the PR template (the last line was being formatted in a weird way by prettier)
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

Don't forget to
[add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset)
if needed!
