### PR TITLE
DB-5636: Ensure latest versions are published

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 		"build:starters": "pnpm --filter './starters/**' build",
 		"ci:publish": "changeset publish",
 		"ci:version": "./scripts/ci-version",
-		"cli:get-versions": "pnpm --filter './packages/create-pantheon-decoupled-kit' get-versions",
 		"dev:gatsby-wp": "pnpm --filter './starters/gatsby-wordpress-starter' develop",
 		"dev:next-drupal": "pnpm --filter './starters/next-drupal-starter' dev",
 		"dev:next-wp": "pnpm --filter './starters/next-wordpress-starter' dev",

--- a/scripts/ci-version
+++ b/scripts/ci-version
@@ -8,4 +8,4 @@ pnpm changeset version
 # to use for our dependencies in the starter templates. Thus, canary releases
 # will ship with canary tagged versions of packages and regular
 # releases will ship with the latest released versions
-pnpm cli:get-versions
+pnpm build:cli


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
This should ensure the `create-pdk`'s `bin.js` includes the very latest versions when we publish. Without the build, I think our published versions will be one behind, but this should fix it.
@backlineint Would making this build a `prepublish` step make more sense?
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->