### PR TITLE
DB-5693: Starter Kit ACF Adjustments

### DIFF
--- a/.changeset/fluffy-suits-knock.md
+++ b/.changeset/fluffy-suits-knock.md
@@ -1,0 +1,7 @@
+---
+"create-pantheon-decoupled-kit": patch
+---
+
+- [next-wp-acf-addon] Adjustments to comply with a generated WP backend with ACF enabled for new front end sites projects
+- [gatsby-wp-acf-addon] Adjustments to comply with a generated WP backend with ACF enabled for new front end sites projects
+

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.jsx
@@ -4,21 +4,20 @@ import { graphql } from 'gatsby'
 import Layout from '../components/layout'
 import Seo from '../components/seo'
 import Post from '../components/post'
-import { withGrid, PostGridItem } from '../components/grid'
+import { PostGrid } from '../components/grid'
 
 const PostTemplate = ({ data: { previous, next, post } }) => {
-	const PostGrid = withGrid(PostGridItem)
 
 	return (
 		<Layout>
 			<Post post={post} next={next} previous={previous} />
-			{post.relatedContent?.relatedContent ? (
+			{post.relatedContent?.relatedPosts ? (
 				<section>
 					<header className="prose text-2xl mx-auto mt-20">
 						<h2 className="text-center mx-auto">Related Content</h2>
 					</header>
 					<PostGrid
-						data={post.relatedContent.relatedContent.map(item => ({
+						data={post.relatedContent.relatedPosts.map(item => ({
 							post: item,
 						}))}
 					/>
@@ -64,7 +63,7 @@ export const pageQuery = graphql`
 			}
 			relatedContent {
 				fieldGroupName
-				relatedContent {
+				relatedPosts {
 					... on WpPost {
 						id
 						content

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/next-wp/nextWpPostView.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/next-wp/nextWpPostView.hbs
@@ -39,7 +39,7 @@ export default function PostTemplate({ menuItems, post, preview }) {
 				{{/if}}
 			/>
 			{{#if wpAcfAddon}}
-			{post.relatedContent?.relatedContent ? (
+			{post.relatedContent?.relatedPosts ? (
 				<section>
 					{{#if tailwindcss}}
 					<header className="prose text-2xl mx-auto mt-20">
@@ -51,7 +51,7 @@ export default function PostTemplate({ menuItems, post, preview }) {
 					</header>
 					<PostGrid
 						contentType="posts"
-						data={post.relatedContent.relatedContent}
+						data={post.relatedContent.relatedPosts}
 					/>
 				</section>
 			) : null}

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/next-wp/nextWpPostsJS.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/next-wp/nextWpPostsJS.hbs
@@ -48,7 +48,7 @@ export async function getPostByUri(uri) {
 				content
 		{{#if wpAcfAddon}}
 				relatedContent {
-					relatedContent {
+					relatedPosts {
 						... on Post {
 							id
 							uri


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

- Small query adjustments and layout adjustments to the ACF add-ons to work with a new WordPress for Front-End project.

## Where were the changes made?
`cli > templates > next-wp-acf-addon && gatsby-wp-acf-addon`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Both ACF starters were generated without warnings and were able to successfully query a WP backend with ACF enabled.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->