### PR TITLE
Update footer in snapshots for 2023

### DIFF
--- a/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/footer.test.tsx.snap
+++ b/packages/nextjs-kit/src/__tests__/snapshotTests/__snapshots__/footer.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`<Footer /> > should render 'footer' 1`] = `
       <span
         class="mx-auto"
       >
-        © 2022 Built with 
+        © 2023 Built with 
         <a
           class="text-white hover:text-blue-100 underline"
           href="https://nextjs.org/"

--- a/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/authApi.test.jsx.snap
+++ b/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/authApi.test.jsx.snap
@@ -123,7 +123,7 @@ exports[`<AuthApiExampleTemplate /> > should render a failure message if unauthe
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"
@@ -251,7 +251,7 @@ exports[`<AuthApiExampleTemplate /> > should render a success message if authent
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"

--- a/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/homepage.test.jsx.snap
+++ b/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/homepage.test.jsx.snap
@@ -204,7 +204,7 @@ exports[`<Index /> > should render with posts 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"

--- a/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/page.test.jsx.snap
+++ b/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/page.test.jsx.snap
@@ -121,7 +121,7 @@ exports[`<PageTemplate /> > should render with a page 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"

--- a/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/pagesIndex.test.jsx.snap
+++ b/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/pagesIndex.test.jsx.snap
@@ -158,7 +158,7 @@ exports[`<PageIndexTemplate /> > should render with pages 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"

--- a/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/pagination.test.jsx.snap
+++ b/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/pagination.test.jsx.snap
@@ -454,7 +454,7 @@ exports[`<PaginationPostsExample /> > check back button works 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"
@@ -914,7 +914,7 @@ exports[`<PaginationPostsExample /> > check next button works 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"
@@ -1389,7 +1389,7 @@ exports[`<PaginationPostsExample /> > should render the paginated data 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"

--- a/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/post.test.jsx.snap
+++ b/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/post.test.jsx.snap
@@ -174,7 +174,7 @@ exports[`<PostTemplate /> > should render with a post 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"

--- a/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/postsIndex.test.jsx.snap
+++ b/starters/gatsby-wordpress-starter/__tests__/snapshotTests/__snapshots__/postsIndex.test.jsx.snap
@@ -200,7 +200,7 @@ exports[`<PostIndexTemplate /> > should render with posts 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-purple-300 underline hover:text-blue-100"
             href="https://www.gatsbyjs.com"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/[...alias].test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/[...alias].test.jsx.snap
@@ -112,7 +112,7 @@ exports[`default <CatchAllRoute /> > should render a page 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -298,7 +298,7 @@ exports[`default <CatchAllRoute /> > should render an article 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/articles.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/articles.test.jsx.snap
@@ -140,7 +140,7 @@ exports[`default <ArticleTemplate /> > should render with default profile articl
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -281,7 +281,7 @@ exports[`default <SSRArticlesListTemplate /> > should render with default profil
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/auth-api.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/auth-api.test.jsx.snap
@@ -120,7 +120,7 @@ exports[`default <AuthApiExampleTemplate /> > should render a failure message if
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -245,7 +245,7 @@ exports[`default <AuthApiExampleTemplate /> > should render a success message if
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/examples-index.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/examples-index.test.jsx.snap
@@ -130,7 +130,7 @@ exports[`default <ExamplesPageTemplate /> > should render 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/homepage.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/homepage.test.jsx.snap
@@ -140,7 +140,7 @@ exports[`default <HomepageTemplate /> > should render with default profile artic
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/pages.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/pages.test.jsx.snap
@@ -128,7 +128,7 @@ exports[`default <PageListTemplate /> > should render with default profile pages
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -263,7 +263,7 @@ exports[`default <PageTemplate /> > should render with default profile page 1`] 
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/pagination.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/pagination.test.jsx.snap
@@ -434,7 +434,7 @@ Erat et...
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/recipes.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/recipes.test.jsx.snap
@@ -80,7 +80,7 @@ exports[`Default <RecipeListTemplate /> > should render a 404 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -181,7 +181,7 @@ exports[`Default <RecipeTemplate /> > should render a 404 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/default/ssr-isr-example.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/default/ssr-isr-example.test.jsx.snap
@@ -129,7 +129,7 @@ exports[`default <SSGISRExampleTemplate /> > should render with default profile 
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/[...alias].test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/[...alias].test.jsx.snap
@@ -132,7 +132,7 @@ exports[`umami <CatchAllRoute /> > should render a page 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -373,7 +373,7 @@ exports[`umami <CatchAllRoute /> > should render a recipe 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -579,7 +579,7 @@ exports[`umami <CatchAllRoute /> > should render an article 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/articles.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/articles.test.jsx.snap
@@ -220,7 +220,7 @@ exports[`umami <ArticleTemplate /> > should render with umami profile articles 1
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -528,7 +528,7 @@ exports[`umami <SSRArticlesListTemplate /> > should render with umami profile ar
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/auth-api.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/auth-api.test.jsx.snap
@@ -140,7 +140,7 @@ exports[`umami <AuthApiExampleTemplate /> > should render a failure message if u
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -285,7 +285,7 @@ exports[`umami <AuthApiExampleTemplate /> > should render a success message if a
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/examples-index.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/examples-index.test.jsx.snap
@@ -150,7 +150,7 @@ exports[`umami <ExamplesPageTemplate /> > should render 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/homepage.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/homepage.test.jsx.snap
@@ -307,7 +307,7 @@ exports[`umami <HomepageTemplate /> > should render with umami profile articles 
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/pages.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/pages.test.jsx.snap
@@ -162,7 +162,7 @@ exports[`umami <PageListTemplate /> > should render with umami profile pages 1`]
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -322,7 +322,7 @@ exports[`umami <PageTemplate /> > should render with umami profile page 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/pagination.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/pagination.test.jsx.snap
@@ -454,7 +454,7 @@ Erat et...
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/recipes.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/recipes.test.jsx.snap
@@ -379,7 +379,7 @@ exports[`Umami <RecipeListTemplate /> > should render with umami profile recipes
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -673,7 +673,7 @@ exports[`Umami <RecipeTemplate /> > should render with a umami profile recipe 1`
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-drupal-starter/__tests__/__snapshots__/umami/ssr-isr-example.test.jsx.snap
+++ b/starters/next-drupal-starter/__tests__/__snapshots__/umami/ssr-isr-example.test.jsx.snap
@@ -296,7 +296,7 @@ exports[`umami <SSGISRExampleTemplate /> > should render with umami profile arti
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/auth-api.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/auth-api.test.jsx.snap
@@ -109,7 +109,7 @@ exports[`<AuthApiExampleTemplate /> > should render a failure message if unauthe
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -223,7 +223,7 @@ exports[`<AuthApiExampleTemplate /> > should render a success message if authent
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/example-index.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/example-index.test.jsx.snap
@@ -119,7 +119,7 @@ exports[`<ExamplesPageTemplate /> > should render the examples list page 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/homepage.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/homepage.test.jsx.snap
@@ -160,7 +160,7 @@ exports[`<HomepageTemplate /> > should render with posts 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/pages.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/pages.test.jsx.snap
@@ -121,7 +121,7 @@ exports[`<PageListTemplate /> > should render with pages 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -296,7 +296,7 @@ exports[`<PageTemplate /> > should render a page 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/pagination.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/pagination.test.jsx.snap
@@ -314,7 +314,7 @@ exports[`<PaginationExampleTemplate /> > should render the Pagination Example pa
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/posts.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/posts.test.jsx.snap
@@ -142,7 +142,7 @@ exports[`<PostListTemplate /> > should render with posts 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"
@@ -287,7 +287,7 @@ exports[`<PostTemplate /> > should render a post 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"

--- a/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/ssg-isr-example.test.jsx.snap
+++ b/starters/next-wordpress-starter/__tests__/snapshotTests/__snapshots__/ssg-isr-example.test.jsx.snap
@@ -138,7 +138,7 @@ exports[`<SSGISRExampleTemplate /> > should render with posts 1`] = `
         <span
           class="mx-auto"
         >
-          © 2022 Built with 
+          © 2023 Built with 
           <a
             class="text-white hover:text-blue-100 underline"
             href="https://nextjs.org/"


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Happy New Year 🥳 
Snapshot tests were failing because of the year in the footer. This should last us until next year unless there's a better solution here.
## Where were the changes made?
Updated snapshot tests
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->
Not sure if the starters need a changeset here? probably not.