### PR TITLE
DB-3747: Automatically set `FRONTEND_URL`

### DIFF
--- a/.changeset/olive-jeans-begin.md
+++ b/.changeset/olive-jeans-begin.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": minor
+---
+
+Automatically set `FRONTEND_URL`

--- a/.changeset/ten-lemons-brake.md
+++ b/.changeset/ten-lemons-brake.md
@@ -1,5 +1,0 @@
----
-"web": patch
----
-
-Update `FRONTEND_URL` definition details

--- a/.changeset/ten-lemons-brake.md
+++ b/.changeset/ten-lemons-brake.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Update `FRONTEND_URL` definition details

--- a/starters/next-drupal-starter/README.md
+++ b/starters/next-drupal-starter/README.md
@@ -40,8 +40,8 @@ DEBUG_MODE=
 # this value can also bet set in the command line
 # before running commands for example
 # FRONTEND_URL=example.com npm run build
-# If not set, FRONTEND_URL is set to equal
-# PANTHEON_ENVIRONMENT_URL if it is defined
+# If not set, the FRONTEND_URL will default
+# to the value of PANTHEON_ENVIRONMENT_URL
 FRONTEND_URL=
 
 # These variables are needed to enable Preview

--- a/starters/next-drupal-starter/README.md
+++ b/starters/next-drupal-starter/README.md
@@ -40,6 +40,8 @@ DEBUG_MODE=
 # this value can also bet set in the command line
 # before running commands for example
 # FRONTEND_URL=example.com npm run build
+# If not set, FRONTEND_URL is set to equal
+# PANTHEON_ENVIRONMENT_URL if it is defined
 FRONTEND_URL=
 
 # These variables are needed to enable Preview

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -20,6 +20,14 @@ if (
 	throw new Error(message);
 }
 
+console.log('HERE');
+console.log(process.env.PANTHEON_ENVIRONMENT_URL);
+if (process.env.FRONTEND_URL === undefined) {
+	process.env.FRONTEND_URL = process.env.PANTHEON_ENVIRONMENT_URL
+		? process.env.PANTHEON_ENVIRONMENT_URL
+		: undefined;
+}
+
 let backendUrl, imageDomain;
 if (process.env.BACKEND_URL === undefined) {
 	backendUrl = `https://${process.env.PANTHEON_CMS_ENDPOINT}`;

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -20,8 +20,6 @@ if (
 	throw new Error(message);
 }
 
-console.log('HERE');
-console.log(process.env.PANTHEON_ENVIRONMENT_URL);
 if (process.env.FRONTEND_URL === undefined) {
 	process.env.FRONTEND_URL = process.env.PANTHEON_ENVIRONMENT_URL
 		? process.env.PANTHEON_ENVIRONMENT_URL

--- a/starters/next-drupal-starter/next.config.js
+++ b/starters/next-drupal-starter/next.config.js
@@ -20,10 +20,12 @@ if (
 	throw new Error(message);
 }
 
-if (process.env.FRONTEND_URL === undefined) {
-	process.env.FRONTEND_URL = process.env.PANTHEON_ENVIRONMENT_URL
-		? process.env.PANTHEON_ENVIRONMENT_URL
-		: undefined;
+// if the FRONTEND_URL is not set, fallback to the PANTHEON_ENVIRONMENT_URL
+if (
+	process.env.FRONTEND_URL === undefined &&
+	process.env.PANTHEON_ENVIRONMENT_URL
+) {
+	process.env.FRONTEND_URL = process.env.PANTHEON_ENVIRONMENT_URL;
 }
 
 let backendUrl, imageDomain;

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-environment-variables.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-environment-variables.md
@@ -25,7 +25,10 @@ IMAGE_DOMAIN=my-image-cdn.site
 ```
 
 If your site is translated and you would like the hreflang metadata set
-correctly, you may set `FRONTEND_URL` to the URL of your frontend site:
+correctly, you may set `FRONTEND_URL` to the URL of your frontend site.
+
+If unset, `FRONTEND_URL` will default to the value of `PANTHEON_ENVIRONMENT_URL`
+if it is defined.
 
 ```
 FRONTEND_URL=https://my-frontend-site.pantheon.site

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-environment-variables.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-environment-variables.md
@@ -27,8 +27,7 @@ IMAGE_DOMAIN=my-image-cdn.site
 If your site is translated and you would like the hreflang metadata set
 correctly, you may set `FRONTEND_URL` to the URL of your frontend site.
 
-If unset, `FRONTEND_URL` will default to the value of `PANTHEON_ENVIRONMENT_URL`
-if it is defined.
+If the`FRONTEND_URL` is not set, it will default to the value of `PANTHEON_ENVIRONMENT_URL`
 
 ```
 FRONTEND_URL=https://my-frontend-site.pantheon.site


### PR DESCRIPTION
`` <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

- The `FRONTEND_URL` is automatically set to `PANTHEON_ENVIRONMENT_URL` if defined.
- Docs updated to reflect this change

## Where were the changes made?
`next-drupal-starter`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
I deployed a site without setting the `FRONTEND_URL` env var and observed that the `hrefLang` was set correctly based off of the `PANTHEON_ENVIRONMENT_URL`.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
