### PR TITLE
Fix gatsby dev mode, use pnpm cache in github action

### DIFF
--- a/.changeset/slow-apples-hunt.md
+++ b/.changeset/slow-apples-hunt.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/gatsby-wordpress-starter': patch
+---
+
+Add eslint@^7.5.0 as a dev dependency to satisfy a monorepo error

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
+          cache: 'pnpm'
       - name: install pnpm
         run: npm i pnpm@7.17.1 -g
       - name: Setup npmrc

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
+          cache: 'pnpm'
       - name: install pnpm
         run: npm i pnpm@7.17.1 -g
       - name: Setup npmrc

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"author": "@pantheon-systems",
 	"main": "index.js",
-	"prettier": "@pantheon-systems/configs/prettier.config.js",
+	"prettier": "@pantheon-systems/configs/prettier",
 	"scripts": {
 		"build:all": "pnpm build:pkgs && pnpm build:starters",
 		"build:cms-kit": "pnpm --filter cms-kit build",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 			"@pantheon-systems/nextjs-kit": "workspace:*",
 			"@pantheon-systems/cms-kit": "workspace:*",
 			"@pantheon-systems/configs": "workspace:*",
+			"@pantheon-systems/eslint-config": "workspace:*",
 			"@types/react": "17.0.40",
 			"node-fetch@<2.6.7": ">=2.6.7",
 			"ansi-regex@>2.1.1 <5.0.1": ">=5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ overrides:
   '@pantheon-systems/nextjs-kit': workspace:*
   '@pantheon-systems/cms-kit': workspace:*
   '@pantheon-systems/configs': workspace:*
+  '@pantheon-systems/eslint-config': workspace:*
   '@types/react': 17.0.40
   node-fetch@<2.6.7: '>=2.6.7'
   ansi-regex@>2.1.1 <5.0.1: '>=5.0.1'
@@ -111,7 +112,7 @@ importers:
   packages/cms-kit:
     specifiers:
       '@pantheon-systems/configs': workspace:*
-      '@pantheon-systems/eslint-config': '*'
+      '@pantheon-systems/eslint-config': workspace:*
       '@rollup/plugin-typescript': ^9.0.2
       c8: ^7.12.0
       eslint-plugin-prettier: ^4.2.1
@@ -129,7 +130,7 @@ importers:
       '@gdwc/drupal-state': ^4.2.0
       '@pantheon-systems/cms-kit': workspace:*
       '@pantheon-systems/configs': workspace:*
-      '@pantheon-systems/eslint-config': '*'
+      '@pantheon-systems/eslint-config': workspace:*
       '@types/isomorphic-fetch': ^0.0.36
       isomorphic-fetch: ^3.0.0
       jsona: ^1.9.7
@@ -154,7 +155,7 @@ importers:
   packages/nextjs-kit:
     specifiers:
       '@pantheon-systems/configs': workspace:*
-      '@pantheon-systems/eslint-config': '*'
+      '@pantheon-systems/eslint-config': workspace:*
       '@testing-library/react': 12.1.5
       '@vitejs/plugin-react': ^2.1.0
       autoprefixer: ^10.4.12
@@ -187,7 +188,7 @@ importers:
     specifiers:
       '@pantheon-systems/cms-kit': workspace:*
       '@pantheon-systems/configs': workspace:*
-      '@pantheon-systems/eslint-config': '*'
+      '@pantheon-systems/eslint-config': workspace:*
       '@rollup/plugin-typescript': ^9.0.2
       c8: ^7.12.0
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -218,6 +219,7 @@ importers:
       '@vitest/coverage-c8': ^0.24.1
       autoprefixer: ^10.4.12
       dumper.js: ^1.3.1
+      eslint: ^7.5.0
       gatsby: ^4.24.0
       gatsby-plugin-image: ^2.24.0
       gatsby-plugin-manifest: ^4.24.0
@@ -267,6 +269,7 @@ importers:
       '@vitest/coverage-c8': 0.24.1
       autoprefixer: 10.4.12_postcss@8.4.16
       dumper.js: 1.3.1
+      eslint: 7.32.0
       postcss: 8.4.16
       prettier: 2.7.1
       tailwindcss: 3.1.8_postcss@8.4.16
@@ -555,7 +558,6 @@ packages:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
       '@babel/highlight': 7.18.6
-    dev: false
 
   /@babel/code-frame/7.18.6:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
@@ -3392,7 +3394,6 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@eslint/eslintrc/1.3.2:
     resolution: {integrity: sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==}
@@ -3745,7 +3746,6 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@humanwhocodes/gitignore-to-minimatch/1.0.2:
     resolution: {integrity: sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==}
@@ -5917,7 +5917,7 @@ packages:
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
     dev: false
 
-  /@typescript-eslint/eslint-plugin/4.33.0_sz4i7qznf44sliit4yqchbvfk4:
+  /@typescript-eslint/eslint-plugin/4.33.0_ffi3uiz42rv3jyhs6cr7p7qqry:
     resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5930,10 +5930,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0
-      '@typescript-eslint/parser': 4.33.0
+      '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0
+      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
       '@typescript-eslint/scope-manager': 4.33.0
       debug: 4.3.4
+      eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
@@ -5998,7 +5999,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/experimental-utils/4.33.0:
+  /@typescript-eslint/experimental-utils/4.33.0_eslint@7.32.0:
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6011,14 +6012,15 @@ packages:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0
+      eslint: 7.32.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0
+      eslint-utils: 3.0.0_eslint@7.32.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/parser/4.33.0:
+  /@typescript-eslint/parser/4.33.0_eslint@7.32.0:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -6034,6 +6036,7 @@ packages:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0
       debug: 4.3.4
+      eslint: 7.32.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6454,7 +6457,6 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 7.4.1
-    dev: false
 
   /acorn-jsx/5.3.2_acorn@8.8.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -6569,7 +6571,6 @@ packages:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
-    dev: false
 
   /algoliasearch-helper/3.10.0_algoliasearch@4.14.2:
     resolution: {integrity: sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==}
@@ -10212,15 +10213,15 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0_sz4i7qznf44sliit4yqchbvfk4
-      '@typescript-eslint/parser': 4.33.0
+      '@typescript-eslint/eslint-plugin': 4.33.0_ffi3uiz42rv3jyhs6cr7p7qqry
+      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
-      eslint-plugin-flowtype: 5.10.0
-      eslint-plugin-import: 2.26.0_sz4i7qznf44sliit4yqchbvfk4
-      eslint-plugin-jsx-a11y: 6.6.1
-      eslint-plugin-react: 7.31.7
-      eslint-plugin-react-hooks: 4.6.0
+      eslint-plugin-flowtype: 5.10.0_eslint@7.32.0
+      eslint-plugin-import: 2.26.0_ffi3uiz42rv3jyhs6cr7p7qqry
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@7.32.0
+      eslint-plugin-react: 7.31.7_eslint@7.32.0
+      eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
     dev: false
 
   /eslint-import-resolver-node/0.3.6:
@@ -10270,7 +10271,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0
+      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
@@ -10303,7 +10304,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-flowtype/5.10.0:
+  /eslint-plugin-flowtype/5.10.0_eslint@7.32.0:
     resolution: {integrity: sha512-vcz32f+7TP+kvTUyMXZmCnNujBQZDNmcqPImw8b9PZ+16w1Qdm6ryRuYZYVaG9xRqqmAPr2Cs9FAX5gN+x/bjw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -10312,6 +10313,7 @@ packages:
       eslint:
         optional: true
     dependencies:
+      eslint: 7.32.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
     dev: false
@@ -10348,7 +10350,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import/2.26.0_sz4i7qznf44sliit4yqchbvfk4:
+  /eslint-plugin-import/2.26.0_ffi3uiz42rv3jyhs6cr7p7qqry:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10360,11 +10362,12 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0
+      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
+      eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
       eslint-module-utils: 2.7.3_lkzaig2qiyp6elizstfbgvzhie
       has: 1.0.3
@@ -10380,7 +10383,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-jsx-a11y/6.6.1:
+  /eslint-plugin-jsx-a11y/6.6.1_eslint@7.32.0:
     resolution: {integrity: sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -10397,6 +10400,7 @@ packages:
       axobject-query: 2.2.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
+      eslint: 7.32.0
       has: 1.0.3
       jsx-ast-utils: 3.3.3
       language-tags: 1.0.5
@@ -10464,7 +10468,7 @@ packages:
       prettier-linter-helpers: 1.0.0
     dev: true
 
-  /eslint-plugin-react-hooks/4.6.0:
+  /eslint-plugin-react-hooks/4.6.0_eslint@7.32.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -10472,6 +10476,8 @@ packages:
     peerDependenciesMeta:
       eslint:
         optional: true
+    dependencies:
+      eslint: 7.32.0
     dev: false
 
   /eslint-plugin-react-hooks/4.6.0_eslint@8.24.0:
@@ -10485,7 +10491,7 @@ packages:
     dependencies:
       eslint: 8.24.0
 
-  /eslint-plugin-react/7.31.7:
+  /eslint-plugin-react/7.31.7_eslint@7.32.0:
     resolution: {integrity: sha512-8NldBTeYp/kQoTV1uT0XF6HcmDqbgZ0lNPkN0wlRw8DJKXEnaWu+oh/6gt3xIhzvQ35wB2Y545fJhIbJSZ2NNw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10497,6 +10503,7 @@ packages:
       array-includes: 3.1.5
       array.prototype.flatmap: 1.3.0
       doctrine: 2.1.0
+      eslint: 7.32.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
@@ -10554,9 +10561,8 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       eslint-visitor-keys: 1.3.0
-    dev: false
 
-  /eslint-utils/3.0.0:
+  /eslint-utils/3.0.0_eslint@7.32.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
@@ -10565,6 +10571,7 @@ packages:
       eslint:
         optional: true
     dependencies:
+      eslint: 7.32.0
       eslint-visitor-keys: 2.1.0
     dev: false
 
@@ -10583,7 +10590,6 @@ packages:
   /eslint-visitor-keys/1.3.0:
     resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
     engines: {node: '>=4'}
-    dev: false
 
   /eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
@@ -10660,7 +10666,6 @@ packages:
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /eslint/8.24.0:
     resolution: {integrity: sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==}
@@ -10716,7 +10721,6 @@ packages:
       acorn: 7.4.1
       acorn-jsx: 5.3.2_acorn@7.4.1
       eslint-visitor-keys: 1.3.0
-    dev: false
 
   /espree/9.4.0:
     resolution: {integrity: sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==}
@@ -11463,7 +11467,6 @@ packages:
 
   /functional-red-black-tree/1.0.1:
     resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
-    dev: false
 
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -12002,8 +12005,8 @@ packages:
       '@parcel/core': 2.6.2
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.7_jw65f7ntaswmo2djm5m3s4rnbq
       '@types/http-proxy': 1.17.9
-      '@typescript-eslint/eslint-plugin': 4.33.0_sz4i7qznf44sliit4yqchbvfk4
-      '@typescript-eslint/parser': 4.33.0
+      '@typescript-eslint/eslint-plugin': 4.33.0_ffi3uiz42rv3jyhs6cr7p7qqry
+      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0
       '@vercel/webpack-asset-relocator-loader': 1.7.3
       acorn-loose: 8.3.0
       acorn-walk: 8.2.0
@@ -12041,11 +12044,11 @@ packages:
       error-stack-parser: 2.1.4
       eslint: 7.32.0
       eslint-config-react-app: 6.0.0_kflhqiw2gi6h2iu5wlkegoxuda
-      eslint-plugin-flowtype: 5.10.0
-      eslint-plugin-import: 2.26.0_sz4i7qznf44sliit4yqchbvfk4
-      eslint-plugin-jsx-a11y: 6.6.1
-      eslint-plugin-react: 7.31.7
-      eslint-plugin-react-hooks: 4.6.0
+      eslint-plugin-flowtype: 5.10.0_eslint@7.32.0
+      eslint-plugin-import: 2.26.0_ffi3uiz42rv3jyhs6cr7p7qqry
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@7.32.0
+      eslint-plugin-react: 7.31.7_eslint@7.32.0
+      eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
       eslint-webpack-plugin: 2.7.0_2gji4j2x5okmdz3i2csw4u63de
       event-source-polyfill: 1.0.25
       execa: 5.1.1
@@ -12854,7 +12857,6 @@ packages:
   /ignore/4.0.6:
     resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
     engines: {node: '>= 4'}
-    dev: false
 
   /ignore/5.2.0:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
@@ -14519,7 +14521,6 @@ packages:
 
   /json-schema-traverse/1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-    dev: false
 
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -14888,7 +14889,6 @@ packages:
 
   /lodash.truncate/4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
-    dev: false
 
   /lodash.uniq/4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -17014,7 +17014,6 @@ packages:
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
-    dev: false
 
   /promise/7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
@@ -17780,7 +17779,6 @@ packages:
   /require-from-string/2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /require-like/0.1.2:
     resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
@@ -18943,7 +18941,6 @@ packages:
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: false
 
   /tailwindcss/3.1.8_postcss@8.4.16:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
@@ -19887,7 +19884,6 @@ packages:
 
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
-    dev: false
 
   /v8-to-istanbul/8.1.1:
     resolution: {integrity: sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==}

--- a/starters/gatsby-wordpress-starter/package.json
+++ b/starters/gatsby-wordpress-starter/package.json
@@ -53,6 +53,7 @@
 		"@vitest/coverage-c8": "^0.24.1",
 		"autoprefixer": "^10.4.12",
 		"dumper.js": "^1.3.1",
+		"eslint": "^7.5.0",
 		"postcss": "^8.4.16",
 		"prettier": "^2.7.1",
 		"tailwindcss": "^3.1.8",


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->
Hopefully this will fix or give more insight into why the action is failing. A bug was found with gatsby dev mode with `pnpm@7.17.1` and this should alleviate that.

## What changes were made?
- add eslint@^7.5.0 to gatsby-wp-starter
- include the eslint-config workspace in the root package.json
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information
This should close #427 but I'm still a bit lost on why the Action is failing.
<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
