### PR TITLE
DB-5059: Add docs for developing with the cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,10 @@ Formatting and linting can also be run manually using the following commands:
 
 ## Testing
 
-This project is configured to run [Jest](https://facebook.github.io/jest/) tests
-via `pnpm --filter './packages/**' test`. All new code is expected to be covered
-by tests and these tests will run as part of our CI process and will also be run
-locally as a pre-commit hook.
+This project is configured to run [Jest](https://facebook.github.io/jest/) and
+[Vitest](https://vitest.dev) tests via `pnpm --filter './packages/**' test`. All
+new code is expected to be covered by tests and these tests will run as part of
+our CI process and will also be run locally as a pre-commit hook.
 
 Tests should be added in a `__tests__` directory adjacent to the file they are
 testing and the files should be named `<fileName>.test.ts`.
@@ -98,29 +98,109 @@ TODOS:
 - Allow individual import of modules rather than requiring imports from the main
   bundle.
 
-### Starters
-
 To contribute to the starters, you will need a backend to develop against.
 
-### next-drupal-starter
+## Working With `create-pantheon-decoupled-kit`
 
-#### Testing
+`create-pantheon-decoupled-kit` or "the cli" is meant to be a new way to develop
+and consume the starter kits. We would like to support an ever growing matrix of
+frameworks, with or without certain features or add-ons like tailwindcss or
+TypeScript to name a few. In order to support this while reducing friction to
+new frameworks and add-ons, we have taken inspiration from other `create-` apps
+in similar open source spaces, including
+[`create-sitecore-jss`](https://github.com/Sitecore/jss/tree/dev/packages/create-sitecore-jss),
+[`create-astro`](https://github.com/withastro/astro/tree/main/packages/create-astro),
+and [`create-create-app`](https://github.com/uetchy/create-create-app). The cli
+uses
+[`node-plop`](https://github.com/plopjs/plop/tree/master/packages/node-plop)
+under the hood, so if you are comfortable writing
+[plop generators and templates](https://plopjs.com/documentation/#your-first-plopfile),
+this should be very familiar.
 
-- Unit and snapshot tests are written using [vitest](https://vitest.dev). Tests
-  should be written in the `__tests__` directory.
-- Test data should be in `__tests__/data`, preferably in a json format.
-- Fetch calls should be mocked with [msw](https://mswjs.io) so that tests do not
-  rely on a running backend to pass.
-- Tests should be written with the two data profiles in mind: the Umami demo
-  data profile, and the Default example data profile.
+### Types Of Generators
 
-<!-- Instructions on how to spin up a backend for local development here -->
+There are theoretically two types of generators: base generators and add-ons. A
+base generator bootstraps a project, and add-ons are runnable on top of an
+already generated project. Add-ons should be callable while bootstrapping a new
+project as well.
 
-### gatsby-wordpress-starter
+## Creating A Generator
 
-<!-- Instructions on how to spin up a backend for local development here -->
+Templates are written in the
+[handlebars templating language](https://handlebarsjs.com/). See
+https://plopjs.com/documentation/#your-first-plopfile for instructions on
+creating generators. There are a few differences between vanilla plop generators
+and Decoupled Kit Generators:
 
-## Notes for Maintainers
+1. the export must be written in TypeScript.
+1. it must be `typeof DecoupledKitGenerator` which is a `PlopGenerator` with an
+   added `name` field.
+1. it must export an object instead of a function.
+1. it must allow prompts to be skipped by passing in named command line
+   arguments.
+1. it should use the `addWithDiff` action to write new files.
 
-When merging pull requests, please use the "Merge Commit" option on the pull
-request in GitHub.
+## Adding Partials
+
+Partials should be used when possible. Partials must be added to the
+`create-pantheon-decoupled-kit/src/templates/partials` directory in order to be
+automatically registered to plop's handlebars compiler.
+
+## Adding Custom Actions
+
+Actions should be exported from their own file under
+`create-pantheon-decoupled-kit/src/utils`. The actions should use the
+[CustomActionConfig interface from `node-plop`](https://github.com/plopjs/plop/blob/main/packages/node-plop/types/index.d.ts#L175).
+If needed, extend the `config` object inline like so:
+
+```typescript
+import type { Answers } from 'inquirer';
+import type { CustomActionConfig, NodePlopAPI } from 'node-plop';
+
+export const exampleAction = (
+	answers: Answers,
+	config: CustomActionConfig<'exampleAction'> & {
+		requiredString: string,
+		requiredBoolean: boolean,
+		etc.
+	},
+	plop: NodePlopAPI
+) => { ... }
+```
+
+Be aware of the existing actions as names must be unique. You will need to add
+your action to the actions array inside the `setGenerators` function in
+`create-pantheon-decoupled-kit/src/index.ts`. Add your action as an object with
+a `name` key, with a value equal to the action name using `camelCase`, and an
+`action` key with a value equal to your action which should be imported into the
+file.
+
+```typescript
+[{ name: 'exampleAction', action: exampleAction }, ...]
+```
+
+The new action will be registered and callable from any generator.
+
+## The `watch` Script
+
+The `watch` script enables a generator to run and watch for changes to the
+template files. If a template of the given generator changes, the generator
+reruns and outputs the new changes in the configured directory. Thanks to Hot
+Module Reloading (HMR), which is enabled by most modern frontend frameworks,
+this feature unlocks the following workflow:
+
+1. Generate a project in the `starters` workspace of the monorepo
+1. Start the result in dev mode e.g. `pnpm dev:next-wp` and visit the page in a
+   web browser
+1. Make changes to a template file of the given generator
+1. Changes to the template are reflected in the browser
+
+In order to use the `watch` script, configure a `watch.js/ts` file at the root
+of the `./packages/create-pantheon-decoupled-kit` directory. It should export a
+JSON object named `watchOptions` in the shape of
+[minimist `ParsedArgs`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f834dd47e704fe7c65a87664864e78332e63bee7/types/minimist/index.d.ts#L80).
+The `watch` script will pick up this file and execute the generators listed in
+order in the `_` array. See the `watch.example.ts` for an example.
+
+:::note It is not possible to `watch` with multiple project generators in the
+`_` array. Subsequent generators must be add-ons. :::

--- a/packages/create-pantheon-decoupled-kit/README.md
+++ b/packages/create-pantheon-decoupled-kit/README.md
@@ -57,3 +57,6 @@ Please see the
 to contribute to the project.
 
 <!-- TODO: Write details for contributing to this package -->
+
+See https://decoupledkit.pantheon.io/docs/contributing for details on
+contributing to this module.

--- a/packages/create-pantheon-decoupled-kit/index.ts
+++ b/packages/create-pantheon-decoupled-kit/index.ts
@@ -1,0 +1,3 @@
+export * from './src/index';
+export * from './src/utils/index';
+export * from './src/types';

--- a/packages/create-pantheon-decoupled-kit/package.json
+++ b/packages/create-pantheon-decoupled-kit/package.json
@@ -27,7 +27,7 @@
 	],
 	"prettier": "@pantheon-systems/configs/prettier",
 	"typedoc": {
-		"entryPoint": "./src/index.ts"
+		"entryPoint": "./index.ts"
 	},
 	"scripts": {
 		"build": "pnpm clean && node ./esbuild.js && pnpm copy-templates",

--- a/packages/create-pantheon-decoupled-kit/src/utils/index.ts
+++ b/packages/create-pantheon-decoupled-kit/src/utils/index.ts
@@ -1,0 +1,4 @@
+export { addWithDiff } from './addWithDiff';
+export { getPartials } from './getPartials';
+export { runInstall } from './runInstall';
+export { runESLint } from './runESLint';

--- a/packages/create-pantheon-decoupled-kit/watch.example.ts
+++ b/packages/create-pantheon-decoupled-kit/watch.example.ts
@@ -1,11 +1,19 @@
 import path from 'path';
 import type { ParsedArgs } from 'minimist';
 export const watchOptions: ParsedArgs = {
-	_: ['test-add'],
-	input: 'hello',
-	outDir: path.resolve('../../test'),
-	choice: 'one',
-	choice2: 'four',
+	_: ['next-wp'],
+	outDir: path.resolve('../../starters/next-wordpress-generated'),
+	appName: 'Next WordPress Watch Example',
+	// any handlebars variable can be injected here, they don't need a prompt.
+	WPGRAPHQL_URL: 'https://myWPSite.pantheonsite.io/wp/graphql',
+	// prevent the install step after project generation.
+	// The watch script sets this to true after the initial run.
+	noInstall: true,
+	// force overwrite of the target directory.
+	// WARNING: this option could overwrite uncommited work.
+	// Choose an empty outDir for best results with this options.
 	force: true,
+	// squelch console output from generators.
+	// watch script still shows output.
 	silent: true,
 };

--- a/web/docs/Packages/create-pantheon-decoupled-kit/index.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/index.md
@@ -24,17 +24,7 @@ monorepo.
   # build the package
   pnpm build:cli
   # run the bin script
-  node ./packages/create-pantheon-decoupled-kit/dist/bin.js
-```
-
-<!-- TODO: this is mostly verified but need to confirm check. npm definitely works. -->
-
-Or, install the local package globally with `npm` Note: We are using `npm` here
-because `pnpm` does not support locally installed `create-` packages
-
-```bash
-  npm install --global ./packages/create-pantheon-decoupled-kit
-  npx create-pantheon-decoupled-kit
+  pnpm create-pantheon-decoupled-kit
 ```
 
 ## Usage
@@ -49,7 +39,7 @@ prompts in your terminal
 Or, pass in arguments up front to skip those prompts
 
 ```bash
-  pnpm create pantheon-decoupled-kit --appName my-app --dir ./my-app-dir --framework nextjs
+  pnpm create pantheon-decoupled-kit next-wp --appName my-app --outDir ./my-app-dir --force
 ```
 
 ### `watch` script
@@ -75,3 +65,48 @@ Please see the
 to contribute to the project.
 
 <!-- TODO: Write details for contributing to this package -->
+
+### Before You Begin
+
+`create-pantheon-decoupled-kit` or "the cli" is meant to be a new way to develop and consume the starter kits. We would like to support an ever growing matrix of frameworks, with or without certain features or add-ons like tailwindcss or TypeScript to name a few. In order to support this while reducing friction to new frameworks and add-ons, we have taken inspiration from other `create-` apps in similar open source spaces, including [`create-sitecore-jss`](https://github.com/Sitecore/jss/tree/dev/packages/create-sitecore-jss), [`create-astro`](https://github.com/withastro/astro/tree/main/packages/create-astro), and [`create-create-app`](https://github.com/uetchy/create-create-app). The cli uses [`node-plop`](https://github.com/plopjs/plop/tree/master/packages/node-plop) under the hood, so if you are comfortable writing [plop generators and templates](https://plopjs.com/documentation/#your-first-plopfile), this should be very familiar. 
+
+#### Types Of Generators
+
+There are theoretically two types of generators: base generators and add-ons. A base generator bootstraps a project, and add-ons are runnable on top of an already generated project. Add-ons should be callable while bootstrapping a new project as well.
+### Creating A Generator
+
+Templates are written in the [handlebars templating language](https://handlebarsjs.com/). See https://plopjs.com/documentation/#your-first-plopfile for instructions on creating generators. There are a few differences between vanilla plop generators and Decoupled Kit Generators:
+
+1. the export must be written in TypeScript.
+1. it must be `typeof DecoupledKitGenerator` which is a `PlopGenerator` with an added `name` field.
+1. it must export an object instead of a function.
+1. it must allow prompts to be skipped by passing in named command line arguments.
+1. it should use the `addWithDiff` action to write new files.
+
+### Adding Partials
+Partials should be used when possible. Partials must be added to the `create-pantheon-decoupled-kit/src/templates/partials` directory in order to be automatically registered to plop's handlebars compiler.
+
+### Adding Custom Actions
+Actions should be exported from their own file under `create-pantheon-decoupled-kit/src/utils`. The actions should use the [CustomActionConfig interface from `node-plop`](https://github.com/plopjs/plop/blob/main/packages/node-plop/types/index.d.ts#L175). If needed, extend the `config` object inline like so:
+
+```typescript
+import type { Answers } from 'inquirer';
+import type { CustomActionConfig, NodePlopAPI } from 'node-plop';
+
+export const exampleAction = (
+	answers: Answers,
+	config: CustomActionConfig<'exampleAction'> & {
+		requiredString: string,
+		requiredBoolean: boolean,
+		etc.
+	},
+	plop: NodePlopAPI
+) => { ... }
+```
+
+Be aware of the existing actions as names must be unique. You will need to add your action to the actions array inside the `setGenerators` function in `create-pantheon-decoupled-kit/src/index.ts`. Add your action as an object with a `name` key, with a value equal to the action name using `camelCase`, and an `action` key with a value equal to your action which should be imported into the file. 
+
+```typescript
+[{ name: 'exampleAction', action: exampleAction }, ...]
+```
+The new action will be registered and callable from any generator.

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DecoupledKitGenerator.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DecoupledKitGenerator.md
@@ -1,0 +1,23 @@
+---
+id: "DecoupledKitGenerator"
+title: "Interface: DecoupledKitGenerator"
+sidebar_label: "DecoupledKitGenerator"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Hierarchy
+
+- `Partial`<`PlopGeneratorConfig`\>
+
+  ↳ **`DecoupledKitGenerator`**
+
+## Properties
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[src/types.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/622f2895a/packages/create-pantheon-decoupled-kit/src/types.ts#L11)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/_category_.yml
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/_category_.yml
@@ -1,0 +1,2 @@
+label: "Interfaces"
+position: 4

--- a/web/docs/Packages/create-pantheon-decoupled-kit/modules.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/modules.md
@@ -6,7 +6,67 @@ sidebar_position: 0.5
 custom_edit_url: null
 ---
 
+## Interfaces
+
+- [DecoupledKitGenerator](interfaces/DecoupledKitGenerator.md)
+
 ## Functions
+
+### addWithDiff
+
+▸ **addWithDiff**(`answers`, `config`, `plop`): `Promise`<`string`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `answers` | `Answers` |
+| `config` | `CustomActionConfig`<``"addWithDiff"``\> & { `path`: `string` ; `templates`: `string`  } |
+| `plop` | `NodePlopAPI` |
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Defined in
+
+[src/utils/addWithDiff.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/622f2895a/packages/create-pantheon-decoupled-kit/src/utils/addWithDiff.ts#L10)
+
+___
+
+### getPartials
+
+▸ **getPartials**(`rootDir`): `Promise`<{ `name`: `string` ; `partial`: `string`  }[]\>
+
+Gets all handlebars templates in `${rootDir}/templates/partials`
+
+**`Remarks`**
+
+a single partial:
+```
+{
+	name: 'myPartial',
+	partial: '...(a handlebars template here)'
+}
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `rootDir` | `string` | dir to look for the partials dir from |
+
+#### Returns
+
+`Promise`<{ `name`: `string` ; `partial`: `string`  }[]\>
+
+an array of partials
+
+#### Defined in
+
+[src/utils/getPartials.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/622f2895a/packages/create-pantheon-decoupled-kit/src/utils/getPartials.ts#L18)
+
+___
 
 ### main
 
@@ -16,7 +76,7 @@ Initializes the CLI prompts based on parsed arguments
 
 **`See`**
 
-DecoupledKitGenerator.
+[DecoupledKitGenerator](interfaces/DecoupledKitGenerator.md).
 
 **`Remarks`**
 
@@ -27,7 +87,7 @@ positional args are assumed to be generator names. Multiple generators can be qu
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `args` | `ParsedArgs` | minimist.ParsedArgs |
-| `DecoupledKitGenerators` | `DecoupledKitGenerator`[] | An array of plop Generators with an added name field. |
+| `DecoupledKitGenerators` | [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)[] | An array of plop Generators with an added name field. |
 
 #### Returns
 
@@ -37,7 +97,7 @@ Runs the actions for the generators given as positional params or if none are fo
 
 #### Defined in
 
-[index.ts:58](https://github.com/CobyPear/decoupled-kit-js/blob/0c623b70/packages/create-pantheon-decoupled-kit/src/index.ts#L58)
+[src/index.ts:73](https://github.com/pantheon-systems/decoupled-kit-js/blob/622f2895a/packages/create-pantheon-decoupled-kit/src/index.ts#L73)
 
 ___
 
@@ -67,7 +127,51 @@ Parses CLI arguments using `minimist`
 
 #### Defined in
 
-[index.ts:32](https://github.com/CobyPear/decoupled-kit-js/blob/0c623b70/packages/create-pantheon-decoupled-kit/src/index.ts#L32)
+[src/index.ts:49](https://github.com/pantheon-systems/decoupled-kit-js/blob/622f2895a/packages/create-pantheon-decoupled-kit/src/index.ts#L49)
+
+___
+
+### runESLint
+
+▸ **runESLint**(`answers`, `_config`, `_plop`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `answers` | `Answers` |
+| `_config` | `CustomActionConfig`<``"runLint"``\> |
+| `_plop` | `NodePlopAPI` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[src/utils/runESLint.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/622f2895a/packages/create-pantheon-decoupled-kit/src/utils/runESLint.ts#L8)
+
+___
+
+### runInstall
+
+▸ **runInstall**(`answers`, `_config`, `_plop`): ``"success"`` \| ``"skipping install"``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `answers` | `Answers` |
+| `_config` | `CustomActionConfig`<``"runInstall"``\> |
+| `_plop` | `NodePlopAPI` |
+
+#### Returns
+
+``"success"`` \| ``"skipping install"``
+
+#### Defined in
+
+[src/utils/runInstall.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/622f2895a/packages/create-pantheon-decoupled-kit/src/utils/runInstall.ts#L8)
 
 ___
 
@@ -79,14 +183,14 @@ Set generator based on exports from src/generators
 
 **`See`**
 
- - DecoupledKitGenerator.
+ - [DecoupledKitGenerator](interfaces/DecoupledKitGenerator.md).
  - NodePlopAPI
 
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `generators` | `DecoupledKitGenerator`[] | An array of plop Generators with an added name field. |
+| `generators` | [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)[] | An array of plop Generators with an added name field. |
 
 #### Returns
 
@@ -96,4 +200,4 @@ An instance of plop
 
 #### Defined in
 
-[index.ts:16](https://github.com/CobyPear/decoupled-kit-js/blob/0c623b70/packages/create-pantheon-decoupled-kit/src/index.ts#L16)
+[src/index.ts:19](https://github.com/pantheon-systems/decoupled-kit-js/blob/622f2895a/packages/create-pantheon-decoupled-kit/src/index.ts#L19)

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -12,7 +12,9 @@ const nextjskitTypedocOptions = generateTypeDocOptions('nextjs-kit', 3);
 const cliTypeDocOptions = generateTypeDocOptions(
 	'create-pantheon-decoupled-kit',
 	4,
-	{ compilerOptions: { skipLibCheck: true } },
+	{
+		compilerOptions: { skipLibCheck: true },
+	},
 );
 const environmentUrl = process.env.PANTHEON_ENVIRONMENT_URL;
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Add docs for contributing to/developing with the cli.
## Where were the changes made?
- `CONTRIBUTING.md`, 
- `create-pantheon` - created barrel files for utils and all exports so that typedoc picks up everything
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information
I tacked the docs onto CONTRIBUTING.md, but open to putting them somewhere else. I wasn't sure if we should make a new entry somewhere in `/docs/Frontend Starters`. If we want it in `/docs/Packages/create-pantheon-decoupled-kit` after the API ref is generated, we might need to write some custom script. There didn't seem to be a way to include arbitrary markdown files in the `typedoc` output, or at least the one feature that did was about to be deprecated (couldn't get it working anyway :))

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->