### PR TITLE
DB-5240: loose ends for GraphQL Caching Docs

### DIFF
--- a/web/docs/Backend Starters/Decoupled WordPress/caching-considerations.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/caching-considerations.md
@@ -63,3 +63,10 @@ composer require wpackagist-plugin/pantheon-advanced-page-cache
 ```
 
 - In the WordPress dashboard, enable the Pantheon Advanced Page Cache plugin.
+
+### Taking Advantage of GraphQL Caching on the Front-end
+
+For details on how to make full use of WPGraphQL Network Caching in your
+front-end application, see the
+[Surrogate Key Based Cache Purging](/docs/frontend-starters/nextjs/nextjs-wordpress/next-wordpress-surrogate-key-caching)
+entry in the Front-end Starters section of the documentation.

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
@@ -14,7 +14,9 @@ See https://docs.fastly.com/en/guides/working-with-surrogate-keys for more
 information on working with surrogate keys.
 
 This guide uses WordPress with the
-[WPGraphQL plugin](https://wordpress.org/plugins/wp-graphql/) and the
+[WPGraphQL plugin](https://wordpress.org/plugins/wp-graphql/),
+[WPGraphQL Smart Cache plugin](https://github.com/wp-graphql/wp-graphql-smart-cache)
+and the
 [Pantheon Advanced Page Cache plugin](https://wordpress.org/plugins/pantheon-advanced-page-cache/)
 installed.
 
@@ -26,27 +28,41 @@ sequenceDiagram
     participant B as Next.js + wordpress-kit
     participant C as WordPress
     A->>B: Request a page that fetches from WordPress
-    B->>C: Add Pantheon-SKey header to request
+    B->>C: Add Pantheon-SKey header to request via GET
     C->>B: Surrogate-Key-Raw header included on response
     B->>A: Set Surrogate-Key header on outgoing response to browser
 ```
 
 The `GraphqlClientFactory` class from our `@pantheon-systems/wordpress-kit` npm
-package adds the `Pantheon-Debug` header to each request. Responses from
-WordPress will contain the `Surrogate-Key` header. With these keys, your
+package adds the `Pantheon-Skey` header to each request and uses the GET method
+by default to take advantage of WPGraphQL Smart Cache network caching. Responses
+from WordPress will contain the `Surrogate-Key` header. With these keys, your
 frontend can be instructed to purge content from a cache when the content in
 WordPress changes.
 
 ## How To Ensure Headers Are Set On Custom Routes
 
+:::note
+
+The Decoupled Kit
+[WordPress Back-end Starter Project](../../../Backend%20Starters/Decoupled%20WordPress/creating-new-project.md)
+and [WordPress Next.js Starter Kit](./intro.md) handle the configuration below
+automatically.
+
+:::
+
 - The WordPress backend has the
   [WPGraphQL plugin](https://wordpress.org/plugins/wp-graphql/) installed and
   configured
 - The WordPress backend has the
+  [WPGraphQL Smart Cache plugin](https://github.com/wp-graphql/wp-graphql-smart-cache)
+  installed and configured, with the Object Cache option disabled
+- The WordPress backend has the
   [Pantheon Advanced Page Cache plugin](https://wordpress.org/plugins/pantheon-advanced-page-cache/)
   installed and configured
 - The route fetches data using the `@pantheon-systems/wordpress-kit` Graphql
-  client or requests to WordPress include the `Pantheon-SKey: 1` header
+  client or requests to WordPress are made using the GET method and include the
+  `Pantheon-SKey: 1` header
   - in order to see the headers, you must use the `client.rawRequest()` method.
 - The headers must be added to the outgoing response from Next.js in
   `getServerSideProps` (see


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Minor updates and cross linking between WP Caching Considerations and WP Next Surrogate Key Based Purging.

## Where were the changes made?

Docs.

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

Ran the docs site locally.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->