### PR TITLE
[gatsby-wordpress] Fix URL for graphql client if WPGRAPHQL_URL is not set

### DIFF
--- a/.changeset/breezy-mangos-smell.md
+++ b/.changeset/breezy-mangos-smell.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/gatsby-wordpress-starter': patch
+---
+
+Fallback to PANTHEON_CMS_ENDPOINT if WPGRAPHQL_URL is not set when creating the
+graphql client to fetch private posts

--- a/starters/gatsby-wordpress-starter/gatsby-config.js
+++ b/starters/gatsby-wordpress-starter/gatsby-config.js
@@ -21,11 +21,16 @@ if (process.env.PANTHEON_UPLOAD_PATH) {
 	injectedOptions['pathPrefix'] = process.env.PANTHEON_UPLOAD_PATH
 }
 
+// Need the ternary here because the config will run multiple times per plugin
+process.env.PANTHEON_CMS_ENDPOINT =
+	process.env.PANTHEON_CMS_ENDPOINT &&
+	process.env.PANTHEON_CMS_ENDPOINT.startsWith('https://')
+		? process.env.PANTHEON_CMS_ENDPOINT
+		: `https://${process.env.PANTHEON_CMS_ENDPOINT}/wp/graphql`
+
 // Use URL from .env if it exists, otherwise fall back on the
 // Pantheon CMS endpoint
-const url =
-	process.env.WPGRAPHQL_URL ||
-	`https://${process.env.PANTHEON_CMS_ENDPOINT}/wp/graphql`
+const url = process.env.WPGRAPHQL_URL || process.env.PANTHEON_CMS_ENDPOINT
 
 module.exports = {
 	...(injectedOptions && injectedOptions),

--- a/starters/gatsby-wordpress-starter/lib/privatePosts.js
+++ b/starters/gatsby-wordpress-starter/lib/privatePosts.js
@@ -1,6 +1,9 @@
 const { gql, GraphqlClientFactory } = require('@pantheon-systems/wordpress-kit')
 
-const client = new GraphqlClientFactory(process.env.WPGRAPHQL_URL).create()
+const wpGraphqlEndpoint =
+	process.env.WPGRAPHQL_URL || process.env.PANTHEON_CMS_ENDPOINT
+
+const client = new GraphqlClientFactory(wpGraphqlEndpoint).create()
 
 async function privatePostsQuery() {
 	const credentials = `${process.env.WP_APPLICATION_USERNAME}:${process.env.WP_APPLICATION_PASSWORD}`


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- In the gatsby-config.js, ensure the PANTHEON_CMS_ENDPOINT env var has the proper protocol so that it is not set multiple times, as the config file is rerun during build
- in privatePosts, pass in a valid endpoint

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
gatsby-wp-starter

## How have the changes been tested?
tested locally with either WPGRAPHQL_URL or PANTHEON_CMS_ENDPOINT env vars set.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
