### PR TITLE
DB-4060: Block Editor Alignment Options

### DIFF
--- a/.changeset/four-wolves-chew.md
+++ b/.changeset/four-wolves-chew.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/nextjs-kit': minor
+---
+
+Refactor content with image component

--- a/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/contentWithImage.test.tsx.snap
+++ b/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/contentWithImage.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ContentWithImage /> > should render 'contentWithImage' 1`] = `
     class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
   >
     <section
-      class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+      class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
     >
       <h1>
         Example Post with Image
@@ -44,7 +44,7 @@ exports[`<ContentWithImage /> > should render 'contentWithImage' 1`] = `
       </div>
     </div>
     <div
-      class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+      class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
     >
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/contentWithImage.test.tsx.snap
+++ b/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/contentWithImage.test.tsx.snap
@@ -5,19 +5,23 @@ exports[`<ContentWithImage /> > should render 'contentWithImage' 1`] = `
   <article
     class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
   >
-    <h1>
-      Example Post with Image
-    </h1>
-    <p
-      class="ps-text-sm ps-text-gray-600"
+    <section
+      class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
     >
-      8/4/2022
-    </p>
-    <a
-      class="ps-font-normal ps-cursor-pointer"
-    >
-      Back →
-    </a>
+      <h1>
+        Example Post with Image
+      </h1>
+      <p
+        class="ps-text-sm ps-text-gray-600"
+      >
+        8/4/2022
+      </p>
+      <a
+        class="ps-font-normal ps-cursor-pointer"
+      >
+        Back →
+      </a>
+    </section>
     <div
       class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
     >
@@ -40,7 +44,7 @@ exports[`<ContentWithImage /> > should render 'contentWithImage' 1`] = `
       </div>
     </div>
     <div
-      class="ps-break-words ps-mt-12"
+      class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
     >
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/packages/nextjs-kit/src/components/contentWithImage.tsx
+++ b/packages/nextjs-kit/src/components/contentWithImage.tsx
@@ -34,25 +34,23 @@ const ContentWithImage: React.FC<ContentProps> = ({
 	content,
 	date,
 	imageProps,
-	contentClassName,
+	contentClassName = 'ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4',
 }: ContentProps) => {
 	const router = useRouter();
 
-	const classNames = (...classes: (string | undefined)[]) => {
-		return classes.filter(Boolean).join(' ');
-	};
-
 	return (
 		<article className="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12">
-			<h1>{title}</h1>
-			{date ? <p className="ps-text-sm ps-text-gray-600">{date}</p> : null}
+			<section className="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4">
+				<h1>{title}</h1>
+				{date ? <p className="ps-text-sm ps-text-gray-600">{date}</p> : null}
 
-			<a
-				onClick={() => router.back()}
-				className="ps-font-normal ps-cursor-pointer"
-			>
-				Back &rarr;
-			</a>
+				<a
+					onClick={() => router.back()}
+					className="ps-font-normal ps-cursor-pointer"
+				>
+					Back &rarr;
+				</a>
+			</section>
 			<div className="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg">
 				{imageProps ? (
 					<div className="ps-relative ps-mb-10 ps-min-h-[50vh]">
@@ -68,7 +66,7 @@ const ContentWithImage: React.FC<ContentProps> = ({
 			</div>
 
 			<div
-				className={classNames('ps-break-words ps-mt-12', contentClassName)}
+				className={`ps-break-words ps-mt-12 ${contentClassName}`}
 				dangerouslySetInnerHTML={{ __html: content }}
 			/>
 		</article>

--- a/packages/nextjs-kit/src/components/contentWithImage.tsx
+++ b/packages/nextjs-kit/src/components/contentWithImage.tsx
@@ -34,13 +34,13 @@ const ContentWithImage: React.FC<ContentProps> = ({
 	content,
 	date,
 	imageProps,
-	contentClassName = 'ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4',
+	contentClassName = 'ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto',
 }: ContentProps) => {
 	const router = useRouter();
 
 	return (
 		<article className="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12">
-			<section className="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4">
+			<section className="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto">
 				<h1>{title}</h1>
 				{date ? <p className="ps-text-sm ps-text-gray-600">{date}</p> : null}
 

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/[...alias].test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/[...alias].test.jsx.snap
@@ -195,7 +195,7 @@ exports[`default <CatchAllRoute /> > should render an article 1`] = `
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
         <section
-          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <h1>
             Example Top Level Article
@@ -228,7 +228,7 @@ exports[`default <CatchAllRoute /> > should render an article 1`] = `
           </div>
         </div>
         <div
-          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <h2>
             Nonummy Tristique Pulvinar Justo Primis Mi

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/[...alias].test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/[...alias].test.jsx.snap
@@ -194,14 +194,18 @@ exports[`default <CatchAllRoute /> > should render an article 1`] = `
       <article
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
-        <h1>
-          Example Top Level Article
-        </h1>
-        <a
-          class="ps-font-normal ps-cursor-pointer"
+        <section
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
-          Back →
-        </a>
+          <h1>
+            Example Top Level Article
+          </h1>
+          <a
+            class="ps-font-normal ps-cursor-pointer"
+          >
+            Back →
+          </a>
+        </section>
         <div
           class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
         >
@@ -224,7 +228,7 @@ exports[`default <CatchAllRoute /> > should render an article 1`] = `
           </div>
         </div>
         <div
-          class="ps-break-words ps-mt-12"
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
           <h2>
             Nonummy Tristique Pulvinar Justo Primis Mi

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/articles.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/articles.test.jsx.snap
@@ -61,14 +61,18 @@ exports[`default <ArticleTemplate /> > should render with default profile articl
       <article
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
-        <h1>
-          This is an Example Article
-        </h1>
-        <a
-          class="ps-font-normal ps-cursor-pointer"
+        <section
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
-          Back →
-        </a>
+          <h1>
+            This is an Example Article
+          </h1>
+          <a
+            class="ps-font-normal ps-cursor-pointer"
+          >
+            Back →
+          </a>
+        </section>
         <div
           class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
         >
@@ -91,7 +95,7 @@ exports[`default <ArticleTemplate /> > should render with default profile articl
           </div>
         </div>
         <div
-          class="ps-break-words ps-mt-12"
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ullamcorper dignissim cras tincidunt lobortis feugiat. Augue lacus viverra vitae congue eu consequat ac felis. Vulputate sapien nec sagittis aliquam malesuada bibendum arcu vitae elementum. Pulvinar elementum integer enim neque. At tempor commodo ullamcorper a lacus vestibulum. Nec tincidunt praesent semper feugiat nibh. Nisl nisi scelerisque eu ultrices vitae auctor eu augue ut. Bibendum neque egestas congue quisque egestas diam. Pellentesque elit ullamcorper dignissim cras.

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/articles.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/articles.test.jsx.snap
@@ -62,7 +62,7 @@ exports[`default <ArticleTemplate /> > should render with default profile articl
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
         <section
-          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <h1>
             This is an Example Article
@@ -95,7 +95,7 @@ exports[`default <ArticleTemplate /> > should render with default profile articl
           </div>
         </div>
         <div
-          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ullamcorper dignissim cras tincidunt lobortis feugiat. Augue lacus viverra vitae congue eu consequat ac felis. Vulputate sapien nec sagittis aliquam malesuada bibendum arcu vitae elementum. Pulvinar elementum integer enim neque. At tempor commodo ullamcorper a lacus vestibulum. Nec tincidunt praesent semper feugiat nibh. Nisl nisi scelerisque eu ultrices vitae auctor eu augue ut. Bibendum neque egestas congue quisque egestas diam. Pellentesque elit ullamcorper dignissim cras.

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/[...alias].test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/[...alias].test.jsx.snap
@@ -455,14 +455,18 @@ exports[`umami <CatchAllRoute /> > should render an article 1`] = `
       <article
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
-        <h1>
-          Example Top Level Article
-        </h1>
-        <a
-          class="ps-font-normal ps-cursor-pointer"
+        <section
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
-          Back →
-        </a>
+          <h1>
+            Example Top Level Article
+          </h1>
+          <a
+            class="ps-font-normal ps-cursor-pointer"
+          >
+            Back →
+          </a>
+        </section>
         <div
           class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
         >
@@ -485,7 +489,7 @@ exports[`umami <CatchAllRoute /> > should render an article 1`] = `
           </div>
         </div>
         <div
-          class="ps-break-words ps-mt-12"
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
           <h2>
             Nonummy Tristique Pulvinar Justo Primis Mi

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/[...alias].test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/[...alias].test.jsx.snap
@@ -456,7 +456,7 @@ exports[`umami <CatchAllRoute /> > should render an article 1`] = `
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
         <section
-          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <h1>
             Example Top Level Article
@@ -489,7 +489,7 @@ exports[`umami <CatchAllRoute /> > should render an article 1`] = `
           </div>
         </div>
         <div
-          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <h2>
             Nonummy Tristique Pulvinar Justo Primis Mi

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/articles.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/articles.test.jsx.snap
@@ -61,14 +61,18 @@ exports[`umami <ArticleTemplate /> > should render with umami profile articles 1
       <article
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
-        <h1>
-          Give it a go and grow your own herbs
-        </h1>
-        <a
-          class="ps-font-normal ps-cursor-pointer"
+        <section
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
-          Back →
-        </a>
+          <h1>
+            Give it a go and grow your own herbs
+          </h1>
+          <a
+            class="ps-font-normal ps-cursor-pointer"
+          >
+            Back →
+          </a>
+        </section>
         <div
           class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
         >
@@ -91,7 +95,7 @@ exports[`umami <ArticleTemplate /> > should render with umami profile articles 1
           </div>
         </div>
         <div
-          class="ps-break-words ps-mt-12"
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
           <p>
             There's nothing like having your own supply of fresh herbs, readily available and close at hand to use while cooking. Whether you have a large garden or a small kitchen window sill, there's always enough room for something home grown.

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/articles.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/articles.test.jsx.snap
@@ -62,7 +62,7 @@ exports[`umami <ArticleTemplate /> > should render with umami profile articles 1
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
         <section
-          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <h1>
             Give it a go and grow your own herbs
@@ -95,7 +95,7 @@ exports[`umami <ArticleTemplate /> > should render with umami profile articles 1
           </div>
         </div>
         <div
-          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <p>
             There's nothing like having your own supply of fresh herbs, readily available and close at hand to use while cooking. Whether you have a large garden or a small kitchen window sill, there's always enough room for something home grown.

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/pages.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/pages.test.jsx.snap
@@ -204,7 +204,7 @@ exports[`<PageTemplate /> > should render a page 1`] = `
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
         <section
-          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <h1>
             Sample Page

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/pages.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/pages.test.jsx.snap
@@ -203,19 +203,23 @@ exports[`<PageTemplate /> > should render a page 1`] = `
       <article
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
-        <h1>
-          Sample Page
-        </h1>
-        <p
-          class="ps-text-sm ps-text-gray-600"
+        <section
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
-          9/13/2022
-        </p>
-        <a
-          class="ps-font-normal ps-cursor-pointer"
-        >
-          Back →
-        </a>
+          <h1>
+            Sample Page
+          </h1>
+          <p
+            class="ps-text-sm ps-text-gray-600"
+          >
+            9/13/2022
+          </p>
+          <a
+            class="ps-font-normal ps-cursor-pointer"
+          >
+            Back →
+          </a>
+        </section>
         <div
           class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
         />

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/posts.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/posts.test.jsx.snap
@@ -225,7 +225,7 @@ exports[`<PostTemplate /> > should render a post 1`] = `
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
         <section
-          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
         >
           <h1>
             Example Post with Image

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/posts.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/posts.test.jsx.snap
@@ -224,19 +224,23 @@ exports[`<PostTemplate /> > should render a post 1`] = `
       <article
         class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
       >
-        <h1>
-          Example Post with Image
-        </h1>
-        <p
-          class="ps-text-sm ps-text-gray-600"
+        <section
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto ps-px-4"
         >
-          9/13/2022
-        </p>
-        <a
-          class="ps-font-normal ps-cursor-pointer"
-        >
-          Back →
-        </a>
+          <h1>
+            Example Post with Image
+          </h1>
+          <p
+            class="ps-text-sm ps-text-gray-600"
+          >
+            9/13/2022
+          </p>
+          <a
+            class="ps-font-normal ps-cursor-pointer"
+          >
+            Back →
+          </a>
+        </section>
         <div
           class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
         >


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Refactor content with image component to have a default styling for the CMS content
- Wrapped the header in a section to apply width logic

## Where were the changes made?
- Nextjs-Kit

## How have the changes been tested?
Locally, tested on Drupal and WordPress flavors, against the Canary site

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
