### PR TITLE
Revert "Canary Release (canary)"

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -15,9 +15,5 @@
     "@pantheon-systems/next-wordpress-starter": "2.0.1",
     "web": "1.0.0"
   },
-  "changesets": [
-    "hip-oranges-whisper",
-    "violet-horses-carry",
-    "young-brooms-argue"
-  ]
+  "changesets": []
 }

--- a/packages/cms-kit/CHANGELOG.md
+++ b/packages/cms-kit/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @pantheon-systems/cms-kit
 
-## 0.2.2-canary.0
-
-### Patch Changes
-
-- f50164f8: Updated dependencies
-
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/cms-kit/package.json
+++ b/packages/cms-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pantheon-systems/cms-kit",
-	"version": "0.2.2-canary.0",
+	"version": "0.2.1",
 	"description": "Pantheon Decoupled Kit's CMS Kit",
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://github.com/pantheon-systems/decoupled-kit-js#readme",

--- a/packages/create-pantheon-decoupled-kit/CHANGELOG.md
+++ b/packages/create-pantheon-decoupled-kit/CHANGELOG.md
@@ -1,11 +1,5 @@
 # create-pantheon-decoupled-kit
 
-## 0.5.1-canary.0
-
-### Patch Changes
-
-- f50164f8: [gatsby-wp] Update dependencies
-
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/create-pantheon-decoupled-kit/package.json
+++ b/packages/create-pantheon-decoupled-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-pantheon-decoupled-kit",
-	"version": "0.5.1-canary.0",
+	"version": "0.5.0",
 	"description": "Pantheon Decoupled Kit CLI",
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://github.com/pantheon-systems/decoupled-kit-js#readme",

--- a/packages/drupal-kit/CHANGELOG.md
+++ b/packages/drupal-kit/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @pantheon-systems/drupal-kit
 
-## 4.2.2-canary.0
-
-### Patch Changes
-
-- f50164f8: Updated dependencies
-- Updated dependencies [f50164f8]
-  - @pantheon-systems/cms-kit@0.2.2-canary.0
-
 ## 4.2.1
 
 ### Patch Changes

--- a/packages/drupal-kit/package.json
+++ b/packages/drupal-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pantheon-systems/drupal-kit",
-	"version": "4.2.2-canary.0",
+	"version": "4.2.1",
 	"description": "Pantheon Decoupled Kit's Drupal Kit",
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://github.com/pantheon-systems/decoupled-kit-js#readme",
@@ -57,6 +57,6 @@
 	},
 	"dependencies": {
 		"@gdwc/drupal-state": "^4.2.0",
-		"@pantheon-systems/cms-kit": "^0.2.2-canary.0"
+		"@pantheon-systems/cms-kit": "^0.2.1"
 	}
 }

--- a/packages/nextjs-kit/CHANGELOG.md
+++ b/packages/nextjs-kit/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @pantheon-systems/nextjs-kit
 
-## 1.7.2-canary.0
-
-### Patch Changes
-
-- f50164f8: Updated dependencies
-- ed3e4f07: Bug fix for an invalid src prop error expierenced in dev mode.
-
 ## 1.7.1
 
 ### Patch Changes

--- a/packages/nextjs-kit/package.json
+++ b/packages/nextjs-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pantheon-systems/nextjs-kit",
-	"version": "1.7.2-canary.0",
+	"version": "1.7.1",
 	"description": "Pantheon Decoupled Kit's Next.js Kit",
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://github.com/pantheon-systems/decoupled-kit-js#readme",

--- a/packages/wordpress-kit/CHANGELOG.md
+++ b/packages/wordpress-kit/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @pantheon-systems/wordpress-kit
 
-## 2.14.2-canary.0
-
-### Patch Changes
-
-- f50164f8: Updated dependencies
-- Updated dependencies [f50164f8]
-  - @pantheon-systems/cms-kit@0.2.2-canary.0
-
 ## 2.14.1
 
 ### Patch Changes

--- a/packages/wordpress-kit/package.json
+++ b/packages/wordpress-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pantheon-systems/wordpress-kit",
-	"version": "2.14.2-canary.0",
+	"version": "2.14.1",
 	"description": "Pantheon Decoupled Kit's WordPress Kit",
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://github.com/pantheon-systems/decoupled-kit-js#readme",
@@ -42,7 +42,7 @@
 		"lint-staged": "lint-staged"
 	},
 	"dependencies": {
-		"@pantheon-systems/cms-kit": "^0.2.2-canary.0",
+		"@pantheon-systems/cms-kit": "^0.2.1",
 		"graphql": "^16.6.0",
 		"graphql-request": "^5.2.0"
 	},


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Revert latest canary release which failed
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->