### PR TITLE
DB-4066: Block spacer styles

### DIFF
--- a/.changeset/ninety-roses-jog.md
+++ b/.changeset/ninety-roses-jog.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/wordpress-kit": minor
+---
+
+Block spacer styles

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/Config.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/Config.ts
@@ -53,6 +53,7 @@ export const mergeToConfig: Config = {
 		'.wp-block-file',
 		'.wp-block-embed',
 		'.wp-block-video',
+		'.wp-block-spacer',
 	],
 	...proseOverride,
 };

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Spacer.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Spacer.ts
@@ -1,0 +1,7 @@
+export const SpacerComponent = () => {
+	return {
+		'.wp-block-spacer': {
+			clear: 'both',
+		},
+	};
+};

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/index.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/index.ts
@@ -9,6 +9,7 @@ import { mediaAndText } from './MediaAndText';
 import { ButtonsComponent } from './Buttons';
 import { FileMediaComponent } from './FileMedia';
 import { VideoComponent } from './Video';
+import { SpacerComponent } from './Spacer';
 
 export {
 	ImageComponent,
@@ -22,4 +23,5 @@ export {
 	ButtonsComponent,
 	FileMediaComponent,
 	VideoComponent,
+	SpacerComponent,
 };

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/index.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/index.ts
@@ -11,6 +11,7 @@ import {
 	ButtonsComponent,
 	FileMediaComponent,
 	VideoComponent,
+	SpacerComponent,
 } from './components';
 import { mergeToConfig } from './Config';
 import { BaseUtilities, ColorUtilities, FontsUtilities } from './utilities';
@@ -48,6 +49,7 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
 	});
 
 	const video = VideoComponent();
+	const spacer = SpacerComponent();
 
 	addUtilities([
 		color.getBackgroundUtilities(),
@@ -72,5 +74,6 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
 		buttons,
 		fileMedia,
 		video,
+		spacer,
 	]);
 }, mergeToConfig);


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

- Added Spacer component

## Where were the changes made?
`wordpress-kit`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested this component locally through a post in the `next-wordpress-starter` that used the spacer style. Observed expected styles and behavior.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
