### PR TITLE
fix: remove workspace from cms-kit version

### DIFF
--- a/packages/drupal-kit/package.json
+++ b/packages/drupal-kit/package.json
@@ -51,6 +51,6 @@
 	},
 	"dependencies": {
 		"@gdwc/drupal-state": "^4.2.0",
-		"@pantheon-systems/cms-kit": "workspace:^0.1.0-canary.0"
+		"@pantheon-systems/cms-kit": "^0.1.0-canary.0"
 	}
 }

--- a/packages/wordpress-kit/package.json
+++ b/packages/wordpress-kit/package.json
@@ -39,7 +39,7 @@
 		"lint-staged": "lint-staged"
 	},
 	"dependencies": {
-		"@pantheon-systems/cms-kit": "workspace:*",
+		"@pantheon-systems/cms-kit": "^0.1.0-canary.0",
 		"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
 		"graphql-request": "^5.0.0"
 	},


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Remove workspace from cms-kit version in drupal-kit and wordpress-kit
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
