### PR TITLE
DB-4070, DB-4071: Fix types for umd bundle

### DIFF
--- a/.changeset/lovely-coins-fly.md
+++ b/.changeset/lovely-coins-fly.md
@@ -1,0 +1,7 @@
+---
+'@pantheon-systems/drupal-kit': patch
+'@pantheon-systems/nextjs-kit': patch
+'@pantheon-systems/wordpress-kit': patch
+---
+
+Fix types field in package.json

--- a/packages/drupal-kit/package.json
+++ b/packages/drupal-kit/package.json
@@ -11,9 +11,9 @@
 	},
 	"author": "@pantheon-systems",
 	"files": [
-		"dist",
-		"src/sdk.{js,ts}"
+		"dist/*"
 	],
+	"types": "dist/index.d.ts",
 	"main": "./dist/drupal-kit.umd.js",
 	"module": "./dist/drupal-kit.es.js",
 	"exports": {

--- a/packages/nextjs-kit/package.json
+++ b/packages/nextjs-kit/package.json
@@ -11,11 +11,11 @@
 	},
 	"author": "@pantheon-systems",
 	"files": [
-		"dist"
+		"dist/*"
 	],
+	"types": "dist/index.d.ts",
 	"main": "./dist/nextjs-kit.umd.js",
 	"module": "./dist/nextjs-kit.es.js",
-	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"require": "./dist/nextjs-kit.umd.js",

--- a/packages/wordpress-kit/package.json
+++ b/packages/wordpress-kit/package.json
@@ -11,9 +11,9 @@
 	},
 	"author": "@pantheon-systems",
 	"files": [
-		"dist",
-		"src/sdk.{js,ts}"
+		"dist/*"
 	],
+	"types": "dist/index.d.ts",
 	"main": "./dist/wordpress-kit.umd.js",
 	"module": "./dist/wordpress-kit.es.js",
 	"exports": {


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Update the types file in `drupal-kit` and `wordpress-kit` and ensure that TSDoc comments and other nice LSP features are working when our libraries our imported.

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Locally with `npm link`, and some hacky editing of the `package.json` with the current release, but this should be tested again with a fresh canary release.
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
