### PR TITLE
DB-4018: remove workspace based dev dependencies for deployment

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,8 +320,6 @@ importers:
       '@docusaurus/core': 2.1.0
       '@docusaurus/preset-classic': 2.1.0
       '@mdx-js/react': ^1.x
-      '@pantheon-systems/configs': workspace:*
-      '@pantheon-systems/eslint-config': workspace:*
       '@types/react': 17.0.40
       clsx: ^1.2.1
       docusaurus-plugin-typedoc: ^0.17.5
@@ -340,8 +338,6 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
-      '@pantheon-systems/configs': link:../configs
-      '@pantheon-systems/eslint-config': link:../configs/eslint
       '@types/react': 17.0.40
       docusaurus-plugin-typedoc: 0.17.5_7zab47scz53et6rw2zwvyhhfd4
       typedoc: 0.23.15

--- a/web/package.json
+++ b/web/package.json
@@ -1,58 +1,56 @@
 {
-	"name": "web",
-	"version": "1.0.0",
-	"private": true,
-	"license": "GPL-3.0-or-later",
-	"homepage": "https://github.com/pantheon-systems/decoupled-kit-js#readme",
-	"bugs": "https://github.com/pantheon-systems/decoupled-kit-js/issues/new?template=bug-report-template.yml",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/pantheon-systems/decoupled-kit-js"
-	},
-	"prettier": "@pantheon-systems/configs/prettier",
-	"scripts": {
-		"docusaurus": "docusaurus",
-		"start": "docusaurus start",
-		"build": "docusaurus build",
-		"swizzle": "docusaurus swizzle",
-		"deploy": "docusaurus deploy",
-		"clear": "docusaurus clear",
-		"serve": "docusaurus serve",
-		"write-translations": "docusaurus write-translations",
-		"write-heading-ids": "docusaurus write-heading-ids",
-		"prettier:fix": "prettier \"**/*.{js,ts,jsx,tsx,md}\" --write --ignore-path ../.prettierignore"
-	},
-	"dependencies": {
-		"@codesandbox/sandpack-react": "^1.8.6",
-		"@docusaurus/core": "2.1.0",
-		"@docusaurus/preset-classic": "2.1.0",
-		"@mdx-js/react": "^1.x",
-		"clsx": "^1.2.1",
-		"prism-react-renderer": "^1.3.5",
-		"react": "17.0.2",
-		"react-dom": "17.0.2"
-	},
-	"browserslist": {
-		"production": [
-			">0.5%",
-			"not dead",
-			"not op_mini all"
-		],
-		"development": [
-			"last 1 chrome version",
-			"last 1 firefox version",
-			"last 1 safari version"
-		]
-	},
-	"devDependencies": {
-		"@pantheon-systems/configs": "workspace:*",
-		"@pantheon-systems/eslint-config": "workspace:*",
-		"@types/react": "17.0.40",
-		"docusaurus-plugin-typedoc": "^0.17.5",
-		"typedoc": "^0.23.15",
-		"typedoc-plugin-markdown": "3.13.6"
-	},
-	"peerDependencies": {
-		"@algolia/client-search": "^4.9.1"
-	}
+  "name": "web",
+  "version": "1.0.0",
+  "private": true,
+  "license": "GPL-3.0-or-later",
+  "homepage": "https://github.com/pantheon-systems/decoupled-kit-js#readme",
+  "bugs": "https://github.com/pantheon-systems/decoupled-kit-js/issues/new?template=bug-report-template.yml",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pantheon-systems/decoupled-kit-js"
+  },
+  "prettier": "@pantheon-systems/configs/prettier",
+  "scripts": {
+    "docusaurus": "docusaurus",
+    "start": "docusaurus start",
+    "build": "docusaurus build",
+    "swizzle": "docusaurus swizzle",
+    "deploy": "docusaurus deploy",
+    "clear": "docusaurus clear",
+    "serve": "docusaurus serve",
+    "write-translations": "docusaurus write-translations",
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "prettier:fix": "prettier \"**/*.{js,ts,jsx,tsx,md}\" --write --ignore-path ../.prettierignore"
+  },
+  "dependencies": {
+    "@codesandbox/sandpack-react": "^1.8.6",
+    "@docusaurus/core": "2.1.0",
+    "@docusaurus/preset-classic": "2.1.0",
+    "@mdx-js/react": "^1.x",
+    "clsx": "^1.2.1",
+    "prism-react-renderer": "^1.3.5",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
+  },
+  "browserslist": {
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@types/react": "17.0.40",
+    "docusaurus-plugin-typedoc": "^0.17.5",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-markdown": "3.13.6"
+  },
+  "peerDependencies": {
+    "@algolia/client-search": "^4.9.1"
+  }
 }


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Removed workspace based dev dependencies for deployment :)

## Where were the changes made?

/web

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
