### PR TITLE
DB-4562: Gatsby 404 page styles

### DIFF
--- a/.changeset/happy-eggs-breathe.md
+++ b/.changeset/happy-eggs-breathe.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/gatsby-wordpress-starter": patch
+---
+
+404 page styles

--- a/starters/gatsby-wordpress-starter/src/pages/404.jsx
+++ b/starters/gatsby-wordpress-starter/src/pages/404.jsx
@@ -9,8 +9,9 @@ const NotFoundPage = ({ data, location }) => {
 
 	return (
 		<Layout location={location} title={siteTitle}>
-			<h1>404: Not Found</h1>
-			<p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+			<div className="flex flex-col mx-auto text-xl prose text-center mt-12">
+				<h2>404: Could not find the requested page</h2>
+			</div>
 		</Layout>
 	)
 }


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
The `gatsby-wordpress-starter` 404 page is styled to look similarly to the 404 page in the `next-wordpress-starter`

## Where were the changes made?
`gatsby-wordpress-starter`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
The `gatsby-wordpress-starter` was ran locally and the 404 page was observed to be visually the same as the `next-wordpress-starter`.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
