### PR TITLE
Move .npmrc write out of actions

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -26,10 +26,6 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-      - name: Setup npmrc
-        run:
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >
-          .npmrc
       - name: install dependencies
         run: pnpm install
       - name: create and publish versions
@@ -41,6 +37,7 @@ jobs:
           title: 'Canary Release'
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Send custom JSON data to Slack workflow
         uses: slackapi/slack-github-action@v1.23.0
         id: slack

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -27,10 +27,6 @@ jobs:
         with:
           node-version: 18
           cache: 'pnpm'
-      - name: Setup npmrc
-        run:
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >
-          .npmrc
       - name: install dependencies
         run: pnpm install
       - name: create and publish versions
@@ -42,6 +38,7 @@ jobs:
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Add registry string to `.npmrc`
- Remove write of `.npmrc` from the Actions workflows
- Add `NPM_TOKEN` to action `env` to be read by the `.npmrc` during the action

## Where were the changes made?
`.npmrc` and GitHub actions workflows

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
If the `.npmrc` is completely missing from the repo, it will be created by the changeset "Canary version" action. This commits that file back to the repo with our secret exposed. This is a problem! I have just tested another canary release with a blank `.npmrc` which seems to prevent the exposed secret issue, however it does not seem to work for the actual publish.

This change should make sure that
1. the `npmrc` is already in the repo so it should not need to be created during the changeset action
2. the token is not written at all during CI, it is instead read from a secret env var. This should prove a bit safer in the long run in case something like this happens again.

## Additional information
I followed this comment and their repo for this fix: https://github.com/changesets/action/issues/98#issuecomment-917292485
<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->