### PR TITLE
DB-3768: ensure parent directory is created

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       # Add Github workflow before split
       - run: |
-          mkdir ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows
+          mkdir -p ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows
       - run: |
           cp ${{ github.workspace }}/.github/templates/trigger-e2e.yml.template ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows/trigger-e2e.yml
       - uses: 'symplify/monorepo-split-github-action@2.1'


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

The mkdir command was failing because it was a nested directory. Added the -p flag to fix this.

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
