### PR TITLE
DB-5253: Fix workflow files output repo

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -22,26 +22,32 @@ jobs:
         # define package to repository map
         include:
           # next-drupal-starter + umami
-          - local_path: "starters/next-drupal-starter-umami-canary-generated"
-            split_repository: "next-drupal-starter-umami-canary"
-            generator_cmd: "next-drupal next-drupal-umami-addon --appName next-drupal-starter-umami-canary
-              --noInstall --force --silent"
+          - local_path: 'starters/next-drupal-starter-umami-canary-generated'
+            split_repository: 'next-drupal-starter-umami-canary'
+            generator_cmd:
+              'next-drupal next-drupal-umami-addon --appName
+              @pantheon-systems/next-drupal-starter-umami-canary --noInstall
+              --force --silent'
           # next-drupal-starter default
-          - local_path: "starters/next-drupal-starter-default-canary-generated"
-            split_repository: "next-drupal-starter-default-canary"
-            generator_cmd: "next-drupal --appName
-              test-next-drupal-starter-default --noInstall --force
-              --silent"
+          - local_path: 'starters/next-drupal-starter-default-canary-generated'
+            split_repository: 'next-drupal-starter-default-canary'
+            generator_cmd:
+              'next-drupal --appName
+              @pantheon-systems/next-drupal-starter-default-canary --noInstall
+              --force --silent'
           # gatsby-wordpress-starter
-          - local_path: "starters/gatsby-wordpress-starter-canary-generated"
-            split_repository: "gatsby-wordpress-starter-canary"
-            generator_cmd: "gatsby-wp --appName test-gatsby-wordpress-starter
-              --noInstall --force --silent"
+          - local_path: 'starters/gatsby-wordpress-starter-canary-generated'
+            split_repository: 'gatsby-wordpress-starter-default-canary'
+            generator_cmd:
+              'gatsby-wp --appName
+              @pantheon-systems/gatsby-wordpress-starter-canary --noInstall
+              --force --silent'
           # next-wordpress-starter
-          - local_path: "starters/next-wordpress-starter-canary-generated"
-            split_repository: "next-wordpress-starter-canary"
-            generator_cmd: "next-wp --appName test-next-wordpress-starter
-              --noInstall --force --silent"
+          - local_path: 'starters/next-wordpress-starter-canary-generated'
+            split_repository: 'next-wordpress-starter-default-canary'
+            generator_cmd:
+              'next-wp --appName @pantheon-systems/next-wordpress-starter-canary
+              --noInstall --force --silent'
 
           # canary docs site
           - local_path: 'web'
@@ -52,10 +58,13 @@ jobs:
         with:
           node-version: 18
       - uses: actions/checkout@v3
-      # install canary version of the CLI
+        if: ${{ matrix.generator_cmd }}
+        # install canary version of the CLI
       - run: npm i --global create-pantheon-decoupled-kit@canary
-      # run the command to generate the starter in the matrix.local_path directory
-      - run: create-pantheon-decoupled-kit ${{ matrix.generator_cmd }} --outDir ./${{ matrix.local_path }}
+        if: ${{ matrix.generator_cmd }}
+        # run the command to generate the starter in the matrix.local_path directory
+      - run: |
+          create-pantheon-decoupled-kit ${{ matrix.generator_cmd }} --outDir ./${{ matrix.local_path }}
       # Add Github workflow before split
       - run: |
           mkdir -p ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -77,20 +77,23 @@ jobs:
         # define package to repository map
         include:
           # next-drupal-starter
-          - local_path: "starters/next-drupal-starter-generated"
-            split_repository: "next-drupal-starter"
-            generator_cmd: "next-drupal next-drupal-umami-addon --appName @pantheon-systems/next-drupal-starter
-              --noInstall --force --silent"
+          - local_path: 'starters/next-drupal-starter-generated'
+            split_repository: 'next-drupal-starter'
+            generator_cmd:
+              'next-drupal next-drupal-umami-addon --appName
+              @pantheon-systems/next-drupal-starter --noInstall --force --silent'
           # gatsby-wordpress-starter
-          - local_path: "starters/gatsby-wordpress-starter-generated"
-            split_repository: "gatsby-wordpress-starter-canary"
-            generator_cmd: "gatsby-wp --appName @pantheon-systems/gatsby-wordpress-starter
-              --noInstall --force --silent"
+          - local_path: 'starters/gatsby-wordpress-starter-generated'
+            split_repository: 'gatsby-wordpress-starter'
+            generator_cmd:
+              'gatsby-wp --appName @pantheon-systems/gatsby-wordpress-starter
+              --noInstall --force --silent'
           # next-wordpress-starter
-          - local_path: "starters/next-wordpress-starter-generated"
-            split_repository: "next-wordpress-starter-canary"
-            generator_cmd: "next-wp --appName @pantheon-systems/next-wordpress-starter
-              --noInstall --force --silent"
+          - local_path: 'starters/next-wordpress-starter-generated'
+            split_repository: 'next-wordpress-starter'
+            generator_cmd:
+              'next-wp --appName @pantheon-systems/next-wordpress-starter
+              --noInstall --force --silent'
 
             # docs site
           - local_path: 'web'
@@ -100,10 +103,14 @@ jobs:
         with:
           node-version: 18
       - uses: actions/checkout@v3
-      # install CLI
+        # install CLI
+        if: ${{ matrix.generator_cmd }}
       - run: npm i --global create-pantheon-decoupled-kit
-      # run the command to generate the starter in the matrix.local_path directory
-      - run: create-pantheon-decoupled-kit ${{ matrix.generator_cmd }} --outDir ./${{ matrix.local_path }}
+        # run the command to generate the starter in the matrix.local_path directory
+        if: ${{ matrix.generator_cmd }}
+      - run:
+          create-pantheon-decoupled-kit ${{ matrix.generator_cmd }} --outDir
+          ./${{ matrix.local_path }}
       # no tag
       - if: "!startsWith(github.ref, 'refs/tags/')"
         uses: 'danharrin/monorepo-split-github-action@v2.3.0'


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
A few things are not working with the latest CI changes:
1. the docs workspace did not get published.
2. some repo names were not correct in the split workflows
3. build failed for the two repos that were _correct_

1 and 2 should hopefully be solved by the changes below. I am still a bit stumped as to why the builds failed for the 2 splits that were correct.
My guess is that these repos have the `.env.development.local` file inside the repo, even though they should be gitignored, which is causing the builds to fail because that file is basically empty. 

Another interesting development is that [the `.gitignore` file which I would expect to be committed to the split repo, instead was renamed to `.npmignore`](https://github.com/pantheon-systems/next-drupal-starter-umami-canary/commit/bcfe187bb1d498ef59eec9819fd47fb6cd1a216c#diff-34958b02363eec9a904716f0b4a8782b021c6b33b2e8599019e36c88e045240b). I'm not sure why exactly, but this causes `.gitignore`d files like `.env.development.local` to show up in the git repo. I'm not sure if that file is causing builds to fail, but I wanted to see if this helped at all before diving into the failed builds.


## Where were the changes made?
split repo workflow files
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->