### PR TITLE
DB-5227: Fix missing dependency

### DIFF
--- a/.changeset/chilled-icons-obey.md
+++ b/.changeset/chilled-icons-obey.md
@@ -1,0 +1,6 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-wp] Re-add `tailwindcss` as a dependency as it is required for
+`@pantheon-systems/wordpress-kit`

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/package.json.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/package.json.hbs
@@ -38,6 +38,7 @@
 		"eslint-config-next": "^13.1.1",
 		"msw": "^0.47.3",
 		"prettier": "^2.7.1",
+		"tailwindcss": "^3.1.8",
 		"typescript": "4.8.4",
 		"vite": "^3.1.4",
 		"vitest": "^0.23.4"

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/tailwindcssDeps.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/tailwindcssDeps.hbs
@@ -1,7 +1,9 @@
 {{#if devDeps}}	
 "autoprefixer": "^10.4.12",
 "postcss": "^8.4.16",
+	{{#unless wp}}
 "tailwindcss": "^3.1.8",
+	{{/unless}}
 {{else}}
 "@tailwindcss/typography": "^0.5.7",
 {{/if}}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
`tailwindcss` is a required dependency for our `wordpress-kit` because of the plugin. This means that the output of a tailwindless next-wp project will fail without this dependency. If `auto-install-peers` is set to true, depending on the package manager, this isn't an issue. But we should not rely on users needing to install this dependency themselves.
## Where were the changes made?
Adds `tailwindcss` back to the `next-wp` package.json in all cases
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested locally with the watch script
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->