### PR TITLE
DB-3768: prefix github workspace to path

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -35,9 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # Add Github workflow before split
-      - run: mkdir ${{ matrix.local_path }}/.github/workflows
       - run: |
-          cp .github/templates/trigger-e2e.yml.template ${{ matrix.local_path }}/.github/workflows/trigger-e2e.yml
+          mkdir ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows
+      - run: |
+          cp ${{ github.workspace }}/.github/templates/trigger-e2e.yml.template ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows/trigger-e2e.yml
       - uses: 'symplify/monorepo-split-github-action@2.1'
         with:
           # ↓ split <local_path> directory


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Added the github workspace path to attempt to correct file/directory related commands.

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
