### PR TITLE
Add tailwindcss flag to next-wp generator_commands

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -47,7 +47,7 @@ jobs:
             split_repository: 'next-wordpress-starter-default-canary'
             generator_cmd:
               'next-wp --appName @pantheon-systems/next-wordpress-starter-canary
-              --noInstall --force --silent'
+              --noInstall --tailwindcss --force --silent'
 
           # canary docs site
           - local_path: 'web'

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -93,7 +93,7 @@ jobs:
             split_repository: 'next-wordpress-starter'
             generator_cmd:
               'next-wp --appName @pantheon-systems/next-wordpress-starter
-              --noInstall --force --silent'
+              --noInstall --tailwindcss --force --silent'
 
             # docs site
           - local_path: 'web'


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
The `--tailwindcss` flag is now required for CI to not hang. Maybe theere is an oppurtunity for `CI` mode on the CLI that will select the default answer if it is not passed in via flag and CI mode is true.
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
canary-sites-split.yml & release-and-split.yml
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->