### PR TITLE
Add --tailwindcss flag to next-drupal-starter release split cmd

### DIFF
--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -78,7 +78,8 @@ jobs:
             split_repository: 'next-drupal-starter'
             generator_cmd:
               'next-drupal next-drupal-umami-addon --appName
-              @pantheon-systems/next-drupal-starter --noInstall --force --silent'
+              @pantheon-systems/next-drupal-starter --noInstall --tailwindcss
+              --force --silent'
           # gatsby-wordpress-starter
           - local_path: 'starters/gatsby-wordpress-starter-generated'
             split_repository: 'gatsby-wordpress-starter'


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
The `generate_cmd` for the next-drupal-starter in `release-and-split.yml` now needs the --tailwindcss flag
## Where were the changes made?
ci
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->