### PR TITLE
Sprint 34 - exit prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "canary",
   "initialVersions": {
     "@pantheon-systems/eslint-config": "0.0.0",


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Exiting pre-release mode

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
