### PR TITLE
DB-3186: Update query parameters

### DIFF
--- a/.changeset/late-dryers-collect.md
+++ b/.changeset/late-dryers-collect.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-wordpress-starter": patch
+---
+
+Update query parameters

--- a/starters/next-wordpress-starter/lib/Pages.js
+++ b/starters/next-wordpress-starter/lib/Pages.js
@@ -1,31 +1,10 @@
 import { gql } from '@pantheon-systems/wordpress-kit';
 import { client } from './WordPressClient';
 
-export async function getAllPagesUri() {
+export async function getLatestPages(totalPages) {
 	const query = gql`
-		query AllPagesURI {
-			pages {
-				edges {
-					node {
-						id
-						uri
-					}
-				}
-			}
-		}
-	`;
-
-	const {
-		pages: { edges },
-	} = await client.request(query);
-
-	return edges.map(({ node }) => node.uri.replaceAll('/', ''));
-}
-
-export async function getLatestPages() {
-	const query = gql`
-		query LatestPagesQuery {
-			pages(first: 12) {
+		query LatestPagesQuery($totalPages: Int!) {
+			pages(first: $totalPages) {
 				edges {
 					node {
 						id
@@ -45,7 +24,7 @@ export async function getLatestPages() {
 
 	const {
 		pages: { edges },
-	} = await client.request(query);
+	} = await client.request(query, { totalPages });
 
 	return edges.map(({ node }) => node);
 }

--- a/starters/next-wordpress-starter/lib/Posts.js
+++ b/starters/next-wordpress-starter/lib/Posts.js
@@ -1,10 +1,10 @@
 import { gql } from '@pantheon-systems/wordpress-kit';
 import { client } from './WordPressClient';
 
-export async function getLatestPosts() {
+export async function getLatestPosts(totalPosts) {
 	const query = gql`
-		query LatestPostsQuery {
-			posts(first: 12) {
+		query LatestPostsQuery($totalPosts: Int!) {
+			posts(first: $totalPosts) {
 				edges {
 					node {
 						id
@@ -24,7 +24,7 @@ export async function getLatestPosts() {
 
 	const {
 		posts: { edges },
-	} = await client.request(query);
+	} = await client.request(query, { totalPosts });
 
 	return edges.map(({ node }) => node);
 }

--- a/starters/next-wordpress-starter/pages/examples/ssg-isr.jsx
+++ b/starters/next-wordpress-starter/pages/examples/ssg-isr.jsx
@@ -36,7 +36,7 @@ export default function SSGISRExampleTemplate({ menuItems, posts }) {
 
 export async function getStaticProps() {
 	const menuItems = await getFooterMenu();
-	const posts = await getLatestPosts();
+	const posts = await getLatestPosts(100);
 
 	return {
 		props: {

--- a/starters/next-wordpress-starter/pages/index.jsx
+++ b/starters/next-wordpress-starter/pages/index.jsx
@@ -54,7 +54,7 @@ export default function Home({ menuItems, posts }) {
 
 export async function getServerSideProps({ res }) {
 	const menuItems = await getFooterMenu();
-	const posts = await getLatestPosts();
+	const posts = await getLatestPosts(12);
 	setEdgeHeader({ res });
 
 	return {

--- a/starters/next-wordpress-starter/pages/pages/index.jsx
+++ b/starters/next-wordpress-starter/pages/pages/index.jsx
@@ -38,7 +38,7 @@ export default function PageListTemplate({ menuItems, pages }) {
 
 export async function getServerSideProps({ res }) {
 	const menuItems = await getFooterMenu();
-	const pages = await getLatestPages(12);
+	const pages = await getLatestPages(100);
 	setEdgeHeader({ res });
 
 	return {

--- a/starters/next-wordpress-starter/pages/pages/index.jsx
+++ b/starters/next-wordpress-starter/pages/pages/index.jsx
@@ -27,7 +27,7 @@ export default function PageListTemplate({ menuItems, pages }) {
 					<PageHeader title="Pages" />
 					<Paginator
 						data={pages}
-						itemsPerPage={10}
+						itemsPerPage={12}
 						Component={RenderCurrentItems}
 					/>
 				</section>
@@ -38,7 +38,7 @@ export default function PageListTemplate({ menuItems, pages }) {
 
 export async function getServerSideProps({ res }) {
 	const menuItems = await getFooterMenu();
-	const pages = await getLatestPages();
+	const pages = await getLatestPages(12);
 	setEdgeHeader({ res });
 
 	return {

--- a/starters/next-wordpress-starter/pages/posts/index.jsx
+++ b/starters/next-wordpress-starter/pages/posts/index.jsx
@@ -10,7 +10,6 @@ import { getFooterMenu } from '../../lib/Menus';
 import { getLatestPosts } from '../../lib/Posts';
 
 export default function PostsListTemplate({ menuItems, posts }) {
-	console.log(posts);
 	const PostGrid = withGrid(PostGridItem);
 	const RenderCurrentItems = ({ currentItems }) => {
 		return <PostGrid contentType="posts" data={currentItems} />;

--- a/starters/next-wordpress-starter/pages/posts/index.jsx
+++ b/starters/next-wordpress-starter/pages/posts/index.jsx
@@ -10,6 +10,7 @@ import { getFooterMenu } from '../../lib/Menus';
 import { getLatestPosts } from '../../lib/Posts';
 
 export default function PostsListTemplate({ menuItems, posts }) {
+	console.log(posts);
 	const PostGrid = withGrid(PostGridItem);
 	const RenderCurrentItems = ({ currentItems }) => {
 		return <PostGrid contentType="posts" data={currentItems} />;
@@ -26,7 +27,7 @@ export default function PostsListTemplate({ menuItems, posts }) {
 				<section>
 					<Paginator
 						data={posts}
-						itemsPerPage={10}
+						itemsPerPage={12}
 						Component={RenderCurrentItems}
 					/>
 				</section>
@@ -37,7 +38,7 @@ export default function PostsListTemplate({ menuItems, posts }) {
 
 export async function getServerSideProps({ res }) {
 	const menuItems = await getFooterMenu();
-	const posts = await getLatestPosts();
+	const posts = await getLatestPosts(100);
 	setEdgeHeader({ res });
 
 	return {


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Updates maximum number of posts/pages returned.

## Where were the changes made?
`next-wordpress-starter`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Ran starter locally and observes all posts and pages are returned.
## Additional information

<!--- Add any other context about the feature or fix here. --->
WP and graph ql default to displaying 10 results per query when an amount is not specified. There is no good way to return 'all data' other than assigning the `first` query param a value. I adjusted our page and post queries to accept a variable specifying the number of items to be returned. This should get us the desired functionality we want and also allow us to reuse queries a bit more. For example with this set up the home page showing only 12 results can use the same query of the posts list which has all posts. 

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
