### PR TITLE
DB-4830: Set Pantheon Environment Env Variables 

### DIFF
--- a/starters/next-wordpress-starter/next.config.js
+++ b/starters/next-wordpress-starter/next.config.js
@@ -38,6 +38,20 @@ if (process.env.WPGRAPHQL_URL === undefined) {
 // remove trailing slash if it exists
 imageDomain = imageDomain.replace(/\/$/, '');
 
+let PANTHEON_ENVIRONMENT_PREFIX, IS_LIVE_ENVIRONMENT;
+if (process.env.PANTHEON_ENVIRONMENT_URL) {
+	const envPrefix = process.env.PANTHEON_ENVIRONMENT_URL.match(/^([^-]*)/)[0];
+	PANTHEON_ENVIRONMENT_PREFIX =
+		process.env.PANTHEON_ENVIRONMENT_URL.match(/^([^-]*-)[^-]*/)[0];
+	if (envPrefix !== 'live') {
+		PANTHEON_ENVIRONMENT_PREFIX =
+			process.env.PANTHEON_ENVIRONMENT_URL.match(/^([^-]*-)[^-]*/)[0];
+	} else {
+		PANTHEON_ENVIRONMENT_PREFIX = 'live';
+		IS_LIVE_ENVIRONMENT = 'live';
+	}
+}
+
 const injectedOptions = {};
 if (process.env.PANTHEON_UPLOAD_PATH) {
 	injectedOptions['basePath'] = process.env.PANTHEON_UPLOAD_PATH;

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-environment-variables.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-environment-variables.md
@@ -67,8 +67,8 @@ must be used inside of `next.config.js`.
   beginning prefix (live, pr-number (pr-12), branch-name (multi-integration)) of
   `PANTHEON_ENVIRONMENT_URL`. This is to act as a variable to key off of and
   source data from a specific BE environment
-- `IS_LIVE` - Automatically set to true if `PANTHEON_ENVIRONMENT_URL` is live
-  and false otherwise
+- `IS_LIVE_ENVIRONMENT` - Automatically set to true if
+  `PANTHEON_ENVIRONMENT_URL` is live and false otherwise
 
 Either the `PANTHEON_CMS_ENDPOINT` or `WPGRAPHQL_URL` will need to be set.
 

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-environment-variables.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-environment-variables.md
@@ -67,6 +67,8 @@ must be used inside of `next.config.js`.
   beginning prefix (live, pr-number (pr-12), branch-name (multi-integration)) of
   `PANTHEON_ENVIRONMENT_URL`. This is to act as a variable to key off of and
   source data from a specific BE environment
+- `IS_LIVE` - Automatically set to true if `PANTHEON_ENVIRONMENT_URL` is live
+  and false otherwise
 
 Either the `PANTHEON_CMS_ENDPOINT` or `WPGRAPHQL_URL` will need to be set.
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- A PANTHEON_ENVIRONMENT envar is set which is the value of the prefix before -[site-name].appa.pantheon.site in PANTHEON_ENVIRONMENT_URL
- A  IS_LIVE_ENVIRONMENT variable is set to true if PANTHEON_ENVIRONMENT is live and false otherwise
- New environment variables are added to the developer docs
- An example of how to key off of these new variables to source data from a specific BE environment is added to the developer docs

## Where were the changes made?
`next-wordpress-starter`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Successfully connected to a Multidev without additional configuration 

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
