### PR TITLE
DB-5712: Add CSR Search Input to `/pages` Layout

### DIFF
--- a/.changeset/long-yaks-lie.md
+++ b/.changeset/long-yaks-lie.md
@@ -1,0 +1,6 @@
+---
+"create-pantheon-decoupled-kit": minor
+---
+
+Added a new addon, `next-drupal-search-api-addon`. It includes the beginning of an example implementation
+of the Drupal Search API

--- a/packages/create-pantheon-decoupled-kit/src/generators/index.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/index.ts
@@ -5,6 +5,7 @@ import { nextDrupalUmamiAddon } from './next-drupal-umami-addon.generator';
 import { nextWpAcfAddon } from './next-wp-acf-addon.generator';
 import { gatsbyWpAcfAddon } from './gatsby-wp-acf-addon.generator';
 import { tailwindcssAddon } from './tailwindcss-addon.generator';
+import { nextDrupalSearchApiAddon } from './next-drupal-search-api-addon.generator';
 
 export const decoupledKitGenerators = [
 	nextWp,
@@ -14,4 +15,5 @@ export const decoupledKitGenerators = [
 	nextWpAcfAddon,
 	gatsbyWpAcfAddon,
 	tailwindcssAddon,
+	nextDrupalSearchApiAddon,
 ] as const;

--- a/packages/create-pantheon-decoupled-kit/src/generators/next-drupal-search-api-addon.generator.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/next-drupal-search-api-addon.generator.ts
@@ -1,0 +1,18 @@
+// next-drupal-search-api-addon
+import { addWithDiff, runLint } from '../actions';
+import type { DecoupledKitGenerator, DefaultAnswers } from '../types';
+
+export const nextDrupalSearchApiAddon: DecoupledKitGenerator<DefaultAnswers> = {
+	name: 'next-drupal-search-api-addon',
+	description:
+		'Example implementation of the Drupal Search API for the next-drupal starter',
+	prompts: [
+		{
+			name: 'outDir',
+			message: 'Where should the output go?',
+			default: `${process.cwd()}/next-drupal-search-api-addon`,
+		},
+	],
+	templates: ['next-drupal-search-api-addon'],
+	actions: [addWithDiff, runLint],
+};

--- a/packages/create-pantheon-decoupled-kit/src/generators/next-drupal-search-api-addon.generator.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/next-drupal-search-api-addon.generator.ts
@@ -1,4 +1,3 @@
-// next-drupal-search-api-addon
 import { addWithDiff, runLint } from '../actions';
 import type { DecoupledKitGenerator, DefaultAnswers } from '../types';
 

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/[...alias].test.jsx.snap
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/[...alias].test.jsx.snap
@@ -1,0 +1,360 @@
+// Vitest Snapshot v1
+
+exports[`<CatchAllRoute /> > should render a page 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <article
+        class="prose lg:prose-xl mt-10 mx-auto"
+      >
+        <h1>
+          Top Level Page
+        </h1>
+        <a
+          class="font-normal"
+          href="/pages"
+        >
+          Pages →
+        </a>
+        <div
+          class="mt-12 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg"
+        >
+          <div>
+            <p>
+              This is an about page. It should be available as a top level route like 
+              <code>
+                /about
+              </code>
+              .
+            </p>
+            
+
+          </div>
+        </div>
+      </article>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<CatchAllRoute /> > should render an article 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <article
+        class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
+      >
+        <section
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
+        >
+          <h1>
+            Example Top Level Article
+          </h1>
+          <a
+            class="ps-font-normal ps-cursor-pointer"
+          >
+            Back →
+          </a>
+        </section>
+        <div
+          class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
+        >
+          <div
+            class="ps-relative ps-mb-10 ps-min-h-[50vh]"
+          >
+            <img
+              alt="Example Top Level Article"
+              data-nimg="fill"
+              decoding="async"
+              sizes="100vw"
+              src="/_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2F2022-07%2Fkitties.jpg&w=1200&q=75"
+              srcset="/_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2F2022-07%2Fkitties.jpg&w=320&q=75 320w, /_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2F2022-07%2Fkitties.jpg&w=420&q=75 420w, /_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2F2022-07%2Fkitties.jpg&w=768&q=75 768w, /_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2F2022-07%2Fkitties.jpg&w=1024&q=75 1024w, /_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2F2022-07%2Fkitties.jpg&w=1200&q=75 1200w"
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; object-fit: cover; color: transparent;"
+            />
+          </div>
+        </div>
+        <div
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
+        >
+          <h2>
+            Nonummy Tristique Pulvinar Justo Primis Mi
+          </h2>
+          
+
+          <h3>
+            Ultricies Velit Dapibus Cursus Proin Magnis
+          </h3>
+          
+
+          <p>
+            Est varius. Conubia semper facilisis primis urna nec dis placerat dictum interdum dapibus dictumst phasellus phasellus neque dui posuere habitant nunc. Lorem mollis varius Sagittis Habitasse ultricies euismod euismod. Posuere cubilia platea pede. Viverra habitant praesent ac phasellus quisque vel diam fusce nisl maecenas vestibulum netus torquent Molestie volutpat metus donec cubilia. Ipsum, nec morbi lacinia sem. Nascetur sed. Justo ultrices velit hymenaeos aliquam hymenaeos potenti id.
+          </p>
+          
+
+          <h3>
+            Quis Metus Orci Nibh Dapibus
+          </h3>
+          
+
+          <p>
+            Mus porta parturient leo class. Sapien orci tincidunt mattis torquent. Pretium etiam sapien mauris commodo vestibulum potenti ipsum a, cubilia accumsan adipiscing rutrum. Egestas. Ornare aliquam nibh. Pede placerat praesent nonummy est facilisi sapien porttitor rhoncus molestie torquent. Lorem magnis non et natoque. Ipsum justo leo pharetra hymenaeos praesent pharetra hymenaeos fermentum, semper. Ultrices dolor gravida sit enim, mus. Est nam class, condimentum dis dictumst, ut ut cum magna pulvinar primis vitae imperdiet aliquet vitae id amet, justo curae; et, vitae tempor ultricies maecenas lectus ut faucibus.
+          </p>
+          
+
+          <p>
+            Vehicula. Semper convallis tempus habitant accumsan justo porta auctor Nonummy vestibulum rhoncus nam odio sociosqu blandit ut. Nostra luctus malesuada ac risus torquent massa habitant cubilia Porttitor ad lorem, tempus ridiculus vulputate iaculis. Gravida placerat suscipit. Pulvinar facilisi. Leo. Vivamus lorem diam est. Suscipit rhoncus ullamcorper leo fames viverra. Mattis posuere aliquet congue hymenaeos. Per montes. Litora. Tellus.
+          </p>
+          
+
+          <h3>
+            Convallis Porta Morbi Accumsan
+          </h3>
+          
+
+          <p>
+            In. Viverra habitasse commodo urna pharetra. Eleifend euismod. Justo volutpat, cras eu. Porta sociosqu tortor scelerisque. Orci tincidunt dictum viverra imperdiet phasellus Fames quam diam metus etiam nascetur litora, hac bibendum dictum sociis. Odio fringilla blandit elementum risus hendrerit justo suscipit, in quisque platea mollis vulputate, montes vivamus. Ipsum magnis mus erat cum phasellus at. Aliquet Ad netus vitae interdum fermentum fermentum conubia habitant. Sed penatibus hendrerit enim dictum magna, faucibus sit integer elementum tincidunt laoreet varius odio mollis. Amet vivamus morbi penatibus aptent. Montes, eget litora dictumst.
+          </p>
+          
+
+        </div>
+      </article>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/articles.test.jsx.snap
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/articles.test.jsx.snap
@@ -1,0 +1,343 @@
+// Vitest Snapshot v1
+
+exports[`<ArticleTemplate /> > should render articles 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <article
+        class="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12"
+      >
+        <section
+          class="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
+        >
+          <h1>
+            This is an Example Article
+          </h1>
+          <a
+            class="ps-font-normal ps-cursor-pointer"
+          >
+            Back →
+          </a>
+        </section>
+        <div
+          class="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg ps-shadow-lg [&*>img]:ps-rounded-lg"
+        >
+          <div
+            class="ps-relative ps-mb-10 ps-min-h-[50vh]"
+          >
+            <img
+              alt="This is an Example Article"
+              data-nimg="fill"
+              decoding="async"
+              sizes="100vw"
+              src="/_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2Fpizza.jpg&w=1200&q=75"
+              srcset="/_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2Fpizza.jpg&w=320&q=75 320w, /_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2Fpizza.jpg&w=420&q=75 420w, /_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2Fpizza.jpg&w=768&q=75 768w, /_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2Fpizza.jpg&w=1024&q=75 1024w, /_next/image?url=https%3A%2F%2Fdefault%2Fsites%2Fdefault%2Ffiles%2Fpizza.jpg&w=1200&q=75 1200w"
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; object-fit: cover; color: transparent;"
+            />
+          </div>
+        </div>
+        <div
+          class="ps-break-words ps-mt-12 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto"
+        >
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ullamcorper dignissim cras tincidunt lobortis feugiat. Augue lacus viverra vitae congue eu consequat ac felis. Vulputate sapien nec sagittis aliquam malesuada bibendum arcu vitae elementum. Pulvinar elementum integer enim neque. At tempor commodo ullamcorper a lacus vestibulum. Nec tincidunt praesent semper feugiat nibh. Nisl nisi scelerisque eu ultrices vitae auctor eu augue ut. Bibendum neque egestas congue quisque egestas diam. Pellentesque elit ullamcorper dignissim cras.
+          </p>
+          
+
+
+          <p>
+            Quis lectus nulla at volutpat diam ut venenatis tellus in. Tempus urna et pharetra pharetra. Eu consequat ac felis donec. Donec ultrices tincidunt arcu non sodales neque sodales ut. Suscipit tellus mauris a diam maecenas sed enim ut. Semper eget duis at tellus at urna condimentum mattis. Dictum fusce ut placerat orci nulla pellentesque dignissim enim. Porta lorem mollis aliquam ut porttitor leo. Eu sem integer vitae justo eget magna fermentum iaculis eu. Amet commodo nulla facilisi nullam vehicula ipsum a arcu cursus. Laoreet sit amet cursus sit amet dictum sit amet justo. Ac placerat vestibulum lectus mauris ultrices eros. Fermentum iaculis eu non diam phasellus vestibulum lorem sed. Lorem dolor sed viverra ipsum nunc aliquet bibendum enim facilisis. Odio ut sem nulla pharetra. Urna molestie at elementum eu facilisis sed odio.
+          </p>
+          
+
+
+          <p>
+            Non enim praesent elementum facilisis leo vel fringilla. Risus commodo viverra maecenas accumsan lacus vel. Eget egestas purus viverra accumsan in. Nunc congue nisi vitae suscipit tellus mauris a diam maecenas. Ipsum nunc aliquet bibendum enim. Turpis nunc eget lorem dolor sed viverra. Quis risus sed vulputate odio ut enim blandit volutpat. Etiam sit amet nisl purus in mollis nunc sed. At lectus urna duis convallis convallis tellus. Feugiat in ante metus dictum at tempor commodo ullamcorper a. Volutpat commodo sed egestas egestas. Eget egestas purus viverra accumsan in nisl nisi scelerisque eu. Aliquet nibh praesent tristique magna sit amet purus. Dignissim diam quis enim lobortis scelerisque. Posuere sollicitudin aliquam ultrices sagittis. Tristique sollicitudin nibh sit amet commodo nulla facilisi. Scelerisque viverra mauris in aliquam. Rhoncus est pellentesque elit ullamcorper dignissim cras tincidunt lobortis feugiat.
+          </p>
+        </div>
+      </article>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<SSRArticlesListTemplate /> > should render articles 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <header
+        class="prose text-2xl mx-auto mt-20"
+      >
+        <h1
+          class="text-center mx-auto"
+        >
+          Articles
+        </h1>
+      </header>
+      <section>
+        <div
+          class="ps-mt-12 ps-grid ps-gap-5 ps-max-w-content ps-mx-auto lg:ps-max-w-screen-lg lg:ps-grid-cols-3"
+        >
+          <a
+            href="/articles/example-article"
+          >
+            <div
+              class="flex flex-col rounded-lg shadow-lg overflow-hidden cursor-pointer border-2 h-full hover:border-indigo-500"
+            >
+              <div
+                class="flex-shrink-0 relative h-40"
+              >
+                <img
+                  alt="This is an Example Article"
+                  src="https://default/sites/default/files/pizza.jpg"
+                />
+              </div>
+              <h2
+                class="my-4 mx-6 text-xl leading-7 font-semibold text-gray-900"
+              >
+                This is an Example Article →
+              </h2>
+            </div>
+          </a>
+        </div>
+      </section>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/auth-api.test.jsx.snap
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/auth-api.test.jsx.snap
@@ -1,0 +1,317 @@
+// Vitest Snapshot v1
+
+exports[`<AuthApiExampleTemplate /> > should render a failure message if unauthenticated 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <div
+        class="prose lg:prose-xl mt-10 flex flex-col mx-auto max-h-screen"
+      >
+        <h1>
+          API Authorization Example
+        </h1>
+        <a
+          href="/"
+        >
+          <span
+            class="w-full underline cursor-pointer"
+          >
+            Home →
+          </span>
+        </a>
+        <div
+          class="mt-12 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg"
+        >
+          <p>
+            Next.js was unable to make an authorized request to the Drupal API. Please check your .env.development.local file to ensure that your 
+            <code>
+              CLIENT_ID
+            </code>
+             and 
+            <code>
+              CLIENT_SECRET
+            </code>
+             are set correctly.
+          </p>
+          <p>
+            For more information on how to set these values, please see 
+            <a
+              href="https://github.com/pantheon-systems/decoupled-kit-js/blob/canary/web/docs/Frontend%20Starters/Next.js/Next.js%20%2B%20Drupal/setting-environment-variables.md"
+            >
+              Setting Environment Variables
+            </a>
+          </p>
+        </div>
+      </div>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<AuthApiExampleTemplate /> > should render a success message if authenticated 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <div
+        class="prose lg:prose-xl mt-10 flex flex-col mx-auto max-h-screen"
+      >
+        <h1>
+          API Authorization Example
+        </h1>
+        <a
+          href="/"
+        >
+          <span
+            class="w-full underline cursor-pointer"
+          >
+            Home →
+          </span>
+        </a>
+        <div
+          class="mt-12 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg"
+        >
+          <p>
+            🎉 Next.js was able to successfully make an authenticated request to Drupal! 🎉
+          </p>
+        </div>
+      </div>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/examples-index.test.jsx.snap
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/examples-index.test.jsx.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1
+
+exports[`<ExamplesPageTemplate /> > should render the examples page 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <div
+        class="prose lg:prose-xl mt-10 flex flex-col mx-auto max-h-screen"
+      >
+        <h1>
+          Examples
+        </h1>
+        <a
+          href="/"
+        >
+          <span
+            class="w-full underline cursor-pointer"
+          >
+            Home →
+          </span>
+        </a>
+        <div
+          class="max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg"
+        >
+          <p>
+            This page outlines a growing list of common use cases that can be used as a reference when building using this starter kit. If you don't need them for your site, feel free to delete the \`pages/examples\` directory in your codebase.
+          </p>
+          <ul>
+            <li>
+              <a
+                href="/examples/auth-api"
+              >
+                API Authorization
+              </a>
+               - confirms that Next.js is able to make authenticated requests to Drupal's API.
+            </li>
+            <li>
+              <a
+                href="/examples/ssg-isr"
+              >
+                SSG and ISR
+              </a>
+               - by default, this starter kit is optimized for SSR and Edge Caching on Pantheon. This example is provided for cases where Next.js static generation options would be beneficial.
+            </li>
+            <li>
+              <a
+                href="/examples/pagination"
+              >
+                Pagination
+              </a>
+               - a paginated list with a large dataset.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/homepage.test.jsx.snap
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/homepage.test.jsx.snap
@@ -1,0 +1,184 @@
+// Vitest Snapshot v1
+
+exports[`<HomepageTemplate /> > should render articles 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <div
+        class="prose sm:prose-xl mt-20 flex flex-col mx-auto max-w-fit"
+      >
+        <h1
+          class="prose text-4xl text-center h-full"
+        >
+          Welcome to 
+          <a
+            class="text-blue-600 no-underline hover:underline"
+            href="https://nextjs.org"
+          >
+            Next.js!
+          </a>
+        </h1>
+        <div
+          class="text-2xl"
+        >
+          <div
+            class="bg-black text-white rounded flex items-center justify-center p-4"
+          >
+            Decoupled Drupal on 
+            <img
+              alt="Pantheon Logo"
+              src="/pantheon.png"
+              width="191"
+            />
+          </div>
+        </div>
+      </div>
+      <section>
+        <div
+          class="ps-mt-12 ps-grid ps-gap-5 ps-max-w-content ps-mx-auto lg:ps-max-w-screen-lg lg:ps-grid-cols-3"
+        >
+          <a
+            href="/articles/example-article"
+          >
+            <div
+              class="flex flex-col rounded-lg shadow-lg overflow-hidden cursor-pointer border-2 h-full hover:border-indigo-500"
+            >
+              <div
+                class="flex-shrink-0 relative h-40"
+              >
+                <img
+                  alt="This is an Example Article"
+                  src="https://default/sites/default/files/pizza.jpg"
+                />
+              </div>
+              <h2
+                class="my-4 mx-6 text-xl leading-7 font-semibold text-gray-900"
+              >
+                This is an Example Article →
+              </h2>
+            </div>
+          </a>
+        </div>
+      </section>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/pages.test.jsx.snap
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/pages.test.jsx.snap
@@ -1,0 +1,329 @@
+// Vitest Snapshot v1
+
+exports[`<PageListTemplate /> > should render pages 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+       
+      <header
+        class="prose text-2xl mx-auto mt-20"
+      >
+        <h1
+          class="text-center mx-auto"
+        >
+          Pages
+        </h1>
+      </header>
+      <div
+        class="mt-12 mx-auto max-w-[50vw]"
+      >
+        <ul>
+          <li
+            class="prose justify-items-start mt-8"
+          >
+            <h2>
+              Test Page With Embedded Image-test page-local
+            </h2>
+            <div />
+            <a
+              class="font-normal underline"
+              href="/pages/test-page-embedded-image-test-page-local"
+            >
+              Read more →
+            </a>
+          </li>
+          <li
+            class="prose justify-items-start mt-8"
+          >
+            <h2>
+              My Page-preview test
+            </h2>
+            <div />
+            <a
+              class="font-normal underline"
+              href="/pages/my-page-preview-test"
+            >
+              Read more →
+            </a>
+          </li>
+        </ul>
+      </div>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<PageTemplate /> > should render a page 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <article
+        class="prose lg:prose-xl mt-10 mx-auto"
+      >
+        <h1>
+          Test Page With Embedded Image-test page-local
+        </h1>
+        <a
+          class="font-normal"
+          href="/pages"
+        >
+          Pages →
+        </a>
+        <div
+          class="mt-12 max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg"
+        >
+          <div>
+            <p>
+              <img
+                alt="Drupal on NPM"
+                data-entity-type="file"
+                data-entity-uuid="85adb65f-7111-42ae-aaa2-1d82e92d5785"
+                height="968"
+                loading="lazy"
+                src="/sites/default/files/inline-images/%40drupal-npm.png"
+                width="3138"
+              />
+            </p>
+          </div>
+        </div>
+      </article>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/pagination.test.jsx.snap
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/pagination.test.jsx.snap
@@ -1,0 +1,478 @@
+// Vitest Snapshot v1
+
+exports[`<PaginationExampleTemplate /> > should render the Pagination Example page 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <div
+        class="prose max-w-screen mx-auto"
+      >
+        <section
+          class="flex flex-col"
+        >
+          <h1
+            class="my-10"
+          >
+            Pagination example
+          </h1>
+          <div
+            class="ps-max-w-full"
+          >
+            <h3
+              class="ps-mb-8 ps-prose-sm ps-font-bold"
+            >
+              Page 1/18
+            </h3>
+            <section>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  Usitas
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Comis defui ex ille lobortis molior premo ulciscor. Diam huic iustum mauris quia voco. Commodo ibidem iriure nibh nostrud olim scisco vereor. Conventi...
+                </p>
+              </article>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  Comis Ex
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Brevitas conventio cui dolor minim os. Amet lenis quibus. Adipiscing exerci ille immitto lucidus roto valetudo volutpat. Caecus causa dolore eros eum ...
+                </p>
+              </article>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  Caecus Enim Macto Persto
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Blandit erat luptatum praesent refoveo veniam. Bene distineo veniam. Eu facilisi feugiat ille. Molior nunc proprius turpis. Abdo eu similis. Accumsan ...
+                </p>
+              </article>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  In
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Adipiscing at ex hos. Ratis refero tamen. Amet interdico jus pala rusticus typicus. Gravis importunus interdico iriure pala paratus paulatim populus r...
+                </p>
+              </article>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  Appellatio Eros Letalis
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Conventio in interdico saluto vulputate. Camur commoveo elit feugiat macto meus nutus similis utinam vulputate. Paulatim premo usitas. Consectetuer er...
+                </p>
+              </article>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  Dolus Iaceo Tum Verto
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Jumentum neo quidne tincidunt ut. Iaceo ideo jugis velit. Adipiscing damnum euismod neque pertineo praemitto tation te valde valetudo. Capto enim leni...
+                </p>
+              </article>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  Defui Exputo Gilvus Suscipit
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Capto diam iaceo pertineo plaga quidem quidne suscipere ullamcorper virtus. Antehabeo distineo eu euismod iusto letalis natu sino suscipit. Appellatio...
+                </p>
+              </article>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  Eros Iriure Venio Vulpes
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Adipiscing conventio fere iaceo magna quidne sed. Facilisis ratis scisco uxor. Elit exerci ymo zelus. Comis ea nutus pala quae refero sudo te ut. Aute...
+                </p>
+              </article>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  Eligo Praemitto
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Erat haero iaceo nibh odio ratis roto. Aptent typicus valde. Aliquam macto melior quadrum suscipere. Facilisis fere nibh paulatim tego vicis.
+
+Erat et...
+                </p>
+              </article>
+              <article
+                class="flex flex-col p-3 w-fit mx-auto mb-10"
+              >
+                <h2
+                  class="justify-start my-auto text-2xl mb-2"
+                >
+                  Abluo Aliquam Inhibeo Luptatum
+                </h2>
+                <p
+                  class="max-w-prose my-2"
+                >
+                  Abluo defui odio vel. Dolus ludus molior ullamcorper. Et letalis meus utrum uxor vel. Ad amet defui hos imputo praesent roto ut uxor. Augue erat eum l...
+                </p>
+              </article>
+            </section>
+            <div
+              class="ps-sticky lg:ps-bottom-12 ps-bottom-4 ps-mt-10"
+            >
+              <nav
+                aria-label="Pagination Navigation"
+                role="navigation"
+              >
+                <ul
+                  class="ps-list-none ps-flex ps-flex-row ps-justify-center ps-mx-auto ps-mt-auto ps-mb-4 [&>li]:ps-p-0"
+                >
+                  <li>
+                    <button
+                      aria-label="Go to Previous Page"
+                      class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-l-2"
+                      disabled=""
+                      id="back-btn"
+                    >
+                      &lt;
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="true"
+                      aria-label="Current Page, Page 1"
+                      class="
+          ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-blue-700 ps-border-2
+          "
+                    >
+                      1
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 2"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      2
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 3"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      3
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 4"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      4
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 5"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      5
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-label="Expand Hidden Buttons"
+                      class="ps-hidden md:ps-block ps-h-16 ps-w-12 ps-border-2 ps-border-black ps-bg-slate-200 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300"
+                    >
+                      ...
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 12"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      12
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 13"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      13
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 14"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      14
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 15"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      15
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 16"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      16
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 17"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      17
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-current="false"
+                      aria-label="Go to Page 18"
+                      class="
+          ps-hidden md:ps-block
+          ps-h-16 ps-w-12 ps-border-t-2 ps-border-b-2 ps-border-black ps-bg-white hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 
+          "
+                    >
+                      18
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      aria-label="Go to Next Page"
+                      class="ps-h-16 ps-w-12 disabled:ps-bg-gray-500 hover:ps-bg-blue-300 focus:ps-bg-blue-200 focus:ps-border-blue-300 ps-border-y-2 ps-border-black ps-bg-white ps-border-r-2"
+                      id="next-btn"
+                    >
+                      &gt;
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/ssr-isr-example.test.jsx.snap
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/__snapshots__/ssr-isr-example.test.jsx.snap
@@ -1,0 +1,173 @@
+// Vitest Snapshot v1
+
+exports[`<SSGISRExampleTemplate /> > should render articles 1`] = `
+<DocumentFragment>
+  <div
+    class="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden"
+  >
+    <div
+      class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto"
+    >
+      <div
+        class="ps-my-0 ps-pt-10 ps-px-5 ps-text-xl"
+      >
+        <nav>
+          <ul
+            class="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-list-none ps-justify-between ps-max-w-screen-sm ps-mx-auto"
+          >
+            <li
+              class="ps-mr-auto"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/"
+              >
+                🏠 Home
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/articles"
+              >
+                📰 Articles
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/pages"
+              >
+                📑 Pages
+              </a>
+            </li>
+            <li
+              class="ps-mx-4"
+            >
+              <a
+                class="ps-font-sans hover:ps-underline"
+                href="/examples"
+              >
+                ⚛️ Examples
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div
+        class="ps-pt-10"
+      >
+        <form>
+          <input
+            class="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+            placeholder="Quick search..."
+            value=""
+          />
+          <button
+            class="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+            id="submit-btn"
+            type="submit"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+    <main
+      class="mb-auto"
+    >
+      <header
+        class="prose text-2xl mx-auto mt-20"
+      >
+        <h1
+          class="text-center mx-auto"
+        >
+          Articles
+        </h1>
+      </header>
+      <div
+        class="mt-8 prose lg:prose-xl max-w-lg mx-auto lg:grid-cols-3 lg:max-w-screen-lg"
+      >
+        <p>
+          <em>
+            By default, this starter kit is optimized for SSR and Edge Caching on Pantheon. This example instead uses Incremental Static Regeneration and is provided as a reference for cases where Next.js static generation options would be beneficial.
+          </em>
+        </p>
+      </div>
+      <section>
+        <div
+          class="ps-mt-12 ps-grid ps-gap-5 ps-max-w-content ps-mx-auto lg:ps-max-w-screen-lg lg:ps-grid-cols-3"
+        >
+          <a
+            href="/articles/example-article"
+          >
+            <div
+              class="flex flex-col rounded-lg shadow-lg overflow-hidden cursor-pointer border-2 h-full hover:border-indigo-500"
+            >
+              <div
+                class="flex-shrink-0 relative h-40"
+              >
+                <img
+                  alt="This is an Example Article"
+                  src="https://default/sites/default/files/pizza.jpg"
+                />
+              </div>
+              <h2
+                class="my-4 mx-6 text-xl leading-7 font-semibold text-gray-900"
+              >
+                This is an Example Article →
+              </h2>
+            </div>
+          </a>
+        </div>
+      </section>
+    </main>
+    <footer
+      class="ps-w-full ps-text-white ps-bg-black ps-p-4 ps-mt-12"
+    >
+      <nav
+        class="ps-flex ps-flex-col ps-max-w-lg ps-mx-auto lg:ps-max-w-screen-lg"
+      >
+        <ul>
+          <li
+            class="ps-list-disc ps-text-blue-300"
+          >
+            <a
+              class="ps-text-blue-300 hover:ps-underline hover:ps-text-blue-100 focus:ps-text-purple-600 active:ps-text-purple-300"
+              href="/"
+            >
+              Home
+            </a>
+          </li>
+        </ul>
+      </nav>
+      <div
+        class="ps-flex ps-my-4 ps-p-2"
+      >
+        <span
+          class="mx-auto"
+        >
+          © 2023 Built with 
+          <a
+            class="text-white hover:text-blue-100 underline"
+            href="https://nextjs.org/"
+          >
+            Next.js
+          </a>
+           and 
+          <a
+            class="text-blue-500 underline hover:text-blue-100"
+            href="https://www.drupal.org/"
+          >
+            Drupal
+          </a>
+        </span>
+      </div>
+    </footer>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/snapshotTests/auth-api.test.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/snapshotTests/auth-api.test.jsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import AuthApiExampleTemplate from '../../pages/examples/auth-api';
+
+import defaultProfileArticlesData from '../data/defaultProfileArticlesData.json';
+import defaultProfileFooterMenu from '../data/defaultProfileMenuItemsMainData.json';
+
+/**
+ * @vitest-environment jsdom
+ */
+
+vi.mock('next/router', () => ({
+	useRouter: () => ({
+		locale: 'en',
+	}),
+}));
+
+describe('<AuthApiExampleTemplate />', () => {
+	const footerMenu = defaultProfileFooterMenu;
+	it('should render a success message if authenticated', () => {
+		const { asFragment } = render(
+			<AuthApiExampleTemplate
+				footerMenu={footerMenu}
+				articles={defaultProfileArticlesData}
+			/>,
+		);
+		expect(asFragment()).toMatchSnapshot();
+	});
+	it('should render a failure message if unauthenticated', () => {
+		const { asFragment } = render(
+			<AuthApiExampleTemplate footerMenu={footerMenu} articles={[]} />,
+		);
+		expect(asFragment()).toMatchSnapshot();
+	});
+});

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/snapshotTests/homepage.test.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/__tests__/snapshotTests/homepage.test.jsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import HomepageTemplate from '../../pages/index';
+
+import defaultProfileArticlesData from '../data/defaultProfileArticlesData.json';
+import defaultProfileFooterMenu from '../data/defaultProfileMenuItemsMainData.json';
+
+vi.mock('next/image');
+
+/**
+ * @vitest-environment jsdom
+ */
+
+vi.mock('next/router', () => ({
+	useRouter: () => ({
+		locale: 'en',
+	}),
+}));
+
+describe('<HomepageTemplate />', () => {
+	it('should render articles', () => {
+		const data = {
+						articles: defaultProfileArticlesData,
+						footerMenu: defaultProfileFooterMenu,
+				  };
+
+		const { asFragment } = render(
+			<HomepageTemplate
+				sortedArticles={data.articles}
+				footerMenu={data.footerMenu}
+			/>,
+		);
+		expect(asFragment()).toMatchSnapshot();
+	});
+});

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/components/layout.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/components/layout.jsx
@@ -1,0 +1,45 @@
+import { Footer, Header, PreviewRibbon } from '@pantheon-systems/nextjs-kit';
+import SearchInput from './search-input';
+export default function Layout({ children, footerMenu, preview = false }) {
+	const navItems = [
+		{ linkText: '🏠 Home', href: '/' },
+		{ linkText: '📰 Articles', href: '/articles' },
+		{ linkText: '📑 Pages', href: '/pages' },
+		{ linkText: '⚛️ Examples', href: '/examples' },
+	];
+	const footerMenuItems = footerMenu?.map(({ title, url, parent }) => ({
+		linkText: title,
+		href: url,
+		parent: parent,
+	}));
+	return (
+		<div className="min-h-screen max-h-screen min-w-screen max-w-screen flex flex-col overflow-x-hidden">
+			{preview && <PreviewRibbon />}
+			<div className="ps-flex ps-flex-row ps-flex-wrap sm:ps-flex-nowrap ps-justify-between ps-max-w-screen-md ps-mx-auto">
+				<Header navItems={navItems} />
+				<div className="ps-pt-10">
+					<SearchInput />
+				</div>
+			</div>
+			<main className="mb-auto">{children}</main>
+			<Footer footerMenuItems={footerMenuItems}>
+				<span className="mx-auto">
+					© {new Date().getFullYear()} Built with{' '}
+					<a
+						className="text-white hover:text-blue-100 underline"
+						href="https://nextjs.org/"
+					>
+						Next.js
+					</a>{' '}
+					and{' '}
+					<a
+						className="text-blue-500 underline hover:text-blue-100"
+						href="https://www.drupal.org/"
+					>
+						Drupal
+					</a>
+				</span>
+			</Footer>
+		</div>
+	);
+}

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/components/search-input.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/components/search-input.jsx
@@ -1,0 +1,39 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+const SearchInput = () => {
+	const [searchQuery, setSearchQuery] = useState('');
+
+	const router = useRouter();
+
+	const onSearch = (event) => {
+		event.preventDefault();
+
+		if (typeof searchQuery !== 'string') {
+			return;
+		}
+
+		const encodedSearchQuery = encodeURI(searchQuery);
+		router.push(`/search/${encodedSearchQuery}`);
+	};
+
+	return (
+		<form onSubmit={onSearch}>
+			<input
+				value={searchQuery || ''}
+				onChange={(event) => setSearchQuery(event.target.value)}
+				className="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
+				placeholder="Quick search..."
+			/>
+			<button
+				type="submit"
+				id="submit-btn"
+				className="ml-1.5 text-black rounded-full ring-[1px] ring-black px-5 py-1 hover:bg-blue-500"
+			>
+				Submit
+			</button>
+		</form>
+	);
+};
+
+export default SearchInput;

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/components/search-input.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/components/search-input.jsx
@@ -23,7 +23,7 @@ const SearchInput = () => {
 				value={searchQuery || ''}
 				onChange={(event) => setSearchQuery(event.target.value)}
 				className="py-1 sm:px-5 text-black rounded-full focus:outline-none ring-[1px] ring-black"
-				placeholder="Quick search..."
+				placeholder="Search"
 			/>
 			<button
 				type="submit"


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

- Creates a new addon, `next-drupal-search-api-addon`, which has the start of an example implementation for the Drupal Search API
- A search box is included in the header in all existing next-drupal starter kit routes.
- Submitting a search redirects to `/search/<term>`

## Where were the changes made?
`cli`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Generated a new project using the locally linked `create-pantheon-decoupled-kit` package. The `next-drupal` and `next-drupal-search-api-addon` generators were used along side each other with no problems. A new project was generated with the new search functionality working as expected.

## Additional information
Testing considerations:
I experimented with one off unit tests for this component but since our `/search`  page has not been implemented and an essential duplicate of this component will be built for use in the `app` directory, I figured testing for this functionality would be more suited to come in through a later ticket to exist in the `app` directory alongside a working search page. LMK if you have any thoughts on this.
<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->