### PR TITLE
DB-5402: Add-on docs for Advanced Custom Fields.

### DIFF
--- a/web/docs/Backend Starters/Decoupled WordPress/add-ons.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/add-ons.md
@@ -5,11 +5,9 @@ slug: '/backend-starters/decoupled-wordpress/add-ons'
 sidebar_position: 6
 ---
 
-## Add-ons that can be used for Decoupled WordPress
+## Decoupled Kit ACF Plugin
 
-### Decoupled Kit ACF Plugin
-
-#### Installation
+### Installation
 
 <!--- TODO: Update the Plugin link with WordPress.org plugin when it's hosted there --->
 
@@ -17,44 +15,45 @@ To install the
 [Decoupled Kit ACF](https://github.com/pantheon-systems/decoupled-kit-acf)
 plugin, follow these steps:
 
-1. Log in to your Decoupled WordPress dashboard.
+1. Log in to your WordPress dashboard.
 1. Go to **Plugins** in the left-hand menu.
-1. Find the plugin Decoupled Kit ACF from list of installed plugins.
+1. Find Decoupled Kit ACF in the list of installed plugins.
 1. Click the **Activate** button under the plugin's name.
 
 :::note
 
+The
 [Advanced Custom Fields](https://wordpress.org/plugins/advanced-custom-fields/)
 &
 [WPGraphQL for Advanced Custom Fields](https://github.com/wp-graphql/wp-graphql-acf)
-will be activated too as Decoupled Kit ACF is depended on them.
+plugins will also be activated since this plugin depends on them.
 
 :::
 
-#### Usage
+### Usage
 
-The Decoupled Kit ACF plugin provides a example ACF fields. These example field
-gets created when the plugin is activated.
+The Decoupled Kit ACF plugin provides an example ACF field group called
+**Related Content**. This field group will be created when the plugin is
+activated.
 
-To view this custom field, create/edit any post. The create/edit post form will
-have a new field name **Related Content**. This field can be used to refer any
-other post into the current post.
+To view this custom field, create or edit any post. The post form will have a
+new field named **Related Content**. This field can be used to associate any
+other post with the current post.
 
-All the required configuration for the **Related Content** advance custom field
-is setup so that it can be used in GraphQL queries.
+All the required configuration for the **Related Content** advanced custom field
+group is configured so that it can be used in GraphQL queries.
 
 :::note
 
-The Custom Field Related Content created as an example won't be listed under the
-Advanced Custom Fields plugin listing page. Currently this a limitation with
-Advanced Custom Fields plugin to know more about it refer the
+Field groups registered via code are not visible in the Advanced Custom Fields
+admin page. As a result, the Related Content field group provided by the plugin
+will not display. More information can be found in the
 [official documentation](https://www.advancedcustomfields.com/resources/register-fields-via-php/#getting-started)
 of Advanced Custom Fields.
 
 :::
 
-#### Contributing
+### Contributing
 
-Contributions are welcome! If you find a bug or have a feature request, please
-create an issue on the
+If you find a bug or have a feature request, please create an issue on the
 [GitHub repository](https://github.com/pantheon-systems/decoupled-kit-acf).

--- a/web/docs/Backend Starters/Decoupled WordPress/add-ons.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/add-ons.md
@@ -1,0 +1,60 @@
+---
+id: 'add-ons'
+title: 'Add-ons'
+slug: '/backend-starters/decoupled-wordpress/add-ons'
+sidebar_position: 6
+---
+
+## Add-ons that can be used for Decoupled WordPress
+
+### Decoupled Kit ACF Plugin
+
+#### Installation
+
+<!--- TODO: Update the Plugin link with WordPress.org plugin when it's hosted there --->
+
+To install the
+[Decoupled Kit ACF](https://github.com/pantheon-systems/decoupled-kit-acf)
+plugin, follow these steps:
+
+1. Log in to your Decoupled WordPress dashboard.
+1. Go to **Plugins** in the left-hand menu.
+1. Find the plugin Decoupled Kit ACF from list of installed plugins.
+1. Click the **Activate** button under the plugin's name.
+
+:::note
+
+[Advanced Custom Fields](https://wordpress.org/plugins/advanced-custom-fields/)
+&
+[WPGraphQL for Advanced Custom Fields](https://github.com/wp-graphql/wp-graphql-acf)
+will be activated too as Decoupled Kit ACF is depended on them.
+
+:::
+
+#### Usage
+
+The Decoupled Kit ACF plugin provides a example ACF fields. These example field
+gets created when the plugin is activated.
+
+To view this custom field, create/edit any post. The create/edit post form will
+have a new field name **Related Content**. This field can be used to refer any
+other post into the current post.
+
+All the required configuration for the **Related Content** advance custom field
+is setup so that it can be used in GraphQL queries.
+
+:::note
+
+The Custom Field Related Content created as an example won't be listed under the
+Advanced Custom Fields plugin listing page. Currently this a limitation with
+Advanced Custom Fields plugin to know more about it refer the
+[official documentation](https://www.advancedcustomfields.com/resources/register-fields-via-php/#getting-started)
+of Advanced Custom Fields.
+
+:::
+
+#### Contributing
+
+Contributions are welcome! If you find a bug or have a feature request, please
+create an issue on the
+[GitHub repository](https://github.com/pantheon-systems/decoupled-kit-acf).

--- a/web/docs/Backend Starters/Decoupled WordPress/caching-considerations.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/caching-considerations.md
@@ -2,7 +2,7 @@
 id: 'caching-considerations'
 title: 'Caching Considerations'
 slug: '/backend-starters/decoupled-wordpress/caching-considerations'
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 With the appropriate configuration, WordPress can be configured to cache GraphQL

--- a/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/add-ons.md
+++ b/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/add-ons.md
@@ -17,7 +17,7 @@ added to your project.
 ### Before You Begin
 
 - Install and activate the
-  [WP Advanced Custom Fields Plugin](https://wordpress.org/plugins/advanced-custom-fields/).
+  [Decoupled Kit Advanced Custom Fields Plugin](/docs/backend-starters/decoupled-wordpress/add-ons#decoupled-kit-acf-plugin).
 
 - Familiarize yourself with the
   [Create Pantheon Decoupled Kit CLI](https://www.npmjs.com/package/create-pantheon-decoupled-kit/).
@@ -30,7 +30,6 @@ added to your project.
   [here](https://www.advancedcustomfields.com/resources/).
 
   :::
-
 
 ### Usage
 

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/add-ons.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/add-ons.md
@@ -17,7 +17,7 @@ added to your project.
 ### Before You Begin
 
 - Install and activate the
-  [WP Advanced Custom Fields Plugin](https://wordpress.org/plugins/advanced-custom-fields/).
+  [Decoupled Kit Advanced Custom Fields Plugin](/docs/backend-starters/decoupled-wordpress/add-ons#decoupled-kit-acf-plugin).
 
 - Familiarize yourself with the
   [Create Pantheon Decoupled Kit CLI](https://www.npmjs.com/package/create-pantheon-decoupled-kit/).


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
A new entry titled ‘Add-ons’ is added to the Decoupled Kit developer docs under Backend Starters → Decoupled WordPress.

## Where were the changes made?
In the documentation part of  Backend Starters → Decoupled WordPress.