### PR TITLE
DB-4081: Try removing force casing in filenames

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": false,
 		"baseUrl": "./packages",
 		"paths": {
 			"@pantheon-systems/drupal-kit/*": ["./drupal-kit/*"],


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Ideally we could hook into the `docusaurus build` script and only run the typedoc plugin to generate the API reference in CI. This does not seem to be possible, so hopefully this will fix the error in the action.

## Where were the changes made?
To the root tsconfig.
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
