### PR TITLE
DB-5376: Update Default Cache Control Values

### DIFF
--- a/.changeset/hip-seas-beam.md
+++ b/.changeset/hip-seas-beam.md
@@ -1,5 +1,7 @@
 ---
-"@pantheon-systems/wordpress-kit": patch
+'@pantheon-systems/wordpress-kit': minor
+'@pantheon-systems/drupal-kit': minor
 ---
 
-Update Default Cache Control Values
+Updated default Cache-Control value from
+`public, s-maxage=10, stale-while-revalidate=600` to `s-public, maxage=600`

--- a/.changeset/hip-seas-beam.md
+++ b/.changeset/hip-seas-beam.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/wordpress-kit": patch
+---
+
+Update Default Cache Control Values

--- a/.changeset/tasty-roses-jog.md
+++ b/.changeset/tasty-roses-jog.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/drupal-kit": minor
+---
+
+Update Default Cache Control Values

--- a/.changeset/tasty-roses-jog.md
+++ b/.changeset/tasty-roses-jog.md
@@ -1,5 +1,0 @@
----
-"@pantheon-systems/drupal-kit": minor
----
-
-Update Default Cache Control Values

--- a/packages/drupal-kit/src/__tests__/PantheonDrupalState.test.ts
+++ b/packages/drupal-kit/src/__tests__/PantheonDrupalState.test.ts
@@ -194,9 +194,7 @@ describe('drupalState', () => {
 		).toEqual(recipesResourceObject1);
 		expect(fetchMock).toBeCalledTimes(1);
 		expect(res.setHeader.mock.calls[0][0]).toBe('Cache-Control');
-		expect(res.setHeader.mock.calls[0][1]).toBe(
-			'public, s-maxage=10, stale-while-revalidate=600',
-		);
+		expect(res.setHeader.mock.calls[0][1]).toBe('public, s-maxage=600');
 	});
 
 	test('Fetch object with params', async () => {

--- a/packages/drupal-kit/src/lib/defaultFetch.ts
+++ b/packages/drupal-kit/src/lib/defaultFetch.ts
@@ -3,15 +3,14 @@ import fetch from 'isomorphic-fetch';
 
 import { setSurrogateKeyHeader } from '@pantheon-systems/cms-kit';
 
-const defaultCacheControlValue =
-	'public, s-maxage=10, stale-while-revalidate=600';
+const defaultCacheControlValue = 'public, s-maxage=600';
 
 /**
  * fetch data from a JSON:API endpoint, bubbling up surrogate keys if possible
  * @param apiUrl the api url for the JSON:API endpoint
  * @param requestInit fetch initialization object
  * @param res response object
- * @param cacheControl optional value to override cache control header, defaults to 'public, s-maxage=10, stale-while-revalidate=600'
+ * @param cacheControl optional value to override cache control header, defaults to 'public, s-maxage=600'
  * @returns a promise containing the data for the JSON:API response
  */
 const defaultFetch = (

--- a/packages/wordpress-kit/__tests__/setEdgeHeader.test.ts
+++ b/packages/wordpress-kit/__tests__/setEdgeHeader.test.ts
@@ -15,9 +15,7 @@ test('set using default cache-control header', () => {
 	const res = mockResponse();
 	setEdgeHeader({ res });
 	expect(res.setHeader.mock.calls[0][0]).toBe('Cache-Control');
-	expect(res.setHeader.mock.calls[0][1]).toBe(
-		'public, s-maxage=10, stale-while-revalidate=600',
-	);
+	expect(res.setHeader.mock.calls[0][1]).toBe('public, s-maxage=600');
 });
 
 test('set a custom cache control header', () => {

--- a/packages/wordpress-kit/src/lib/setEdgeHeader.ts
+++ b/packages/wordpress-kit/src/lib/setEdgeHeader.ts
@@ -1,12 +1,11 @@
 import { ServerResponse } from 'http';
 
-const defaultCacheControlValue =
-	'public, s-maxage=10, stale-while-revalidate=600';
+const defaultCacheControlValue = 'public, s-maxage=600';
 
 /**
  * Sets response headers for edge caching.
  * @param options.res response object
- * @param options.cacheControl optional value to override cache control header, defaults to 'public, s-maxage=10, stale-while-revalidate=600'
+ * @param options.cacheControl optional value to override cache control header, defaults to 'public, s-maxage=600'
  */
 const setEdgeHeader = ({
 	res,

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-cache-control-header.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/setting-cache-control-header.md
@@ -21,7 +21,7 @@ that is passed into the DrupalState helper.
 The default Cache-Control header value is as follows:
 
 ```http
-Cache-Control: public, s-maxage=10, stale-while-revalidate=600
+Cache-Control: public, s-maxage=600
 ```
 
 In the next section, we will explain how to override this default value.

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/setting-cache-control-header.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/setting-cache-control-header.md
@@ -21,7 +21,7 @@ request is sent along it will be cached at the edge.
 The default cache-control header is the following:
 
 ```http
-Cache-Control: public, s-maxage=10, stale-while-revalidate=600
+Cache-Control: public, s-maxage=600
 ```
 
 To override the default, you may pass in your own cache-control header:

--- a/web/docs/Packages/drupal-kit/modules.md
+++ b/web/docs/Packages/drupal-kit/modules.md
@@ -1,7 +1,7 @@
 ---
-id: "modules"
-title: "decoupled-kit-js"
-sidebar_label: "Exports"
+id: 'modules'
+title: 'decoupled-kit-js'
+sidebar_label: 'Exports'
 sidebar_position: 0.5
 custom_edit_url: null
 ---
@@ -18,18 +18,19 @@ custom_edit_url: null
 
 ### defaultFetch
 
-▸ **defaultFetch**(`apiUrl`, `requestInit?`, `res?`, `cacheControl?`): `Promise`<`Response`\>
+▸ **defaultFetch**(`apiUrl`, `requestInit?`, `res?`, `cacheControl?`):
+`Promise`<`Response`\>
 
 fetch data from a JSON:API endpoint, bubbling up surrogate keys if possible
 
 #### Parameters
 
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `apiUrl` | `RequestInfo` | `undefined` | the api url for the JSON:API endpoint |
-| `requestInit` | `RequestInit` | `{}` | fetch initialization object |
-| `res?` | `boolean` \| `ServerResponse`<`IncomingMessage`\> | `undefined` | response object |
-| `cacheControl` | `string` | `defaultCacheControlValue` | optional value to override cache control header, defaults to 'public, s-maxage=10, stale-while-revalidate=600' |
+| Name           | Type                                              | Default value              | Description                                                                         |
+| :------------- | :------------------------------------------------ | :------------------------- | :---------------------------------------------------------------------------------- |
+| `apiUrl`       | `RequestInfo`                                     | `undefined`                | the api url for the JSON:API endpoint                                               |
+| `requestInit`  | `RequestInit`                                     | `{}`                       | fetch initialization object                                                         |
+| `res?`         | `boolean` \| `ServerResponse`<`IncomingMessage`\> | `undefined`                | response object                                                                     |
+| `cacheControl` | `string`                                          | `defaultCacheControlValue` | optional value to override cache control header, defaults to 'public, s-maxage=600' |
 
 #### Returns
 
@@ -41,7 +42,7 @@ a promise containing the data for the JSON:API response
 
 [drupal-kit/src/lib/defaultFetch.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/drupal-kit/src/lib/defaultFetch.ts#L17)
 
-___
+---
 
 ### setSurrogateKeyHeader
 
@@ -51,10 +52,10 @@ Adds an aggregated list of surrogate keys in the working response.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `keys` | ``null`` \| `string` | Value for surrogate-key header in API response. |
-| `res` | `ServerResponse`<`IncomingMessage`\> | The active http.ServerResponse object. |
+| Name   | Type                                 | Description                                     |
+| :----- | :----------------------------------- | :---------------------------------------------- |
+| `keys` | `null` \| `string`                   | Value for surrogate-key header in API response. |
+| `res`  | `ServerResponse`<`IncomingMessage`\> | The active http.ServerResponse object.          |
 
 #### Returns
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Server side rendered responses now use a Cache-Control header of public, s-maxage=600
- Documentation updated accordingly.

## Where were the changes made?
`drupal-kit`
`wordpress-kit`
./web

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Starter observed to run normally with updated headers.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->