### PR TITLE
DB-5693: Adjust Add-on Formatting to Satisfy Lint

### DIFF
--- a/.changeset/funny-owls-build.md
+++ b/.changeset/funny-owls-build.md
@@ -1,0 +1,5 @@
+---
+"create-pantheon-decoupled-kit": minor
+---
+
+[gatsby-wp-acf-addon] Adjust formatting to satisfy lint

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.jsx
@@ -1,33 +1,37 @@
-import React from 'react'
-import { graphql } from 'gatsby'
+import React from 'react';
+import { graphql } from 'gatsby';
 
-import Layout from '../components/layout'
-import Seo from '../components/seo'
-import Post from '../components/post'
-import { withGrid, PostGridItem } from '../components/grid'
+import Layout from '../components/layout';
+import Seo from '../components/seo';
+import Post from '../components/post';
+import { withGrid, PostGridItem } from '../components/grid';
 
-const PostTemplate = ({ data: { previous, next, post }, location }) => {
-	const PostGrid = withGrid(PostGridItem)
+const PostTemplate = ({ data: { previous, next, post } }) => {
+	const PostGrid = withGrid(PostGridItem);
 
 	return (
 		<Layout>
 			<Post post={post} next={next} previous={previous} />
 			{post.relatedContent?.relatedContent ? (
-                <section>
-                    <header className="prose text-2xl mx-auto mt-20">
+				<section>
+					<header className="prose text-2xl mx-auto mt-20">
 						<h2 className="text-center mx-auto">Related Content</h2>
 					</header>
-					<PostGrid data={post.relatedContent.relatedContent.map(item => ({post: item}))} />
-                </section>
-            ) : null}
+					<PostGrid
+						data={post.relatedContent.relatedContent.map((item) => ({
+							post: item,
+						}))}
+					/>
+				</section>
+			) : null}
 		</Layout>
-	)
-}
+	);
+};
 
-export default PostTemplate
+export default PostTemplate;
 
 export function Head({ data: { post } }) {
-	return <Seo title={post.title} description={post.excerpt} />
+	return <Seo title={post.title} description={post.excerpt} />;
 }
 
 export const pageQuery = graphql`
@@ -61,28 +65,28 @@ export const pageQuery = graphql`
 			relatedContent {
 				fieldGroupName
 				relatedContent {
-				  ... on WpPost {
-					id
-					content
-					title
-					excerpt
-					uri
-					date(formatString: "MMMM DD, YYYY")
-					featuredImage {
-						node {
-							altText
-							localFile {
-								childImageSharp {
-									gatsbyImageData(
-										quality: 100
-										placeholder: TRACED_SVG
-										layout: FULL_WIDTH
-									)
+					... on WpPost {
+						id
+						content
+						title
+						excerpt
+						uri
+						date(formatString: "MMMM DD, YYYY")
+						featuredImage {
+							node {
+								altText
+								localFile {
+									childImageSharp {
+										gatsbyImageData(
+											quality: 100
+											placeholder: TRACED_SVG
+											layout: FULL_WIDTH
+										)
+									}
 								}
 							}
 						}
 					}
-				  }
 				}
 			}
 		}
@@ -97,4 +101,4 @@ export const pageQuery = graphql`
 			title
 		}
 	}
-`
+`;

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.jsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { graphql } from 'gatsby';
+import React from 'react'
+import { graphql } from 'gatsby'
 
-import Layout from '../components/layout';
-import Seo from '../components/seo';
-import Post from '../components/post';
-import { withGrid, PostGridItem } from '../components/grid';
+import Layout from '../components/layout'
+import Seo from '../components/seo'
+import Post from '../components/post'
+import { withGrid, PostGridItem } from '../components/grid'
 
 const PostTemplate = ({ data: { previous, next, post } }) => {
-	const PostGrid = withGrid(PostGridItem);
+	const PostGrid = withGrid(PostGridItem)
 
 	return (
 		<Layout>
@@ -18,20 +18,20 @@ const PostTemplate = ({ data: { previous, next, post } }) => {
 						<h2 className="text-center mx-auto">Related Content</h2>
 					</header>
 					<PostGrid
-						data={post.relatedContent.relatedContent.map((item) => ({
+						data={post.relatedContent.relatedContent.map(item => ({
 							post: item,
 						}))}
 					/>
 				</section>
 			) : null}
 		</Layout>
-	);
-};
+	)
+}
 
-export default PostTemplate;
+export default PostTemplate
 
 export function Head({ data: { post } }) {
-	return <Seo title={post.title} description={post.excerpt} />;
+	return <Seo title={post.title} description={post.excerpt} />
 }
 
 export const pageQuery = graphql`
@@ -101,4 +101,4 @@ export const pageQuery = graphql`
 			title
 		}
 	}
-`;
+`


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Formatting tweaks applied to the `gatsby-wp-acf-addon` to satisfy linter on instillation.

## Where were the changes made?
`cli > templates > gatsby-wp-acf-addon`
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
New projects with the gatsby-wp-acf-addon installed pass lint locally.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->