### PR TITLE
DB-5231: Support GraphQL over HTTP GET

### DIFF
--- a/.changeset/eighty-timers-fold.md
+++ b/.changeset/eighty-timers-fold.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/wordpress-kit": minor
+---
+
+Support GraphQL over HTTP GET

--- a/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
+++ b/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
@@ -30,7 +30,6 @@ test('request and response middleware add appropriate headers', async () => {
 });
 
 test('client is configured for GET requests', async () => {
-	// const client = new GraphqlClientFactory('http://my-wp.test/graphql').create();
 	const getClient = new GraphqlClientFactory('http://my-wp.test/graphql', {
 		method: 'GET',
 	}).create();

--- a/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
+++ b/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
@@ -28,3 +28,12 @@ test('request and response middleware add appropriate headers', async () => {
 	expect(res.data).toEqual(basicPostsQuery);
 	expect(res.headers.has('surrogate-key-raw')).toBeTruthy();
 });
+
+test('client is configured for GET requests', async () => {
+	const client = new GraphqlClientFactory('http://my-wp.test/graphql').create();
+	const getClient = new GraphqlClientFactory('http://my-wp.test/graphql', {
+		method: 'GET',
+	}).create();
+
+	expect(client).not.toMatchObject(getClient);
+});

--- a/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
+++ b/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
@@ -32,7 +32,7 @@ test('request and response middleware add appropriate headers', async () => {
 test('client is configured for GET requests', async () => {
 	const getClient = new GraphqlClientFactory('http://my-wp.test/graphql', {
 		method: 'GET',
-	}).create();
+	});
 
 	expect(getClient.options.method).toEqual('GET');
 });

--- a/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
+++ b/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
@@ -30,10 +30,10 @@ test('request and response middleware add appropriate headers', async () => {
 });
 
 test('client is configured for GET requests', async () => {
-	const client = new GraphqlClientFactory('http://my-wp.test/graphql').create();
+	// const client = new GraphqlClientFactory('http://my-wp.test/graphql').create();
 	const getClient = new GraphqlClientFactory('http://my-wp.test/graphql', {
 		method: 'GET',
 	}).create();
 
-	expect(client).not.toMatchObject(getClient);
+	expect(getClient.options.method).toEqual('GET');
 });

--- a/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts
+++ b/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts
@@ -22,9 +22,12 @@ class GraphQLClientFactory {
 			headers: {
 				'Pantheon-SKey': '1',
 			},
+			jsonSerializer:
+				options.method === 'GET'
+					? { parse: JSON.parse, stringify: JSON.stringify }
+					: undefined,
 		};
 	}
-
 	/**
 	 * Creates an instance of `graphql-request` GraphQLClient based on the endpoint and options
 	 */


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Support GraphQL over HTTP GET added to the `wordpress-kit`

## Where were the changes made?
- `wordpress-kit`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
- A GraphQL client was created to support GET requests and the use of this client resulted in successful cache hits.
-   
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->