### PR TITLE
Add conditional for gatsby-plugin-pnpm in gastby-config

### DIFF
--- a/.changeset/red-kings-help.md
+++ b/.changeset/red-kings-help.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[gatsby-wp] Add conditinal to gatsby-config to avoid loading missing plugins

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/gatsby-config.js.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/gatsby-config.js.hbs
@@ -99,12 +99,13 @@ module.exports = {
 				icon: `static/favicon.ico`,
 			},
 		},
-
 		/**
 		 * this (optional) plugin enables Progressive Web App + Offline functionality
 		 * To learn more, visit: https://gatsby.dev/offline
 		 */
 		// `gatsby-plugin-offline`,
+		{{#if gatsbyPnpmPlugin}}
 		'gatsby-plugin-pnpm',
+		{{/if}}
 	],
 }


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Our canary build for the gatsby-wp starter failed due to this plugin missing in the package.json (expected), but still defined in the `gatsby-config.js`. This change will ensure a starter generated wtihout pnpm does not load this plugin in `gatsby-config.js`
## Where were the changes made?
CLI package > gatsby-wp templates
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->