### PR TITLE
Undo config workspace override

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"author": "@pantheon-systems",
 	"main": "index.js",
-	"prettier": "@pantheon-systems/configs/prettier.config.js",
+	"prettier": "./configs/prettier.config.js",
 	"scripts": {
 		"build:all": "pnpm build:pkgs && pnpm build:starters",
 		"build:cms-kit": "pnpm --filter cms-kit build",
@@ -51,7 +51,6 @@
 	],
 	"devDependencies": {
 		"@changesets/cli": "^2.24.4",
-		"@pantheon-systems/configs": "workspace:*",
 		"@types/eslint": "^8.4.6",
 		"@types/jest": "^29.0.3",
 		"@types/node": "^16.11.62",
@@ -80,7 +79,6 @@
 			"@pantheon-systems/drupal-kit": "workspace:*",
 			"@pantheon-systems/nextjs-kit": "workspace:*",
 			"@pantheon-systems/cms-kit": "workspace:*",
-			"@pantheon-systems/configs": "workspace:*",
 			"@types/react": "17.0.40",
 			"node-fetch@<2.6.7": ">=2.6.7",
 			"ansi-regex@>2.1.1 <5.0.1": ">=5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ overrides:
   '@pantheon-systems/drupal-kit': workspace:*
   '@pantheon-systems/nextjs-kit': workspace:*
   '@pantheon-systems/cms-kit': workspace:*
-  '@pantheon-systems/configs': workspace:*
   '@types/react': 17.0.40
   node-fetch@<2.6.7: '>=2.6.7'
   ansi-regex@>2.1.1 <5.0.1: '>=5.0.1'
@@ -34,7 +33,6 @@ importers:
   .:
     specifiers:
       '@changesets/cli': ^2.24.4
-      '@pantheon-systems/configs': workspace:*
       '@types/eslint': ^8.4.6
       '@types/jest': ^29.0.3
       '@types/node': ^16.11.62
@@ -57,7 +55,6 @@ importers:
       vite: ^3.1.4
     devDependencies:
       '@changesets/cli': 2.24.4
-      '@pantheon-systems/configs': link:configs
       '@types/eslint': 8.4.6
       '@types/jest': 29.1.0
       '@types/node': 16.11.62
@@ -87,7 +84,7 @@ importers:
 
   configs/eslint:
     specifiers:
-      '@pantheon-systems/configs': workspace:*
+      '@pantheon-systems/configs': '*'
       '@typescript-eslint/eslint-plugin': ^5.13.0
       '@typescript-eslint/parser': ^5.38.1
       eslint: '>=8'
@@ -110,7 +107,7 @@ importers:
 
   packages/cms-kit:
     specifiers:
-      '@pantheon-systems/configs': workspace:*
+      '@pantheon-systems/configs': '*'
       '@pantheon-systems/eslint-config': '*'
       '@rollup/plugin-typescript': ^9.0.2
       c8: ^7.12.0
@@ -128,7 +125,7 @@ importers:
     specifiers:
       '@gdwc/drupal-state': ^4.2.0
       '@pantheon-systems/cms-kit': workspace:*
-      '@pantheon-systems/configs': workspace:*
+      '@pantheon-systems/configs': '*'
       '@pantheon-systems/eslint-config': '*'
       '@types/isomorphic-fetch': ^0.0.36
       isomorphic-fetch: ^3.0.0
@@ -153,7 +150,7 @@ importers:
 
   packages/nextjs-kit:
     specifiers:
-      '@pantheon-systems/configs': workspace:*
+      '@pantheon-systems/configs': '*'
       '@pantheon-systems/eslint-config': '*'
       '@testing-library/react': 12.1.5
       '@vitejs/plugin-react': ^2.1.0
@@ -186,7 +183,7 @@ importers:
   packages/wordpress-kit:
     specifiers:
       '@pantheon-systems/cms-kit': workspace:*
-      '@pantheon-systems/configs': workspace:*
+      '@pantheon-systems/configs': '*'
       '@pantheon-systems/eslint-config': '*'
       '@rollup/plugin-typescript': ^9.0.2
       c8: ^7.12.0


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Undo configs override made in DB-3832 as it seems to have broken CI. Seems to be similar to [an issue reported in pnpm](https://github.com/pnpm/pnpm/issues/3664). but not quite. Maybe there is some insight there as to how to get our release process smoothed out when we get to it.

## Where were the changes made?
root package.json and lockfile
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
