### PR TITLE
DB-5804: update WordPress build hooks entry to prevent duplicate hook submissions

### DIFF
--- a/web/docs/Backend Starters/Decoupled WordPress/configuring-build-hooks.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/configuring-build-hooks.md
@@ -5,52 +5,35 @@ slug: '/backend-starters/decoupled-wordpress/configuring-build-hooks'
 sidebar_position: 5
 ---
 
-## Create Your First Build Hook
-
-### What Are Build Hooks?
+## What Are Build Hooks?
 
 Build hooks enable certain events in the CMS to trigger builds of a decoupled
 frontend; such as content updates to post, or publishing a new page.
 
-### Install and Activate WP Webhooks Plugin
+## Installing the WP Webhooks Plugin
 
-- Install and activate the
-  [WP-Webhooks Plugin](https://wordpress.org/plugins/wp-webhooks/).
+If you are using the
+[Decoupled WordPress Composer Managed](/docs/backend-starters/decoupled-wordpress/creating-a-new-project)
+starter template, the WP Webhooks plugin will already be included as a Composer
+dependency. It will need to be activated in the WordPress admin dashboard.
 
-### Creating a Build Hook That Triggers When a Post Is Created Or Updated
+For other projects, install and activate the WP Webhooks Plugin as
+[outlined in the plugin documentation](https://wordpress.org/plugins/wp-webhooks/#installation).
+
+### Creating a Build Hook That Triggers When a Post Is Published
 
 1. After generating a build hook on your build platform, navigate to your
-   WordPress admin dashboard and open the WP Webhooks plugin interface
-1. Click on the **Send Data** tab
-1. Select the **Post Created** Webhook trigger
+   WordPress admin dashboard and open the **WP Webhooks settings**.
+1. Click on the **Send Data** tab.
+1. Select the **Post Updated** Webhook trigger.
 1. Click **Add Webhook URL**, name the hook and paste the build hook URL that
-   you generated, submit this form
-1. Repeat the previous two steps to create a hook for the **Post Updated**
-   trigger
+   you generated in the Webhook URL field. Submit this form.
+1. Under the **Action** menu for the hook you created, select **settings**.
+1. Under the **Trigger on post status** setting enter **publish** and toggle the
+   **fire only once per instance** option on. Save your settings.
 
-#### Testing The Post Build Hook
+### Testing Your Build Hook
 
-1. Open your WordPress admin dashboard
-1. Create a new Post or update a previously existing one
-1. Observe that a new build has been triggered in the **Site Overview** page of
-   your build platform
-
-### Creating Build Hooks For Multiple Frontend Environments
-
-The WP Webhooks plugin allows multiple build hooks to be added under a single
-action. This feature can be used to trigger builds in multiple feature branches
-based off of content updates in one WordPress instance.
-
-:::note
-
-Before continuing, generate separate build hooks for each of your sites frontend
-environments on your build platform
-
-:::
-
-1. Navigate to your WordPress admin dashboard
-1. Open the WP Webhooks plugin dashboard
-1. Click on the **Send Data** tab and select your desired Webhook trigger
-1. Click **Add Webhook URL**, name the hook and add one of your previously
-   generated build hook URL's before submitting this form
-1. Repeat the previous two steps for each build hook previously generated
+1. Open your WordPress admin dashboard.
+1. Create a new Post or update a previously existing one.
+1. Observe that a new build has been triggered on your build platform.


### PR DESCRIPTION
<!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Updated WordPress build hooks entry to prevent duplicate hook submissions

## Where were the changes made?

Docs -> BE -> WP -> Configuring Build Hooks.

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->