### PR TITLE
Fix missing dependency

### DIFF
--- a/.changeset/short-starfishes-taste.md
+++ b/.changeset/short-starfishes-taste.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Fix missing dependency - moved Handlebars from dev to prod dependencies.

--- a/packages/create-pantheon-decoupled-kit/package.json
+++ b/packages/create-pantheon-decoupled-kit/package.json
@@ -54,7 +54,6 @@
 		"chalk": "^5.2.0",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.17.4",
-		"handlebars": "^4.7.7",
 		"prettier": "^2.8.3",
 		"rimraf": "^4.1.2",
 		"vite-node": "^0.28.3",
@@ -63,6 +62,7 @@
 	"dependencies": {
 		"diff": "^5.1.0",
 		"fs-extra": "^11.1.0",
+		"handlebars": "^4.7.7",
 		"inquirer": "^9.1.4",
 		"klaw": "^4.1.0",
 		"minimist": "^1.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,7 @@ importers:
     dependencies:
       diff: 5.1.0
       fs-extra: 11.1.0
+      handlebars: 4.7.7
       inquirer: 9.1.4
       klaw: 4.1.0
       minimist: 1.2.7
@@ -142,7 +143,6 @@ importers:
       chalk: 5.2.0
       chokidar: 3.5.3
       esbuild: 0.17.4
-      handlebars: 4.7.7
       prettier: 2.8.3
       rimraf: 4.1.2
       vite-node: 0.28.3


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Handlebars moved to prod dependencies, which is the correct place 😅 

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Will push another canary release after this is merged to confirm the fix is working as intended.
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->