### PR TITLE
Remove .npmignores from project templates

### DIFF
--- a/.changeset/wise-impalas-yawn.md
+++ b/.changeset/wise-impalas-yawn.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Removed .npmignore from project templates

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/.npmignore
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/.npmignore
@@ -1,1 +1,0 @@
-!.gitignore

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/.npmignore
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/.npmignore
@@ -1,1 +1,0 @@
-!.gitignore

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/.npmignore
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/.npmignore
@@ -1,1 +1,0 @@
-!.gitignore


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Remove .npmignore from the templates. They shouldn't be needed anymore.
Must have missed this with the previous ticket to change the .gitignore strategy.
## Where were the changes made?
cli > project templates
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->