### PR TITLE
DB-3768: attempt to add the trigger-e2e workflow prior to canary split

### DIFF
--- a/.github/templates/trigger-e2e.yml.template
+++ b/.github/templates/trigger-e2e.yml.template
@@ -1,0 +1,16 @@
+name: 'Trigger E2E tests on deployment'
+
+on: deployment
+
+jobs:
+  trigger_e2e_tests:
+    name: Trigger end-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger CircleCI Pipeline
+        run: |
+          curl --request POST \
+            --url https://circleci.com/api/v2/project/gh/pantheon-systems/qa-automation/pipeline \
+            --header "Circle-Token: ${{ secrets.CIRCLECI_API_KEY }}" \
+            --header "content-type: application/json" \
+            --data '{"branch":"master", "parameters":{"run-workflow-build-and-test":false, "run-workflow-e2e-test":false, "run-workflow-sdk-test":true}}'

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -34,6 +34,10 @@ jobs:
             split_repository: 'decoupled-kit-docs-canary'
     steps:
       - uses: actions/checkout@v2
+      # Add Github workflow before split
+      - run: mkdir ${{ matrix.local_path }}/.github/workflows
+      - run: |
+          cp .github/templates/trigger-e2e.yml.template ${{ matrix.local_path }}/.github/workflows/trigger-e2e.yml
       - uses: 'symplify/monorepo-split-github-action@2.1'
         with:
           # ↓ split <local_path> directory


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Attempting to copy the necessary github action to add to the starter repo before the canary split. Won't be 100% positive that this will work until we try running it.

The hacky-er alternative is to instead create a new workflow in decoupled-kit-js that depends on canary-sites-split, and sleeps for 10 min before triggering the Circle CI sdk-test job in qa-automation. Gross, but I think it would work.

Somewhere in between those would be to git commit the workflow during CI. My hope is that this PR has the same end result.

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

They haven't been. Couldn't think of a practical way to test this locally.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
