### PR TITLE
DB-3674: Refactor Stores

### DIFF
--- a/.changeset/healthy-seas-hide.md
+++ b/.changeset/healthy-seas-hide.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/drupal-kit": patch
+---
+
+Update to latest version of DrupalState, v4.2.0

--- a/.changeset/smooth-apes-rescue.md
+++ b/.changeset/smooth-apes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/next-drupal-starter": minor
+---
+
+Refactor stores to use DS auth/anon request flow feature

--- a/packages/drupal-kit/package.json
+++ b/packages/drupal-kit/package.json
@@ -49,6 +49,6 @@
 		"vite-plugin-dts": "^1.6.1"
 	},
 	"dependencies": {
-		"@gdwc/drupal-state": "^4.0.1"
+		"@gdwc/drupal-state": "^4.2.0"
 	}
 }

--- a/packages/drupal-kit/src/lib/PantheonDrupalState.ts
+++ b/packages/drupal-kit/src/lib/PantheonDrupalState.ts
@@ -43,14 +43,12 @@ class PantheonDrupalState extends DrupalState {
 	async fetchData(
 		endpoint: string,
 		res: ServerResponse | boolean = false,
-	): Promise<TJsonApiBody> {
+		anon = false,
+	): Promise<TJsonApiBody | void> {
 		let requestInit = {};
 		let authHeader = '';
-		if (this.auth) {
-			// TODO - remove eslint disable. Not sure why eslint can't pick up on
-			// this.getAuthHeader() from the parent class
+		if (this.auth && !anon) {
 			const headers = new Headers();
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			authHeader = await this.getAuthHeader();
 			headers.append('Authorization', authHeader);
 			requestInit = {
@@ -65,29 +63,6 @@ class PantheonDrupalState extends DrupalState {
 			res,
 		)) as TJsonApiBody;
 	}
-	// async fetchData(
-	// 	endpoint: string,
-	// 	res: ServerResponse | boolean = false,
-	// 	anon = true,
-	// ): Promise<TJsonApiBody | void> {
-	// 	let requestInit = {};
-	// 	let authHeader = '';
-	// 	if (!anon) {
-	// 		const headers = new Headers();
-	// 		authHeader = await this.getAuthHeader();
-	// 		headers.append('Authorization', authHeader);
-	// 		requestInit = {
-	// 			headers: headers,
-	// 		};
-	// 	}
-
-	// 	return (await this.fetchJsonapiEndpoint(
-	// 		endpoint,
-	// 		requestInit,
-	// 		this.onError,
-	// 		res,
-	// 	)) as TJsonApiBody;
-	// }
 }
 
 export default PantheonDrupalState;

--- a/packages/drupal-kit/src/lib/PantheonDrupalState.ts
+++ b/packages/drupal-kit/src/lib/PantheonDrupalState.ts
@@ -65,6 +65,29 @@ class PantheonDrupalState extends DrupalState {
 			res,
 		)) as TJsonApiBody;
 	}
+	// async fetchData(
+	// 	endpoint: string,
+	// 	res: ServerResponse | boolean = false,
+	// 	anon = true,
+	// ): Promise<TJsonApiBody | void> {
+	// 	let requestInit = {};
+	// 	let authHeader = '';
+	// 	if (!anon) {
+	// 		const headers = new Headers();
+	// 		authHeader = await this.getAuthHeader();
+	// 		headers.append('Authorization', authHeader);
+	// 		requestInit = {
+	// 			headers: headers,
+	// 		};
+	// 	}
+
+	// 	return (await this.fetchJsonapiEndpoint(
+	// 		endpoint,
+	// 		requestInit,
+	// 		this.onError,
+	// 		res,
+	// 	)) as TJsonApiBody;
+	// }
 }
 
 export default PantheonDrupalState;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,6 @@ overrides:
   parse-path@<5.0.0: '>=5.0.0'
   parse-url@<8.1.0: '>=8.1.0'
 
-patchedDependencies: {}
-
 importers:
 
   .:
@@ -91,7 +89,7 @@ importers:
 
   packages/drupal-kit:
     specifiers:
-      '@gdwc/drupal-state': ^4.0.1
+      '@gdwc/drupal-state': ^4.2.0
       '@pantheon-systems/configs': '*'
       '@pantheon-systems/eslint-config': '*'
       '@types/isomorphic-fetch': ^0.0.36
@@ -102,7 +100,7 @@ importers:
       typescript: ^4.8.4
       vite-plugin-dts: ^1.6.1
     dependencies:
-      '@gdwc/drupal-state': 4.0.1_qcef5mtkqifnealbzizx64k6m4
+      '@gdwc/drupal-state': 4.2.0_57dtt4vsss4vuwatpj6hbsic3q
     devDependencies:
       '@pantheon-systems/configs': link:../../configs
       '@pantheon-systems/eslint-config': link:../../configs/eslint
@@ -471,7 +469,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.14
+      '@jridgewell/trace-mapping': 0.3.15
 
   /@ardatan/relay-compiler/12.0.0_graphql@15.8.0:
     resolution: {integrity: sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==}
@@ -662,6 +660,7 @@ packages:
       '@babel/types': 7.19.3
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: false
 
   /@babel/generator/7.19.3:
     resolution: {integrity: sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==}
@@ -895,10 +894,10 @@ packages:
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-simple-access': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/traverse': 7.19.3
+      '@babel/types': 7.19.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1023,8 +1022,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.19.0
-      '@babel/types': 7.19.0
+      '@babel/traverse': 7.19.3
+      '@babel/types': 7.19.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1032,7 +1031,7 @@ packages:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
       js-tokens: 4.0.0
 
@@ -1042,6 +1041,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.19.3
+    dev: true
 
   /@babel/parser/7.18.9:
     resolution: {integrity: sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==}
@@ -1057,6 +1057,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.19.0
+    dev: false
 
   /@babel/parser/7.19.3:
     resolution: {integrity: sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==}
@@ -3046,8 +3047,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.18.11
-      '@babel/types': 7.18.10
+      '@babel/parser': 7.19.3
+      '@babel/types': 7.19.3
 
   /@babel/template/7.18.6:
     resolution: {integrity: sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==}
@@ -3110,6 +3111,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/traverse/7.19.3:
     resolution: {integrity: sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==}
@@ -3135,6 +3137,7 @@ packages:
       '@babel/helper-string-parser': 7.18.10
       '@babel/helper-validator-identifier': 7.18.6
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types/7.18.9:
     resolution: {integrity: sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==}
@@ -3151,6 +3154,7 @@ packages:
       '@babel/helper-string-parser': 7.18.10
       '@babel/helper-validator-identifier': 7.18.6
       to-fast-properties: 2.0.0
+    dev: false
 
   /@babel/types/7.19.3:
     resolution: {integrity: sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==}
@@ -3588,26 +3592,8 @@ packages:
     dev: false
     optional: true
 
-  /@docsearch/css/1.0.0-alpha.28:
-    resolution: {integrity: sha512-1AhRzVdAkrWwhaxTX6/R7SnFHz8yLz1W8I/AldlTrfbNvZs9INk1FZiEFTJdgHaP68nhgQNWSGlQiDiI3y2RYg==}
-    dev: false
-
   /@docsearch/css/3.1.1:
     resolution: {integrity: sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg==}
-    dev: false
-
-  /@docsearch/react/1.0.0-alpha.28_wcqkhtmu7mswc6yz4uyexck3ty:
-    resolution: {integrity: sha512-XjJOnCBXn+UZmtuDmgzlVIHnnvh6yHVwG4aFq8AXN6xJEIX3f180FvGaowFWAxgdtHplJxFGux0Xx4piHqBzIw==}
-    peerDependencies:
-      react: ^16.8.0
-      react-dom: ^16.8.0
-    dependencies:
-      '@docsearch/css': 1.0.0-alpha.28
-      '@francoischalifour/autocomplete-core': 1.0.0-alpha.28
-      '@francoischalifour/autocomplete-preset-algolia': 1.0.0-alpha.28
-      algoliasearch: 4.14.2
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
     dev: false
 
   /@docsearch/react/3.1.1_kovxwvdy3lfpfjtjywbcrw6yga:
@@ -4364,14 +4350,6 @@ packages:
       - supports-color
     dev: true
 
-  /@francoischalifour/autocomplete-core/1.0.0-alpha.28:
-    resolution: {integrity: sha512-rL9x+72btViw+9icfBKUJjZj87FgjFrD2esuTUqtj4RAX3s4AuVZiN8XEsfjQBSc6qJk31cxlvqZHC/BIyYXgg==}
-    dev: false
-
-  /@francoischalifour/autocomplete-preset-algolia/1.0.0-alpha.28:
-    resolution: {integrity: sha512-bprfNmYt1opFUFEtD2XfY/kEsm13bzHQgU80uMjhuK0DJ914IjolT1GytpkdM6tJ4MBvyiJPP+bTtWO+BZ7c7w==}
-    dev: false
-
   /@gatsbyjs/parcel-namer-relative-to-cwd/1.9.0_@parcel+core@2.6.2:
     resolution: {integrity: sha512-N/GUtMxnYgUdn7BeHFQ3iY4A13bN5a7Jfi+kT0fGbfTggMI3XDvIHWRoMfUDcRtUo2D/gL3sQq5gd1k8obye3A==}
     engines: {node: '>=14.15.0', parcel: 2.x}
@@ -4411,12 +4389,11 @@ packages:
       strip-ansi: 6.0.1
     dev: false
 
-  /@gdwc/drupal-state/4.0.1_qcef5mtkqifnealbzizx64k6m4:
-    resolution: {integrity: sha512-Y0wfehQlVGcvWogAbaQFiz47hwzihOzVzSq4J59JSOv6vkYghjHfdIm+FLSF5+TMYC1hdZkd8WaPSbA5ePCVSg==}
+  /@gdwc/drupal-state/4.2.0_57dtt4vsss4vuwatpj6hbsic3q:
+    resolution: {integrity: sha512-nTXcjb2XQPTL8UuooHUARQmfZ2l9OTQxrEBW1nk1pztYXORjNz11Dk1U97ny3jl/opX/gLYCD4dgIehl0rWXEw==}
     requiresBuild: true
     dependencies:
       '@babel/runtime': 7.19.0
-      '@docsearch/react': 1.0.0-alpha.28_wcqkhtmu7mswc6yz4uyexck3ty
       '@types/isomorphic-fetch': 0.0.35
       '@types/jest': 27.5.2
       drupal-jsonapi-params: 1.2.3
@@ -4437,7 +4414,6 @@ packages:
       - esbuild
       - node-notifier
       - react
-      - react-dom
       - supports-color
       - ts-node
       - typescript
@@ -17391,6 +17367,7 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
       scheduler: 0.19.1
+    dev: true
 
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -18058,6 +18035,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: true
 
   /scheduler/0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
@@ -20124,6 +20102,7 @@ packages:
 
   /w3c-hr-time/1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
+    deprecated: Use your platform's native performance.now() and performance.timeOrigin.
     dependencies:
       browser-process-hrtime: 1.0.0
     dev: false

--- a/starters/next-drupal-starter/__tests__/getPaths.test.js
+++ b/starters/next-drupal-starter/__tests__/getPaths.test.js
@@ -48,7 +48,7 @@ describe('getPaths()', () => {
 			);
 		} catch (error) {
 			expect(error.message).toEqual(
-				`Invalid objectName.\nCheck that node--x is a valid node in your Drupal instance or local store`,
+				`Invalid objectName.\nCheck that node--x is a valid node in your Drupal instance`,
 			);
 		}
 	});

--- a/starters/next-drupal-starter/__tests__/getPreview.test.js
+++ b/starters/next-drupal-starter/__tests__/getPreview.test.js
@@ -1,5 +1,5 @@
 import { getPreview } from '../lib/getPreview';
-import { globalDrupalStateAuthStores } from '../lib/stores';
+import { globalDrupalStateStores } from '../lib/stores';
 
 import umamiPreview from './data/umamiPreview.json';
 import defaultProfilePreview from './data/defaultProfilePreview.json';
@@ -56,13 +56,13 @@ describe('getPreview()', () => {
 		await getPreview(mockContext, 'node--article', '');
 		if (PROFILE === 'umami') {
 			const dataFromState =
-				globalDrupalStateAuthStores[0].getState()['node--articleResources'][
+				globalDrupalStateStores[0].getState()['node--articleResources'][
 					'00517b73-f66c-43eb-93b1-444a68ab97d8'
 				].data;
 			expect(dataFromState).toEqual(umamiPreview.data);
 		} else if (PROFILE === 'default') {
 			const dataFromState =
-				globalDrupalStateAuthStores[0].getState()['node--articleResources'][
+				globalDrupalStateStores[0].getState()['node--articleResources'][
 					'd4b52b83-e92a-4a4f-b2de-647ecb9fb6d0'
 				].data;
 			expect(dataFromState).toEqual(defaultProfilePreview.data);

--- a/starters/next-drupal-starter/lib/getPaths.js
+++ b/starters/next-drupal-starter/lib/getPaths.js
@@ -26,6 +26,7 @@ export const getPaths = async (
 			// fetch the node from Drupal
 			const data = await store.getObject({
 				objectName: node,
+				anon: true,
 			});
 			// filter out data that does not have the urlAliasPrefix in the path alias
 			// so the catch all route works.

--- a/starters/next-drupal-starter/lib/getPreview.js
+++ b/starters/next-drupal-starter/lib/getPreview.js
@@ -1,4 +1,4 @@
-import { globalDrupalStateAuthStores, getCurrentLocaleStore } from './stores';
+import { globalDrupalStateStores, getCurrentLocaleStore } from './stores';
 import { fetchJsonapiEndpoint } from '@pantheon-systems/drupal-kit';
 /**
  *
@@ -15,7 +15,7 @@ export async function getPreview(context, node, params) {
 	const { previewLang } = context.previewData;
 
 	// Get the store for the preview language.
-	const store = getCurrentLocaleStore(previewLang, globalDrupalStateAuthStores);
+	const store = getCurrentLocaleStore(previewLang, globalDrupalStateStores);
 	try {
 		if (context.previewData) {
 			process.env.DEBUG_MODE &&

--- a/starters/next-drupal-starter/lib/stores.js
+++ b/starters/next-drupal-starter/lib/stores.js
@@ -9,7 +9,7 @@ export const makeLocaleStores = ({ locales, debug = false }) =>
 					new DrupalState({
 						apiBase: DRUPAL_URL,
 						defaultLocale: locale,
-						debug: true,
+						debug: debug,
 						clientId: process.env.CLIENT_ID,
 						clientSecret: process.env.CLIENT_SECRET,
 					}),
@@ -17,7 +17,7 @@ export const makeLocaleStores = ({ locales, debug = false }) =>
 		: [
 				new DrupalState({
 					apiBase: DRUPAL_URL,
-					debug: true,
+					debug: debug,
 					clientId: process.env.CLIENT_ID,
 					clientSecret: process.env.CLIENT_SECRET,
 				}),

--- a/starters/next-drupal-starter/lib/stores.js
+++ b/starters/next-drupal-starter/lib/stores.js
@@ -27,7 +27,9 @@ export const makeLocaleStores = ({ locales, debug = false }) =>
 // getStaticProps and getServerSideProps
 /**
  * @type {DrupalState[]}
- * @remarks These stores do not have auth enabled, even if the proper env vars are set.
+ * @remarks These stores have auth enabled. Authenticated and anonymous request control takes place on the level of the request.
+ * @see {@link https://project.pages.drupalcode.org/drupal_state/en/getting-objects/} for more information.
+ *
  */
 export const globalDrupalStateStores = makeLocaleStores({
 	locales: process.env.locales,

--- a/starters/next-drupal-starter/lib/stores.js
+++ b/starters/next-drupal-starter/lib/stores.js
@@ -2,28 +2,24 @@ import { DRUPAL_URL } from './constants';
 import { DrupalState } from '@pantheon-systems/drupal-kit';
 
 // For each locale, make an instance of DrupalState (LocaleStore)
-export const makeLocaleStores = ({ locales, auth = false, debug = false }) =>
+export const makeLocaleStores = ({ locales, debug = false }) =>
 	locales.length > 1
 		? locales.map(
 				(locale) =>
 					new DrupalState({
 						apiBase: DRUPAL_URL,
 						defaultLocale: locale,
-						debug: debug,
-						...(auth && {
-							clientId: process.env.CLIENT_ID,
-							clientSecret: process.env.CLIENT_SECRET,
-						}),
+						debug: true,
+						clientId: process.env.CLIENT_ID,
+						clientSecret: process.env.CLIENT_SECRET,
 					}),
 		  )
 		: [
 				new DrupalState({
 					apiBase: DRUPAL_URL,
-					debug: debug,
-					...(auth && {
-						clientId: process.env.CLIENT_ID,
-						clientSecret: process.env.CLIENT_SECRET,
-					}),
+					debug: true,
+					clientId: process.env.CLIENT_ID,
+					clientSecret: process.env.CLIENT_SECRET,
 				}),
 		  ];
 
@@ -35,15 +31,6 @@ export const makeLocaleStores = ({ locales, auth = false, debug = false }) =>
  */
 export const globalDrupalStateStores = makeLocaleStores({
 	locales: process.env.locales,
-	debug: process.env.DEBUG_MODE || false,
-});
-/**
- * @type {DrupalState[]}
- * @remarks These stores can make authorized calls if CLIENT_ID and CLIENT_SECRET env variables are present
- */
-export const globalDrupalStateAuthStores = makeLocaleStores({
-	locales: process.env.locales,
-	auth: true,
 	debug: process.env.DEBUG_MODE || false,
 });
 

--- a/starters/next-drupal-starter/pages/[...alias].jsx
+++ b/starters/next-drupal-starter/pages/[...alias].jsx
@@ -154,8 +154,7 @@ export async function getServerSideProps(context) {
 			params: context.preview ? previewParams : params,
 			refresh: true,
 			res: context.res,
-			// anon: context.preview ? false : true,
-			anon: true,
+			anon: context.preview ? false : true,
 		});
 
 		const footerMenu = await store.getObject({

--- a/starters/next-drupal-starter/pages/[...alias].jsx
+++ b/starters/next-drupal-starter/pages/[...alias].jsx
@@ -1,8 +1,4 @@
-import {
-	getCurrentLocaleStore,
-	globalDrupalStateStores,
-	globalDrupalStateAuthStores,
-} from '../lib/stores';
+import { getCurrentLocaleStore, globalDrupalStateStores } from '../lib/stores';
 import { getPreview } from '../lib/getPreview';
 import { translatePath } from '@pantheon-systems/drupal-kit';
 import { NextSeo } from 'next-seo';
@@ -127,10 +123,7 @@ export async function getServerSideProps(context) {
 		});
 		const lang = context.preview ? context.previewData.previewLang : locale;
 
-		const store = getCurrentLocaleStore(
-			lang,
-			context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores,
-		);
+		const store = getCurrentLocaleStore(lang, globalDrupalStateStores);
 
 		// get the path from the params
 		const path = Array.isArray(alias) ? alias.join('/') : alias;
@@ -161,12 +154,15 @@ export async function getServerSideProps(context) {
 			params: context.preview ? previewParams : params,
 			refresh: true,
 			res: context.res,
+			// anon: context.preview ? false : true,
+			anon: true,
 		});
 
 		const footerMenu = await store.getObject({
 			objectName: 'menu_items--main',
 			refresh: true,
 			res: context.res,
+			anon: true,
 		});
 		return {
 			props: {

--- a/starters/next-drupal-starter/pages/api/preview.js
+++ b/starters/next-drupal-starter/pages/api/preview.js
@@ -1,4 +1,4 @@
-import { globalDrupalStateAuthStores } from '../../lib/stores';
+import { globalDrupalStateStores } from '../../lib/stores';
 
 const preview = async (req, res) => {
 	// Check the secret and next parameters
@@ -9,7 +9,7 @@ const preview = async (req, res) => {
 
 	// returns the store that matches the locale found in the requested url
 	// or the only store if using a monolingual backend
-	const [store] = globalDrupalStateAuthStores.filter(({ defaultLocale }) => {
+	const [store] = globalDrupalStateStores.filter(({ defaultLocale }) => {
 		const regex = new RegExp(`/${defaultLocale}/`);
 		return defaultLocale ? regex.test(req.url) : true;
 	});

--- a/starters/next-drupal-starter/pages/articles/[...slug].jsx
+++ b/starters/next-drupal-starter/pages/articles/[...slug].jsx
@@ -3,7 +3,6 @@ import { isMultiLanguage } from '../../lib/isMultiLanguage';
 import { getPreview } from '../../lib/getPreview';
 import {
 	getCurrentLocaleStore,
-	globalDrupalStateAuthStores,
 	globalDrupalStateStores,
 } from '../../lib/stores';
 import { IMAGE_URL } from '../../lib/constants';
@@ -48,10 +47,7 @@ export async function getServerSideProps(context) {
 	const multiLanguage = isMultiLanguage(locales);
 	const lang = context.preview ? context.previewData.previewLang : locale;
 
-	const store = getCurrentLocaleStore(
-		lang,
-		context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores,
-	);
+	const store = getCurrentLocaleStore(lang, globalDrupalStateStores);
 
 	// handle nested slugs like /article/featured
 	const slug = `/articles${context.params.slug
@@ -70,6 +66,8 @@ export async function getServerSideProps(context) {
 		params: context.preview ? previewParams : params,
 		refresh: true,
 		res: context.res,
+		// anon: context.preview ? false : true,
+		anon: true,
 	});
 
 	const footerMenu = await store.getObject({
@@ -81,16 +79,15 @@ export async function getServerSideProps(context) {
 	const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
 	// Load all the paths for the current article.
 	const paths = locales.map(async (locale) => {
-		const localeStore = getCurrentLocaleStore(
-			locale,
-			context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores,
-		);
+		const localeStore = getCurrentLocaleStore(locale, globalDrupalStateStores);
 		const { path } = await localeStore.getObject({
 			objectName: 'node--article',
 			id: article.id,
 			params: context.preview ? previewParams : params,
 			refresh: true,
 			res: context.res,
+			// anon: context.preview ? false : true,
+			anon: true,
 		});
 		return path;
 	});

--- a/starters/next-drupal-starter/pages/articles/[...slug].jsx
+++ b/starters/next-drupal-starter/pages/articles/[...slug].jsx
@@ -66,14 +66,14 @@ export async function getServerSideProps(context) {
 		params: context.preview ? previewParams : params,
 		refresh: true,
 		res: context.res,
-		// anon: context.preview ? false : true,
-		anon: true,
+		anon: context.preview ? false : true,
 	});
 
 	const footerMenu = await store.getObject({
 		objectName: 'menu_items--main',
 		refresh: true,
 		res: context.res,
+		anon: true,
 	});
 
 	const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
@@ -86,8 +86,7 @@ export async function getServerSideProps(context) {
 			params: context.preview ? previewParams : params,
 			refresh: true,
 			res: context.res,
-			// anon: context.preview ? false : true,
-			anon: true,
+			anon: context.preview ? false : true,
 		});
 		return path;
 	});

--- a/starters/next-drupal-starter/pages/articles/index.jsx
+++ b/starters/next-drupal-starter/pages/articles/index.jsx
@@ -61,12 +61,14 @@ export async function getServerSideProps(context) {
 			res: context.res,
 			refresh: true,
 			params: 'include=field_media_image.field_media_image',
+			anon: true,
 		});
 
 		const footerMenu = await store.getObject({
 			objectName: 'menu_items--main',
 			res: context.res,
 			refresh: true,
+			anon: true,
 		});
 
 		if (!articles) {

--- a/starters/next-drupal-starter/pages/examples/auth-api.jsx
+++ b/starters/next-drupal-starter/pages/examples/auth-api.jsx
@@ -67,7 +67,7 @@ export async function getServerSideProps(context) {
 			refresh: !BUILD_MODE,
 			res: context.res,
 			params: 'fields[node--article]=length',
-			anon: true,
+			anon: false,
 		});
 		const footerMenu = await authStore.getObject({
 			objectName: 'menu_items--main',

--- a/starters/next-drupal-starter/pages/examples/auth-api.jsx
+++ b/starters/next-drupal-starter/pages/examples/auth-api.jsx
@@ -1,6 +1,6 @@
 import {
 	getCurrentLocaleStore,
-	globalDrupalStateAuthStores,
+	globalDrupalStateStores,
 } from '../../lib/stores';
 import { BUILD_MODE } from '../../lib/constants';
 
@@ -54,7 +54,7 @@ export default function AuthApiExampleTemplate({ articles, footerMenu }) {
 export async function getServerSideProps(context) {
 	const authStore = getCurrentLocaleStore(
 		context.locale,
-		globalDrupalStateAuthStores,
+		globalDrupalStateStores,
 	);
 
 	if (!authStore.auth) {
@@ -67,11 +67,13 @@ export async function getServerSideProps(context) {
 			refresh: !BUILD_MODE,
 			res: context.res,
 			params: 'fields[node--article]=length',
+			anon: true,
 		});
 		const footerMenu = await authStore.getObject({
 			objectName: 'menu_items--main',
 			refresh: !BUILD_MODE,
 			res: context.res,
+			anon: true,
 		});
 		return {
 			props: {

--- a/starters/next-drupal-starter/pages/examples/index.jsx
+++ b/starters/next-drupal-starter/pages/examples/index.jsx
@@ -61,6 +61,7 @@ export async function getStaticProps(context) {
 		const footerMenu = await store.getObject({
 			objectName: 'menu_items--main',
 			refresh: !BUILD_MODE,
+			anon: true,
 		});
 
 		return {

--- a/starters/next-drupal-starter/pages/examples/pagination/[[...page]].jsx
+++ b/starters/next-drupal-starter/pages/examples/pagination/[[...page]].jsx
@@ -72,6 +72,7 @@ export async function getStaticPaths() {
 		objectName: 'node--ds_example',
 		all: true,
 		params: 'fields[node--ds_example]=title,body,id',
+		anon: true,
 	});
 	const itemsPerPage = 10;
 	const totalPages = Math.ceil(data.length / itemsPerPage);
@@ -106,6 +107,7 @@ export async function getStaticProps(context) {
 		params: 'fields[node--ds_example]=title,body,id',
 		all: true,
 		refresh: !BUILD_MODE,
+		anon: true,
 	});
 
 	const store = getCurrentLocaleStore(context.locale, globalDrupalStateStores);

--- a/starters/next-drupal-starter/pages/examples/pagination/[[...page]].jsx
+++ b/starters/next-drupal-starter/pages/examples/pagination/[[...page]].jsx
@@ -111,6 +111,7 @@ export async function getStaticProps(context) {
 	const store = getCurrentLocaleStore(context.locale, globalDrupalStateStores);
 	const footerMenu = await store.getObject({
 		objectName: 'menu_items--main',
+		anon: true,
 	});
 	return {
 		props: {

--- a/starters/next-drupal-starter/pages/examples/ssg-isr.jsx
+++ b/starters/next-drupal-starter/pages/examples/ssg-isr.jsx
@@ -73,6 +73,7 @@ export async function getStaticProps(context) {
 			objectName: 'node--article',
 			params: 'include=field_media_image.field_media_image',
 			refresh: !BUILD_MODE,
+			anon: true,
 		});
 
 		if (!articles) {
@@ -84,6 +85,7 @@ export async function getStaticProps(context) {
 		const footerMenu = await store.getObject({
 			objectName: 'menu_items--main',
 			refresh: !BUILD_MODE,
+			anon: true,
 		});
 
 		return {

--- a/starters/next-drupal-starter/pages/index.jsx
+++ b/starters/next-drupal-starter/pages/index.jsx
@@ -87,6 +87,7 @@ export async function getServerSideProps(context) {
 			params: 'include=field_media_image.field_media_image',
 			refresh: true,
 			res: context.res,
+			anon: true,
 		});
 
 		if (!articles) {
@@ -105,6 +106,7 @@ export async function getServerSideProps(context) {
 			objectName: 'menu_items--main',
 			refresh: true,
 			res: context.res,
+			anon: true,
 		});
 
 		return {

--- a/starters/next-drupal-starter/pages/pages/[...alias].jsx
+++ b/starters/next-drupal-starter/pages/pages/[...alias].jsx
@@ -55,8 +55,7 @@ export async function getServerSideProps(context) {
 			params: context.preview && previewParams,
 			refresh: true,
 			res: context.res,
-			// anon: context.preview ? false : true,
-			anon: true,
+			anon: context.preview ? false : true,
 		});
 	} catch (error) {
 		// retry the fetch with `/pages` prefix
@@ -67,8 +66,7 @@ export async function getServerSideProps(context) {
 			params: context.preview && previewParams,
 			refresh: true,
 			res: context.res,
-			// anon: context.preview ? false : true,
-			anon: true,
+			anon: context.preview ? false : true,
 		});
 	}
 
@@ -92,8 +90,7 @@ export async function getServerSideProps(context) {
 			params: context.preview && previewParams,
 			refresh: true,
 			res: context.res,
-			// anon: context.preview ? false : true,
-			anon: true,
+			anon: context.preview ? false : true,
 		});
 		return path;
 	});

--- a/starters/next-drupal-starter/pages/pages/[...alias].jsx
+++ b/starters/next-drupal-starter/pages/pages/[...alias].jsx
@@ -3,7 +3,6 @@ import { isMultiLanguage } from '../../lib/isMultiLanguage';
 import { getPreview } from '../../lib/getPreview';
 import {
 	getCurrentLocaleStore,
-	globalDrupalStateAuthStores,
 	globalDrupalStateStores,
 } from '../../lib/stores';
 
@@ -37,10 +36,7 @@ export async function getServerSideProps(context) {
 	const { locales, locale } = context;
 	const multiLanguage = isMultiLanguage(context.locales);
 	const lang = context.preview ? context.previewData.previewLang : locale;
-	const store = getCurrentLocaleStore(
-		lang,
-		context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores,
-	);
+	const store = getCurrentLocaleStore(lang, globalDrupalStateStores);
 
 	// handle nested alias like /pages/featured
 	const alias = `${context.params.alias
@@ -59,6 +55,8 @@ export async function getServerSideProps(context) {
 			params: context.preview && previewParams,
 			refresh: true,
 			res: context.res,
+			// anon: context.preview ? false : true,
+			anon: true,
 		});
 	} catch (error) {
 		// retry the fetch with `/pages` prefix
@@ -69,6 +67,8 @@ export async function getServerSideProps(context) {
 			params: context.preview && previewParams,
 			refresh: true,
 			res: context.res,
+			// anon: context.preview ? false : true,
+			anon: true,
 		});
 	}
 
@@ -76,6 +76,7 @@ export async function getServerSideProps(context) {
 		objectName: 'menu_items--main',
 		refresh: true,
 		res: context.res,
+		anon: true,
 	});
 
 	const origin = process.env.NEXT_PUBLIC_FRONTEND_URL;
@@ -83,7 +84,7 @@ export async function getServerSideProps(context) {
 	const paths = locales.map(async (locale) => {
 		const storeByLocales = getCurrentLocaleStore(
 			locale,
-			context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores,
+			globalDrupalStateStores,
 		);
 		const { path } = await storeByLocales.getObject({
 			objectName: 'node--page',
@@ -91,6 +92,8 @@ export async function getServerSideProps(context) {
 			params: context.preview && previewParams,
 			refresh: true,
 			res: context.res,
+			// anon: context.preview ? false : true,
+			anon: true,
 		});
 		return path;
 	});

--- a/starters/next-drupal-starter/pages/pages/index.jsx
+++ b/starters/next-drupal-starter/pages/pages/index.jsx
@@ -73,12 +73,14 @@ export async function getServerSideProps(context) {
 			refresh: true,
 			res: context.res,
 			params: 'fields[node--page]=id,title,body,path',
+			anon: true,
 		});
 
 		const footerMenu = await store.getObject({
 			objectName: 'menu_items--main',
 			refresh: true,
 			res: context.res,
+			anon: true,
 		});
 
 		if (!pages) {

--- a/starters/next-drupal-starter/pages/recipes/[...slug].jsx
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].jsx
@@ -3,7 +3,6 @@ import { isMultiLanguage } from '../../lib/isMultiLanguage';
 import { getPreview } from '../../lib/getPreview';
 import {
 	getCurrentLocaleStore,
-	globalDrupalStateAuthStores,
 	globalDrupalStateStores,
 } from '../../lib/stores';
 import { IMAGE_URL } from '../../lib/constants';
@@ -57,10 +56,7 @@ export async function getServerSideProps(context) {
 	const { locales, locale } = context;
 	const multiLanguage = isMultiLanguage(locales);
 	const lang = context.preview ? context.previewData.previewLang : locale;
-	const store = getCurrentLocaleStore(
-		lang,
-		context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores,
-	);
+	const store = getCurrentLocaleStore(lang, globalDrupalStateStores);
 
 	// handle nested slugs like /recipes/featured
 	const slug = `/recipes${context.params.slug
@@ -79,12 +75,15 @@ export async function getServerSideProps(context) {
 			refresh: true,
 			res: context.res,
 			params: context.preview ? previewParams : params,
+			// anon: context.preview ? false : true,
+			anon: true,
 		});
 
 		const footerMenu = await store.getObject({
 			objectName: 'menu_items--main',
 			refresh: true,
 			res: context.res,
+			anon: true,
 		});
 
 		if (!recipe) {
@@ -96,7 +95,7 @@ export async function getServerSideProps(context) {
 		const paths = locales.map(async (locale) => {
 			const storeByLocales = getCurrentLocaleStore(
 				locale,
-				context.preview ? globalDrupalStateAuthStores : globalDrupalStateStores,
+				globalDrupalStateStores,
 			);
 			const { path } = await storeByLocales.getObject({
 				objectName: 'node--recipe',
@@ -104,6 +103,8 @@ export async function getServerSideProps(context) {
 				params: context.preview ? previewParams : params,
 				refresh: true,
 				res: context.res,
+				// anon: context.preview ? false : true,
+				anon: true,
 			});
 			return path;
 		});

--- a/starters/next-drupal-starter/pages/recipes/[...slug].jsx
+++ b/starters/next-drupal-starter/pages/recipes/[...slug].jsx
@@ -75,8 +75,7 @@ export async function getServerSideProps(context) {
 			refresh: true,
 			res: context.res,
 			params: context.preview ? previewParams : params,
-			// anon: context.preview ? false : true,
-			anon: true,
+			anon: context.preview ? false : true,
 		});
 
 		const footerMenu = await store.getObject({
@@ -103,8 +102,7 @@ export async function getServerSideProps(context) {
 				params: context.preview ? previewParams : params,
 				refresh: true,
 				res: context.res,
-				// anon: context.preview ? false : true,
-				anon: true,
+				anon: context.preview ? false : true,
 			});
 			return path;
 		});

--- a/starters/next-drupal-starter/pages/recipes/index.jsx
+++ b/starters/next-drupal-starter/pages/recipes/index.jsx
@@ -64,12 +64,14 @@ export async function getServerSideProps(context) {
 				'include=field_media_image.field_media_image,field_recipe_category',
 			refresh: true,
 			res: context.res,
+			anon: true,
 		});
 
 		const footerMenu = await store.getObject({
 			objectName: 'menu_items--main',
 			refresh: true,
 			res: context.res,
+			anon: true,
 		});
 
 		if (!recipes) {

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/implementing-preview.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/implementing-preview.md
@@ -43,7 +43,7 @@ import { getPreview } from '../../lib/get-preview';
 import { isMultiLanguage } from '../../lib/isMultiLanguage';
 import {
 	getCurrentLocaleStore,
-	globalDrupalStateAuthStores,
+	globalDrupalStateStores,
 } from '../../lib/stores';
 
 // your React component here
@@ -57,7 +57,7 @@ export async function getStaticProps(context) {
 		? context.previewData.previewLang
 		: context.locale;
 	// set the store based on the language
-	const store = getCurrentLocaleStore(lang, globalDrupalStateAuthStores);
+	const store = getCurrentLocaleStore(lang, globalDrupalStateStores);
 	// gets preview data from the Drupal instance, or in the case of a revision,
 	// sets the proper jsonapi param to fetch the revision from Drupal.
 	context.preview && getPreview(context, 'node--article');


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
In the `next-drupal-starter`, instances of DrupalState no longer require separate instances for auth’d and non-auth’d stores.

## Where were the changes made?
`next-drupal-starter`
`drupal-kit`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Starter was ran locally and observed to be functioning properly using a single store for auth'd and anonymous responses.  

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
