### PR TITLE
DB-5055: tailwindcss addon

### DIFF
--- a/.changeset/proud-eels-dress.md
+++ b/.changeset/proud-eels-dress.md
@@ -1,0 +1,10 @@
+---
+'create-pantheon-decoupled-kit': minor
+---
+
+Added a new action: `addDependencies`. This action allows a generator to add
+dependencies to the `package.json` at the specified `outDir`.
+
+Added a new add-on generator: `tailwindcss-addon`. This generator adds necessary
+dependencies and configs to use with `@pantheon-systems` dependency that rely on
+`tailwindcss`.

--- a/packages/create-pantheon-decoupled-kit/__tests__/actionRunner.test.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/actionRunner.test.ts
@@ -6,6 +6,7 @@ vi.mock('../src/actions', () => ({
 	addWithDiff: vi.fn(),
 	runInstall: vi.fn(),
 	runLint: vi.fn(),
+	addDependencies: vi.fn(),
 }));
 
 const templateData = [

--- a/packages/create-pantheon-decoupled-kit/__tests__/addDependencies.test.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/addDependencies.test.ts
@@ -1,0 +1,100 @@
+import * as actions from '../src/actions/index';
+import fs from 'fs-extra';
+import path from 'path';
+import process from 'process';
+
+vi.mock('inquirer');
+
+const pkgPath = path.resolve(
+	process.cwd(),
+	'__tests__',
+	'templates',
+	'addDependencies',
+	'package.json',
+);
+
+const globalData = {
+	_: ['test-diff'],
+	// 'workaround' for tests to work
+	templateRootDir: `${process.cwd()}/__tests__/`,
+	outDir: `${process.cwd()}/__tests__/templates/addDependencies`,
+	force: false,
+	silent: false,
+};
+
+const emptyPkgJson = {
+	name: 'add-dependencies',
+	version: '1.0.0',
+	description: 'It should add dependencies',
+	keywords: [],
+	author: '',
+	license: 'ISC',
+};
+
+describe('addWithDiff()', () => {
+	beforeEach((context) => {
+		fs.writeFileSync(pkgPath, JSON.stringify(emptyPkgJson));
+
+		context.addDepsSpy = vi.spyOn(actions, 'addDependencies');
+		context.readFileSpy = vi.spyOn(fs, 'readFileSync');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		fs.unlinkSync(pkgPath);
+	});
+
+	it('should read from  the package.json of the outDir', ({
+		addDepsSpy,
+		readFileSpy,
+	}) => {
+		const data = Object.assign({}, globalData);
+		actions.addDependencies({ data });
+		expect(readFileSpy).toHaveBeenCalled();
+		expect(readFileSpy).toHaveReturnedWith(JSON.stringify(emptyPkgJson));
+		expect(addDepsSpy).toHaveBeenCalled();
+	});
+
+	it('should write to the package.json of the outDir with dependencies in `data`', ({
+		addDepsSpy,
+	}) => {
+		const data = Object.assign(
+			{ dependencies: { 'test-dep': '0.0.0' } },
+			globalData,
+		);
+		actions.addDependencies({ data });
+		const result = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+		expect(result.dependencies).toEqual(data.dependencies);
+		expect(addDepsSpy).toHaveBeenCalled();
+	});
+
+	it('should write to the package.json of the outDir with devDependencies in `data`', ({
+		addDepsSpy,
+	}) => {
+		const data = Object.assign(
+			{ devDependencies: { 'test-dep': '0.0.0' } },
+			globalData,
+		);
+		actions.addDependencies({ data });
+		const result = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+		expect(result.devDependencies).toEqual(data.devDependencies);
+		expect(addDepsSpy).toHaveBeenCalled();
+	});
+
+	it.fails('should throw an error if outDir is not valid', ({ addDepsSpy }) => {
+		const data = Object.assign({}, globalData);
+		data.outDir = '';
+		actions.addDependencies({ data });
+		expect(addDepsSpy).toThrowError('outDir is not valid');
+	});
+
+	it.fails(
+		'should throw an error if package.json is not found in outDir',
+		({ addDepsSpy }) => {
+			const data = Object.assign({}, globalData);
+			data.outDir = `${process.cwd()}/__tests__`;
+			actions.addDependencies({ data });
+			expect(addDepsSpy).toThrowError();
+		},
+	);
+});

--- a/packages/create-pantheon-decoupled-kit/__tests__/addDependencies.test.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/addDependencies.test.ts
@@ -33,6 +33,7 @@ const emptyPkgJson = {
 
 describe('addWithDiff()', () => {
 	beforeEach((context) => {
+		fs.ensureFileSync(pkgPath);
 		fs.writeFileSync(pkgPath, JSON.stringify(emptyPkgJson));
 
 		context.addDepsSpy = vi.spyOn(actions, 'addDependencies');

--- a/packages/create-pantheon-decoupled-kit/__tests__/index.test.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/index.test.ts
@@ -229,9 +229,21 @@ To see this list at any time, use the --help command.`);
 
 	it('should not console.log if "silent" arg is true', async ({ logSpy }) => {
 		process.argv = ['node', 'bin.js', 'next-wp', '--silent'];
-
 		await main(parseArgs(), decoupledKitGenerators);
 
 		expect(logSpy).toHaveBeenCalledTimes(0);
+	});
+
+	it('should console.log any nextSteps', async ({ logSpy }) => {
+		process.argv = ['node', 'bin.js', 'tailwindcss-addon'];
+
+		await main(parseArgs(), decoupledKitGenerators);
+
+		expect(logSpy).toHaveBeenNthCalledWith(
+			3,
+			`➡️ ${chalk.cyan(
+				'Follow the guide at this link to complete your tailwindcss configuration:',
+			)} ${chalk.bold.underline('https://tailwindcss.com/docs/installation')}`,
+		);
 	});
 });

--- a/packages/create-pantheon-decoupled-kit/src/actions/addDependencies.ts
+++ b/packages/create-pantheon-decoupled-kit/src/actions/addDependencies.ts
@@ -1,0 +1,71 @@
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+import { Action, isString } from '../types';
+
+/**
+ * Describes dependencies, devDependencies
+ */
+type PkgJsonDeps = {
+	[key: string]: { [key: string]: string };
+};
+
+/**
+ * Adds any dependencies and/or devDependencies
+ * from the data field
+ */
+export const addDependencies: Action = ({ data }) => {
+	if (!isString(data.outDir) || !data.outDir)
+		throw new Error('outDir is not valid');
+	const hasDeps = (arg: unknown): arg is PkgJsonDeps => {
+		if (
+			arg &&
+			typeof arg === 'object' &&
+			('dependencies' in arg || 'devDependencies' in arg)
+		) {
+			return true;
+		}
+		return false;
+	};
+	/**
+	 * 1. open package.json found in the outDir
+	 * 2. merge each dev and prod deps with their match in the package.json
+	 */
+
+	try {
+		const pkgJsonPath = path.resolve(
+			process.cwd(),
+			data.outDir,
+			'package.json',
+		);
+		const pkgJson = JSON.parse(
+			fs.readFileSync(pkgJsonPath, 'utf-8'),
+		) as PkgJsonDeps;
+		if (hasDeps(data)) {
+			console.log(
+				chalk.green(
+					`Adding the following to ${chalk.white.bold('package.json')}...\n`,
+				),
+			);
+			for (const key of ['dependencies', 'devDependencies']) {
+				if (!data[key]) continue;
+				if (!pkgJson[key]) {
+					pkgJson[key] = {};
+				}
+				console.log(
+					chalk.white(`${key}: ${JSON.stringify(data[key], null, 2)}`),
+				),
+					Object.assign(pkgJson[key], data[key]);
+			}
+			fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+		} else {
+			console.log(chalk.yellow('No dependencies to add.'));
+		}
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new Error(`${chalk.cyan('addDependencies:\n')} ${error.message}`);
+		}
+	}
+
+	return `${chalk.cyan('addDependencies:')} ${chalk.green('success')}`;
+};

--- a/packages/create-pantheon-decoupled-kit/src/actions/index.ts
+++ b/packages/create-pantheon-decoupled-kit/src/actions/index.ts
@@ -1,3 +1,4 @@
 export { addWithDiff } from './addWithDiff';
 export { runInstall } from './runInstall';
 export { runLint } from './runLint';
+export { addDependencies } from './addDependencies';

--- a/packages/create-pantheon-decoupled-kit/src/actions/runInstall.ts
+++ b/packages/create-pantheon-decoupled-kit/src/actions/runInstall.ts
@@ -1,12 +1,11 @@
 import chalk from 'chalk';
 import { execSync } from 'child_process';
 import whichPmRuns from 'which-pm-runs';
-import type { Action } from '../types';
+import { Action, isString } from '../types';
 
 export const runInstall: Action = ({ data }) => {
 	if (data?.noInstall) return 'skipping install';
-	if (typeof data?.outDir !== 'string')
-		throw new Error('valid outDir required');
+	if (!isString(data.outDir)) throw new Error('valid outDir required');
 
 	const getPkgManager = whichPmRuns();
 	let pkgManager: string;

--- a/packages/create-pantheon-decoupled-kit/src/generators/index.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/index.ts
@@ -4,6 +4,7 @@ import { gatsbyWp } from './gatsby-wp.generator';
 import { nextDrupalUmamiAddon } from './next-drupal-umami-addon.generator';
 import { nextWpAcfAddon } from './next-wp-acf-addon.generator';
 import { gatsbyWpAcfAddon } from './gatsby-wp-acf-addon.generator';
+import { tailwindcssAddon } from './tailwindcss-addon.generator';
 
 export const decoupledKitGenerators = [
 	nextWp,
@@ -12,4 +13,5 @@ export const decoupledKitGenerators = [
 	nextDrupalUmamiAddon,
 	nextWpAcfAddon,
 	gatsbyWpAcfAddon,
+	tailwindcssAddon,
 ] as const;

--- a/packages/create-pantheon-decoupled-kit/src/generators/tailwindcss-addon.generator.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/tailwindcss-addon.generator.ts
@@ -1,0 +1,32 @@
+import chalk from 'chalk';
+import { addWithDiff, addDependencies, runInstall } from '../actions';
+import type { DecoupledKitGenerator, DefaultAnswers } from '../types';
+
+export const tailwindcssAddon: DecoupledKitGenerator<DefaultAnswers> = {
+	name: 'tailwindcss-addon',
+	description: 'Adds tailwindcss dependencies and config files',
+	prompts: [
+		{
+			name: 'outDir',
+			message: 'Where should the output go?',
+			default: () => `${process.cwd()}/tailwindcss-addon`,
+		},
+	],
+	data: {
+		dependencies: {
+			'@tailwindcss/typography': '^0.5.9',
+		},
+		devDependencies: {
+			autoprefixer: '^10.4.12',
+			postcss: '^8.4.16',
+			tailwindcss: '^3.1.8',
+		},
+	},
+	templates: ['tailwindcss-addon'],
+	actions: [addWithDiff, addDependencies, runInstall],
+	nextSteps: [
+		`${chalk.cyan(
+			'Follow the guide at this link to complete your tailwindcss configuration:',
+		)} ${chalk.bold.underline('https://tailwindcss.com/docs/installation')}`,
+	],
+};

--- a/packages/create-pantheon-decoupled-kit/src/index.ts
+++ b/packages/create-pantheon-decoupled-kit/src/index.ts
@@ -106,6 +106,7 @@ To see this list at any time, use the --help command.`);
 
 	const actions = [];
 	const templateData: TemplateData[] = [];
+	const nextSteps: string[] = [];
 	// gather actions and template data from user input/prompts
 	for (const g of generatorsToRun) {
 		const generator = decoupledKitGenerators.find(
@@ -130,6 +131,8 @@ To see this list at any time, use the --help command.`);
 		// gather all actions and templates
 		actions.push(...generator.actions);
 		templateData.push(templateObj);
+		// gather all nextSteps
+		generator.nextSteps && nextSteps.push(...generator.nextSteps);
 	}
 	// pass the handlebars instance into data so it is available
 	// to any action that needs it
@@ -147,6 +150,7 @@ To see this list at any time, use the --help command.`);
 			chalk.bgGreen.black('Your project was generated with:'),
 			`\n\t${chalk.cyan(generatorsToRun.join('\n\t'))}`,
 		);
+	args?.silent || nextSteps.forEach((step) => console.log(`➡️ ${step}`));
 	args?.silent ||
 		console.log(
 			`${chalk.yellow('cd')} into ${chalk.bold.magenta(

--- a/packages/create-pantheon-decoupled-kit/src/templates/tailwindcss-addon/postcss.config.cjs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/tailwindcss-addon/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {},
+	},
+};

--- a/packages/create-pantheon-decoupled-kit/src/templates/tailwindcss-addon/styles/globals.css
+++ b/packages/create-pantheon-decoupled-kit/src/templates/tailwindcss-addon/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/packages/create-pantheon-decoupled-kit/src/templates/tailwindcss-addon/tailwind.config.cjs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/tailwindcss-addon/tailwind.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+	content: [
+		'./pages/**/*.{js,ts,jsx,tsx}',
+		'./components/**/*.{js,ts,jsx,tsx}',
+		'./src/**/*.{js,ts,jsx,tsx}',
+	],
+	theme: {
+		extend: {},
+	},
+	plugins: [require('@tailwindcss/typography')],
+};

--- a/packages/create-pantheon-decoupled-kit/src/types.ts
+++ b/packages/create-pantheon-decoupled-kit/src/types.ts
@@ -42,6 +42,10 @@ export interface DecoupledKitGenerator<Prompts extends Answers> {
 	 * This will give priority to the templates when de-duping.
 	 */
 	addon?: boolean;
+	/**
+	 * Any message(s) to be rendered after actions are successfully completed.
+	 */
+	nextSteps?: string[];
 }
 
 /**
@@ -52,11 +56,13 @@ export type Action = (config: ActionConfig) => Promise<string> | string;
 
 export type ActionRunner = (config: ActionRunnerConfig) => Promise<string>;
 
+type InputIndex = ParsedArgs & Answers & DataRecord;
 /**
- * Input from command line arguments and/or prompts
+ * Input from command line arguments, prompts, and generator data
  */
-export type Input = ParsedArgs & Answers;
-
+export type Input = {
+	[Property in keyof InputIndex]: InputIndex[Property];
+};
 export interface TemplateData {
 	templateDirs: string[];
 	addon: boolean;

--- a/web/docs/Frontend Starters/create-pantheon-decoupled-kit.md
+++ b/web/docs/Frontend Starters/create-pantheon-decoupled-kit.md
@@ -61,13 +61,23 @@ results. These `project` generators should be used only in conjunction with
 
 ### Add-ons
 
+There are some utility add-ons that are available to any project. These add-ons
+are:
+
+- tailwindcss-addon
+
+  This add-on will bootstrap a project with dependencies and config files
+  necessary to start using [tailwindcss](https://tailwindcss.com). Minimal
+  additional setup may be required, such as importing the css file or changing
+  the paths in the `tailwind.config.cjs`
+
 Available add-ons per project generator are as follows:
 
 | Project Generator | Available Add-ons       |
 | ----------------- | ----------------------- |
 | next-drupal       | next-drupal-umami-addon |
 | next-wp           | next-wp-acf-addon       |
-| gatsby-wp         | gastby-wp-acf-addon     |
+| gatsby-wp         | gatsby-wp-acf-addon     |
 
 For more detail on the available add-ons and their functionality, see the
 following docs:


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Added a new action, `addDependencies`, that will add any dependencies listed in a generators `data` field to the `package.json` found in the `outDir`.
- Added a new generator `tailwindcss-addon` that uses the `addDependencies` action, as well as the `addWithDiff` action to bootstrap a project with tailwindcss dependencies and configs
- Added a `nextSteps` option to generators, so that any crucial information relating specifically to the generator can be logged to the console when all actions are complete.
- Added tests for the `addDependencies` action
-Some tweaks to the `Input` type
- Added this add-on to the CLI docs.

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
cli, docs
## How have the changes been tested?
wrote tests, and used the generator on a React project created with `npm init vite`. After minimal changes (importing the proper css file and removing styles that were already there), I was able to use tailwindcss with no issues.
## Additional information

Regarding the 'nextSteps' for this addon, I am open to suggestions here on what the actual info should be for the nextSteps, as we can't know everything about the user's project to make this no config unless we add more prompts to this generator. Which maybe is what we want to do? But I think I'd rather keep the prompts for this one minimal.

And regarding the docs:  Should we have a new section for 'generic' add-ons? Or is it ok to add these under the `Add-ons` section of our CLI doc (which is  what I did here)

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->