### PR TITLE
DB-4953: [docs] Add implementing-preview to next+wp docs

### DIFF
--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/implementing-preview.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/implementing-preview.md
@@ -20,6 +20,8 @@ your WordPress instance. To do so, follow these instructions:
    This is necessary in order for this user to be able to access revisions and
    private posts.
 
+   :::
+
 1. Hover over the username and click **Edit** to bring up the user's profile
    page.
 1. Scroll down to the Application Passwords section and name your application

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/implementing-preview.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/implementing-preview.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ## Before You Begin
 
-Make sure a `PREVIEW_SECRET` and proper credentials are properly configured on
+Make sure a `PREVIEW_SECRET` and valid credentials are properly configured on
 your WordPress instance. To do so, follow these instructions:
 
 1. Log in to your WordPress instance.

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/implementing-preview.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/implementing-preview.md
@@ -1,0 +1,119 @@
+---
+id: 'next-wordpress-preview'
+title: 'Implementing Decoupled Preview'
+slug: '/frontend-starters/nextjs/nextjs-wordpress/implementing-preview'
+sidebar_position: 2
+---
+
+## Before You Begin
+
+Make sure a `PREVIEW_SECRET` and proper credentials are properly configured on
+your WordPress instance. To do so, follow these instructions:
+
+1. Log in to your WordPress instance.
+1. Navigate to **Users**
+1. Create a new user or use an existing one. This username is, your
+   `WP_APPLICATION_USERNAME`
+1. Hover over the username and click **Edit** to bring up the user's profile
+   page.
+1. Scroll down to the Application Passwords section and name your application
+   password.
+1. Your new `WP_APPLICATION_PASSWORD` will be shown on screen. Copy this value
+   somewhere safe.
+1. We now have a client that can use our preview site. To configure the preview
+   site, navigate to **Settings** > **Preview Sites** and click the **ADD
+   PREVIEW SITE** button. Note: You will need the Pantheon Decoupled WordPress
+   Preview Plugin installed and activated on your instance.
+1. Set the URL to point to http(s)://{YOUR_SITE_URL}/api/preview replacing
+   `{YOUR_SITE_URL}` with the URL of your frontend site, or `localhost:3000` for
+   testing preview locally.
+1. Set a secret for the Preview Site and note this value down as your
+   `PREVIEW_SECRET`.
+
+Now you have all of the credentials needed to make authenticated requests to the
+WordPress instance, including the ability to preview content!
+
+See [Setting Environment Variables](./setting-environment-variables.md) for more
+information on how to set these variables in your local development environment
+or on the Pantheon Dashboard.
+
+## Fetching Preview Content
+
+Now that we are set up, the `wordpress-kit` GraphQL Client can make
+authenticated requests. Below is a snippet that exports a function that gets
+private posts.
+
+```js
+const client = new GraphqlClientFactory(process.env.backendUrl).create();
+
+// Encodes the WordPress credentials in a useable format for the auth header
+const getAuthCredentials = () => {
+	const credentials = `${process.env.WP_APPLICATION_USERNAME}:${process.env.WP_APPLICATION_PASSWORD}`;
+	const encodedCredentials = Buffer.from(credentials, 'binary').toString(
+		'base64',
+	);
+	return encodedCredentials;
+};
+
+// Gets a private post revision
+export async function getPostPreview(id) {
+	const credentials = getAuthCredentials();
+	client.setHeaders({ Authorization: `Basic ${credentials}` });
+
+	const query = gql`
+		query PostPreviewQuery($id: ID!) {
+			post(id: $id, idType: DATABASE_ID, asPreview: true) {
+				title
+				date
+				featuredImage {
+					node {
+						altText
+						sourceUrl
+					}
+				}
+				content
+			}
+		}
+	`;
+
+	const { post } = await client.request(query, { id });
+
+	return { post };
+}
+```
+
+To use `getPostPreview` in a Next.js page:
+
+```js
+// import the helper function
+import { getPostPreview } from '../lib/getPostPreview';
+
+// Your Next.js page component here
+
+export async function getServerSideProps(context) {
+	if (context.previewData) {
+		const id = context.previewData.key;
+		// using the previewData, we have the id of the unpublished post
+		const { post } = getPostPreview(id);
+
+		return {
+			props: { post },
+		};
+	}
+	// ...
+}
+```
+
+See the
+[posts page from the next-wordpress-starter](https://github.com/pantheon-systems/decoupled-kit-js/blob/canary/starters/next-wordpress-starter/pages/posts/%5B...slug%5D.jsx#L44)
+for a full example.
+
+## Clearing Current Preview
+
+If you'd like to view another revision or edit, you may need to clear the
+current previewData cookie. This can be done by going to
+{YOUR_SITE_URL}/api/clear-preview. On successful clear, you will be redirected
+to the homepage.
+
+Our `nextjs-kit` includes a preview ribbon component that can be implemented to
+show a ribbon at the top of the screen when preview mode is true.

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/implementing-preview.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/implementing-preview.md
@@ -12,8 +12,14 @@ your WordPress instance. To do so, follow these instructions:
 
 1. Log in to your WordPress instance.
 1. Navigate to **Users**
-1. Create a new user or use an existing one. This username is, your
+1. Create a new user or use an existing one. This username is your
    `WP_APPLICATION_USERNAME`
+
+   :::info This user must have at least the `Editor` role.
+
+   This is necessary in order for this user to be able to access revisions and
+   private posts.
+
 1. Hover over the username and click **Edit** to bring up the user's profile
    page.
 1. Scroll down to the Application Passwords section and name your application

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/setting-cache-control-header.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/setting-cache-control-header.md
@@ -2,7 +2,7 @@
 id: 'next-wordpress-cache-control-headers'
 title: 'Setting Cache-Control Headers'
 slug: '/frontend-starters/nextjs/nextjs-wordpress/setting-cache-control-headers'
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 ## Before You Begin

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/styling-configuration.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/styling-configuration.md
@@ -2,7 +2,7 @@
 id: 'styling-configuration'
 title: 'Styling Configuration'
 slug: '/frontend-starters/nextjs/nextjs-wordpress/styling-configuration'
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 ## Before You Begin

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
@@ -2,7 +2,7 @@
 title: Surrogate Key Based Cache Purging
 id: next-wordpress-surrogate-key-caching
 slug: '/frontend-starters/nextjs/nextjs-wordpress/next-wordpress-surrogate-key-caching'
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 ## Before You Begin

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/troubleshooting.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/troubleshooting.md
@@ -2,7 +2,7 @@
 id: 'next-wordpress-troubleshooting'
 title: 'Troubleshooting'
 slug: '/frontend-starters/nextjs/nextjs-wordpress/troubleshooting'
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 ## Before You Begin

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/your-first-customization.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/your-first-customization.md
@@ -2,7 +2,7 @@
 id: 'next-wordpress-customization'
 title: 'Your First Next.js & WordPress Customization'
 slug: '/frontend-starters/nextjs/nextjs-wordpress/your-first-nextjs-wordpress-customization'
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 ## Before You Begin


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Added a new doc under the next+wp section about implementing preview
Also changed the sidebar positions to match the next+drupal section 
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->