### PR TITLE
DB-5253: Use CLI to generate starters for mirrors

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v2
         with:
-          version: 7.17.1
+          version: 7.26.3
       - name: Setup nodejs
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -21,20 +21,41 @@ jobs:
       matrix:
         # define package to repository map
         include:
-          - local_path: 'starters/next-drupal-starter'
-            split_repository: 'next-drupal-starter-umami-canary'
-          - local_path: 'starters/next-drupal-starter'
-            split_repository: 'next-drupal-starter-default-canary'
-          - local_path: 'starters/gatsby-wordpress-starter'
-            split_repository: 'gatsby-wordpress-starter-default-canary'
-          - local_path: 'starters/next-wordpress-starter'
-            split_repository: 'next-wordpress-starter-default-canary'
+          # next-drupal-starter + umami
+          - local_path: "starters/next-drupal-starter-umami-canary-generated"
+            split_repository: "next-drupal-starter-umami-canary"
+            generator_cmd: "next-drupal next-drupal-umami-addon --appName next-drupal-starter-umami-canary
+              --noInstall --force --silent"
+          # next-drupal-starter default
+          - local_path: "starters/next-drupal-starter-default-canary-generated"
+            split_repository: "next-drupal-starter-default-canary"
+            generator_cmd: "next-drupal --appName
+              test-next-drupal-starter-default --noInstall --force
+              --silent"
+          # gatsby-wordpress-starter
+          - local_path: "starters/gatsby-wordpress-starter-canary-generated"
+            split_repository: "gatsby-wordpress-starter-canary"
+            generator_cmd: "gatsby-wp --appName test-gatsby--wordpress-starter
+              --noInstall --force --silent"
+          # next-wordpress-starter
+          - local_path: "starters/next-wordpress-starter-canary-generated"
+            split_repository: "next-wordpress-starter-canary"
+            generator_cmd: "next-wp --appName test-next-wordpress-starter
+              --noInstall --force --silent"
+
           # canary docs site
           - local_path: 'web'
             split_repository: 'decoupled-kit-docs-canary'
 
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - uses: actions/checkout@v3
+      # install canary version of the CLI
+      - run: npm i --global create-pantheon-decoupled-kit@canary
+      # run the command to generate the starter in the matrix.local_path directory
+      - run: create-pantheon-decoupled-kit ${{ matrix.generator_cmd }} --outDir ./${{ matrix.local_path }}
       # Add Github workflow before split
       - run: |
           mkdir -p ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows
@@ -59,13 +80,13 @@ jobs:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": "GitHub Action result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "text": "GitHub Action result: ${{ job.status }}\n${{ github.ref }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Action result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    "text": "GitHub Action result: ${{ job.status }}\n${{ github.ref }}"
                   }
                 }
               ]

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -35,7 +35,7 @@ jobs:
           # gatsby-wordpress-starter
           - local_path: "starters/gatsby-wordpress-starter-canary-generated"
             split_repository: "gatsby-wordpress-starter-canary"
-            generator_cmd: "gatsby-wp --appName test-gatsby--wordpress-starter
+            generator_cmd: "gatsby-wp --appName test-gatsby-wordpress-starter
               --noInstall --force --silent"
           # next-wordpress-starter
           - local_path: "starters/next-wordpress-starter-canary-generated"

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v2
         with:
-          version: 7.17.1
+          version: 7.26.3
       - name: Setup nodejs
         uses: actions/setup-node@v3
         with:
@@ -49,13 +49,13 @@ jobs:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": "GitHub Action result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "text": "GitHub Action result: ${{ job.status }}\n${{ github.ref }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Action result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    "text": "GitHub Action result: ${{ job.status }}\n${{ github.ref }}"
                   }
                 }
               ]
@@ -76,18 +76,34 @@ jobs:
       matrix:
         # define package to repository map
         include:
-          - local_path: 'starters/gatsby-wordpress-starter'
-            split_repository: 'gatsby-wordpress-starter'
-          - local_path: 'starters/next-drupal-starter'
-            split_repository: 'next-drupal-starter'
-          - local_path: 'starters/next-wordpress-starter'
-            split_repository: 'next-wordpress-starter'
+          # next-drupal-starter
+          - local_path: "starters/next-drupal-starter-generated"
+            split_repository: "next-drupal-starter"
+            generator_cmd: "next-drupal next-drupal-umami-addon --appName @pantheon-systems/next-drupal-starter
+              --noInstall --force --silent"
+          # gatsby-wordpress-starter
+          - local_path: "starters/gatsby-wordpress-starter-generated"
+            split_repository: "gatsby-wordpress-starter-canary"
+            generator_cmd: "gatsby-wp --appName @pantheon-systems/gatsby-wordpress-starter
+              --noInstall --force --silent"
+          # next-wordpress-starter
+          - local_path: "starters/next-wordpress-starter-generated"
+            split_repository: "next-wordpress-starter-canary"
+            generator_cmd: "next-wp --appName @pantheon-systems/next-wordpress-starter
+              --noInstall --force --silent"
+
             # docs site
           - local_path: 'web'
             split_repository: 'decoupled-kit-docs'
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/checkout@v3
+      # install CLI
+      - run: npm i --global create-pantheon-decoupled-kit
+      # run the command to generate the starter in the matrix.local_path directory
+      - run: create-pantheon-decoupled-kit ${{ matrix.generator_cmd }} --outDir ./${{ matrix.local_path }}
       # no tag
       - if: "!startsWith(github.ref, 'refs/tags/')"
         uses: 'danharrin/monorepo-split-github-action@v2.3.0'

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ locally:
 - Node.js version 18 LTS. We recommend using
   [nvm](https://github.com/nvm-sh/nvm)
 - [npm](https://docs.npmjs.com/cli/v8/commands/npm) version 9.x.x
-- [pnpm](https://pnpm.io/installation) version 7.17.1
+- [pnpm](https://pnpm.io/installation) version 7.26.3
 
   We recommend using npm. Run the following command to install:
 

--- a/web/docs/contributing.md
+++ b/web/docs/contributing.md
@@ -20,7 +20,7 @@ locally:
 
 - Nodejs version 16 LTS. We recomemnd using [nvm](https://github.com/nvm-sh/nvm)
 - [npm](https://docs.npmjs.com/cli/v8/commands/npm) version 8.x.x
-- [pnpm](https://pnpm.io/installation) version 7.17.1
+- [pnpm](https://pnpm.io/installation) version 7.26.3
 
   We recommend using npm. Run the following command to install:
 


### PR DESCRIPTION
<!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Use the CLI in CI to generate starters before split action
- Fixed outdated pnpm version on some docs
- Fixed? the github action output for the slack message; it should now give us slightly more info

## Where were the changes made?
GitHub Actions split jobs
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
PoC on personal GitHub account
## Additional information
<!--- Add any other context about the feature or fix here. --->
Honestly did not think it would work. (famous last words)
<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->