### PR TITLE
DB-4935: Error if previewing a draft

### DIFF
--- a/.changeset/poor-ducks-decide.md
+++ b/.changeset/poor-ducks-decide.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/next-drupal-starter': patch
+---
+
+Add an error message to `getPreview` in case `fetchedPreviewData` is a draft and
+has no `id`

--- a/starters/next-drupal-starter/lib/getPreview.js
+++ b/starters/next-drupal-starter/lib/getPreview.js
@@ -34,7 +34,7 @@ export async function getPreview(context, node, params) {
 			if (context?.previewData?.resourceVersionId) {
 				process.env.DEBUG_MODE &&
 					console.log(
-						`Adding resource version ID param ${context?.previewData?.resourceVersionId}...`,
+						`Adding resource version ID param ${context.previewData.resourceVersionId}...`,
 					);
 				if (params === undefined) {
 					params = '';
@@ -51,10 +51,18 @@ export async function getPreview(context, node, params) {
 					}`,
 					requestInit,
 				);
+				if (!fetchedPreviewData?.data?.id) {
+					throw new Error(
+						'Unable to fetch preview data. Drafts that have been saved are not preview-able and must be published again before preview is possible.',
+					);
+				}
 
 				if (fetchedPreviewData.errors) {
-					throw fetchedPreviewData?.errors.forEach(({ detail }) => detail);
+					throw new Error(
+						fetchedPreviewData?.errors.map(({ detail }) => detail).join('\n'),
+					);
 				}
+
 				const resourceKey = params
 					? `${fetchedPreviewData.data.id}-${params}`
 					: fetchedPreviewData.data.id;
@@ -68,7 +76,7 @@ export async function getPreview(context, node, params) {
 		return params;
 	} catch (error) {
 		process.env.DEBUG_MODE &&
-			console.error('Error verifying preview content: ', error);
+			console.error('Error verifying preview content in getPreview: ', error);
 
 		const [statusCode] = error.message.match(/([0-5]{3})$/gm) || [null];
 
@@ -96,7 +104,7 @@ export async function getPreview(context, node, params) {
 			error: true,
 			redirect: `/preview-error?error=${encodeURIComponent(
 				'Could not verify preview content',
-			)}&message=${encodeURIComponent('Unexpected error')}`,
+			)}&message=${encodeURIComponent(error.message || 'Unexpected error')}`,
 		};
 	}
 }

--- a/starters/next-drupal-starter/lib/getPreview.js
+++ b/starters/next-drupal-starter/lib/getPreview.js
@@ -53,7 +53,7 @@ export async function getPreview(context, node, params) {
 				);
 				if (!fetchedPreviewData?.data?.id) {
 					throw new Error(
-						'Unable to fetch preview data. Drafts that have been saved are not preview-able and must be published again before preview is possible.',
+						'Unable to fetch preview data. Previewing drafts is currently not supported. As an alternative, either preview while editing, or preview a saved revision.',
 					);
 				}
 

--- a/starters/next-drupal-starter/pages/api/preview.js
+++ b/starters/next-drupal-starter/pages/api/preview.js
@@ -1,7 +1,7 @@
 import { globalDrupalStateStores } from '../../lib/stores';
 
 const preview = async (req, res) => {
-	const { secret, slug, objectName } = req.query
+	const { secret, slug, objectName } = req.query;
 	// Check the secret and next parameters
 	// This secret should only be known to this API route and the CMS
 	if (secret !== process.env.PREVIEW_SECRET) {
@@ -37,7 +37,10 @@ const preview = async (req, res) => {
 		});
 	} catch (error) {
 		process.env.DEBUG_MODE &&
-			console.error('Error verifying preview content: ', error);
+			console.error(
+				'Error verifying preview content in pages/api/preview: ',
+				error,
+			);
 		return res.redirect(
 			`/preview-error/?error=${encodeURIComponent(
 				'Could not verify preview content',


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Drafts are not currently supported for Drupal's decoupled_preview. This change adds a clearer error message in the case a user tries to preview a draft.

## Where were the changes made?
next-drupal-starter
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->