### PR TITLE
DB-4829: Images Can Scale Past Native Width and Height

### DIFF
--- a/.changeset/big-zebras-speak.md
+++ b/.changeset/big-zebras-speak.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/wordpress-kit': minor
+---
+
+Use max-width to images

--- a/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Image.ts
+++ b/packages/wordpress-kit/src/lib/tailwindcssPlugin/components/Image.ts
@@ -9,7 +9,7 @@ export const ImageComponent = () => ({
 			wordBreak: 'break-word',
 		},
 		img: {
-			width: '100%',
+			'max-width': '100%',
 			borderRadius: 'inherit',
 		},
 		'&.alignleft': {


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Instead of setting a width: 100%, use max-width to follow WP spirit

## Where were the changes made?
- WordPress-Kit

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
