### PR TITLE
DB-4065: Block separator styles

### DIFF
--- a/.changeset/hungry-roses-destroy.md
+++ b/.changeset/hungry-roses-destroy.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/wordpress-kit": minor
+---
+
+Add block separator styles

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/Config.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/Config.ts
@@ -54,6 +54,7 @@ export const mergeToConfig: Config = {
 		'.wp-block-embed',
 		'.wp-block-video',
 		'.wp-block-spacer',
+		'.wp-block-separator',
 	],
 	...proseOverride,
 };

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Separator.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Separator.ts
@@ -29,6 +29,18 @@ export const SeparatorComponent = () => {
 				paddingLeft: '2em',
 				fontFamily: 'serif',
 			},
+			'&.has-background': {
+				padding: '0',
+			},
+			'&.has-background:not(.is-style-dots)': {
+				borderBottom: 'none',
+				height: '1px',
+				padding: '0',
+			},
+			'&.wp-block-separator.has-background:not(.is-style-wide):not(.is-style-dots)':
+				{
+					height: '2px',
+				},
 		},
 	};
 };

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Separator.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Separator.ts
@@ -1,0 +1,34 @@
+export const SeparatorComponent = () => {
+	return {
+		'.wp-block-separator': {
+			border: 'none',
+			borderBottom: '2px solid',
+			marginLeft: 'auto',
+			marginRight: 'auto',
+			borderColor: 'black !important',
+			'&.is-style-default': {
+				width: '100px',
+			},
+			'&.is-style-wide': {
+				maxWidth: '650px',
+				marginLeft: 'auto !important',
+				marginRight: 'auto !important',
+			},
+			'&.is-style-dots': {
+				background: 'none!important',
+				border: 'none',
+				textAlign: 'center',
+				lineHeight: '1',
+				height: 'auto',
+			},
+			'&.is-style-dots:before': {
+				content: '"···"',
+				color: 'currentColor',
+				fontSize: '1.5em',
+				letterSpacing: '2em',
+				paddingLeft: '2em',
+				fontFamily: 'serif',
+			},
+		},
+	};
+};

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Separator.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Separator.ts
@@ -10,7 +10,7 @@ export const SeparatorComponent = () => {
 				width: '100px',
 			},
 			'&.is-style-wide': {
-				maxWidth: '650px',
+				maxWidth: '720px',
 				marginLeft: 'auto !important',
 				marginRight: 'auto !important',
 			},

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/index.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/index.ts
@@ -10,6 +10,7 @@ import { ButtonsComponent } from './Buttons';
 import { FileMediaComponent } from './FileMedia';
 import { VideoComponent } from './Video';
 import { SpacerComponent } from './Spacer';
+import { SeparatorComponent } from './Separator';
 
 export {
 	ImageComponent,
@@ -24,4 +25,5 @@ export {
 	FileMediaComponent,
 	VideoComponent,
 	SpacerComponent,
+	SeparatorComponent,
 };

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/index.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/index.ts
@@ -12,6 +12,7 @@ import {
 	FileMediaComponent,
 	VideoComponent,
 	SpacerComponent,
+	SeparatorComponent,
 } from './components';
 import { mergeToConfig } from './Config';
 import { BaseUtilities, ColorUtilities, FontsUtilities } from './utilities';
@@ -50,6 +51,7 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
 
 	const video = VideoComponent();
 	const spacer = SpacerComponent();
+	const separator = SeparatorComponent();
 
 	addUtilities([
 		color.getBackgroundUtilities(),
@@ -75,5 +77,6 @@ export default plugin(function ({ addUtilities, theme, addComponents }) {
 		fileMedia,
 		video,
 		spacer,
+		separator,
 	]);
 }, mergeToConfig);


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

- Added Separator component

## Where were the changes made?
`wordpress-kit`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested this component locally through a post in the `next-wordpress-starter` that used the separator block. Observed expected styles and behavior.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
