### PR TITLE
DB-883: Update surrogate key headers

### DIFF
--- a/.changeset/angry-rules-knock.md
+++ b/.changeset/angry-rules-knock.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/wordpress-kit': minor
+---
+
+clients created with `GraphqlClientFactory` now set the `Pantheon-SKey` header
+instead of `Pantheon-Debug`

--- a/.changeset/eight-waves-behave.md
+++ b/.changeset/eight-waves-behave.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/cms-kit': minor
+---
+
+`setSurrogateKeyHeader` now sets the `Surrogate-Key` header instead of
+`Surrogate-Key-Raw`

--- a/.changeset/large-donuts-mix.md
+++ b/.changeset/large-donuts-mix.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/drupal-kit': minor
+---
+
+`defaultFetch` now sets the `Pantheon-SKey` header instead of `Pantheon-Debug`

--- a/packages/cms-kit/src/utils/setSurrogateKeyHeader.ts
+++ b/packages/cms-kit/src/utils/setSurrogateKeyHeader.ts
@@ -29,11 +29,11 @@ const setSurrogateKeyHeader = (
 				...new Set([...surrogateKeys, ...newSurrogateKeys]),
 			];
 			const uniqueSurrogateKeys = uniqueKeysArr.join(' ');
-			res.setHeader('Surrogate-Key-Raw', uniqueSurrogateKeys);
+			res.setHeader('Surrogate-Key', uniqueSurrogateKeys);
 			return uniqueSurrogateKeys;
 		} else if (typeof keys === 'string') {
 			// if the header is not present already and we have keys, set the header
-			res.setHeader('Surrogate-Key-Raw', keys);
+			res.setHeader('Surrogate-Key', keys);
 			return keys;
 		}
 	}

--- a/packages/drupal-kit/src/lib/defaultFetch.ts
+++ b/packages/drupal-kit/src/lib/defaultFetch.ts
@@ -30,7 +30,7 @@ const defaultFetch = (
 	// and set appropriate cache-control headers on the active response.
 	if (res && typeof res !== 'boolean') {
 		// Ensure api response contains surrogate key headers.
-		headers.set('Pantheon-Debug', '1');
+		headers.set('Pantheon-SKey', '1');
 
 		res.setHeader('Cache-Control', cacheControl);
 	}

--- a/packages/wordpress-kit/__mocks__/server/basicPostsQuery.ts
+++ b/packages/wordpress-kit/__mocks__/server/basicPostsQuery.ts
@@ -5,7 +5,7 @@ import basicPostsQueryData from '../../__tests__/data/basicPostsQuery.json';
 export const basicPostsQuery = graphql.query<typeof basicPostsQueryData>(
 	'BasicPostsQuery',
 	(req, res, ctx) => {
-		if (req.headers.has('pantheon-debug')) {
+		if (req.headers.has('Pantheon-SKey')) {
 			return res(
 				ctx.data(basicPostsQueryData),
 				ctx.set('Surrogate-Key-Raw', 'post-7 post-1 user-1 graphql-collection'),

--- a/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts
+++ b/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts
@@ -20,7 +20,7 @@ class GraphQLClientFactory {
 		this.options = {
 			...options,
 			headers: {
-				'pantheon-debug': '1',
+				'Pantheon-SKey': '1',
 			},
 		};
 	}

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
@@ -25,15 +25,15 @@ sequenceDiagram
     participant B as Next.js + drupal-kit
     participant C as Drupal
     A->>B: Request a page that fetches from Drupal
-    B->>C: Add Pantheon-Debug header to request
+    B->>C: Add Pantheon-SKey header to request
     C->>B: Surrogate-Key-Raw header included on response
-    B->>A: Set Surrogate-Key-Raw header on outgoing response to browser
+    B->>A: Set Surrogate-Key header on outgoing response to browser
 ```
 
 The `PantheonDrupalState` class from our `@pantheon-systems/drupal-kit` npm
-package includes an adapted fetch method which adds the `Pantheon-Debug` header
+package includes an adapted fetch method which adds the `Pantheon-SKey` header
 to each request to Drupal. Responses from Drupal will contain the
-`Surrogate-Key-Raw` header. With these keys, your frontend can be instructed to
+`Surrogate-Key` header. With these keys, your frontend can be instructed to
 purge content from a cache when the content in Drupal changes.
 
 ## How To Ensure Headers Are Set On Custom Routes
@@ -45,7 +45,7 @@ purge content from a cache when the content in Drupal changes.
   `@pantheon-systems/drupal-kit` in your application.
 - Use the fetch methods available (see
   [`drupal-kit`](../../../Packages/drupal-kit/) for more information). The
-  Surrogate-Key-Raw header should be set automatically if Drupal is configured
+  Surrogate-Key header should be set automatically if Drupal is configured
   correctly.
 - Pass the
   [`context.res`](https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#context-parameter)

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
@@ -26,14 +26,14 @@ sequenceDiagram
     participant B as Next.js + wordpress-kit
     participant C as WordPress
     A->>B: Request a page that fetches from WordPress
-    B->>C: Add Pantheon-Debug header to request
+    B->>C: Add Pantheon-SKey header to request
     C->>B: Surrogate-Key-Raw header included on response
-    B->>A: Set Surrogate-Key-Raw header on outgoing response to browser
+    B->>A: Set Surrogate-Key header on outgoing response to browser
 ```
 
 The `GraphqlClientFactory` class from our `@pantheon-systems/wordpress-kit` npm
 package adds the `Pantheon-Debug` header to each request. Responses from
-WordPress will contain the `Surrogate-Key-Raw` header. With these keys, your
+WordPress will contain the `Surrogate-Key` header. With these keys, your
 frontend can be instructed to purge content from a cache when the content in
 WordPress changes.
 
@@ -46,7 +46,7 @@ WordPress changes.
   [Pantheon Advanced Page Cache plugin](https://wordpress.org/plugins/pantheon-advanced-page-cache/)
   installed and configured
 - The route fetches data using the `@pantheon-systems/wordpress-kit` Graphql
-  client or requests to WordPress include the `Pantheon-Debug: 1` header
+  client or requests to WordPress include the `Pantheon-SKey: 1` header
   - in order to see the headers, you must use the `client.rawRequest()` method.
 - The headers must be added to the outgoing response from Next.js in
   `getServerSideProps` (see


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Instead of setting `Pantheon-Debug`, `wordpress-kit` and `drupal-kit` fetch methods now set `Pantheon-SKey`
- Instead of setting `Surrogate-Key-Raw` on outgoing responses, `cms-kit`'s `setSurrogateKeyHeader` now sets the `Surrogate-Key` header on the outgoing response.
- The appropriate docs  have been updated as needed

## Where were the changes made?
cms-kit, drupal-kit, wordpress-kit, docs
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tests pass
tested locally with each starter kit against our default QA backends to ensure correct header is output in the browser.
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->