### PR TITLE
Use empty .npmrc, update NPM_TOKEN in CI workflows

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     strategy:
       fail-fast: false

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Putting the `${NPM_TOKEN}` env var in the `.npmrc` causes a bunch of noisy warnings when doing anything with `pnpm` locally if this var is not set.
CI should work with a blank `.npmrc` as long as `NPM_TOKEN` is defined in the `env`.

This PR should fix those warnings from a missing `NPM_TOKEN`, as well as fix the CI jobs.
`NPM_TOKEN` is removed from canary-sites-split since that action does not need it.
## Where were the changes made?
CI
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->