### PR TITLE
Omit cmsEndpoint in generator_cmd

### DIFF
--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -25,29 +25,29 @@ jobs:
           - local_path: 'starters/next-drupal-starter-umami-canary-generated'
             split_repository: 'next-drupal-starter-umami-canary'
             generator_cmd:
-              'next-drupal next-drupal-umami-addon --appName
-              @pantheon-systems/next-drupal-starter-umami-canary --noInstall
-              --tailwindcss --force --silent'
+              "next-drupal next-drupal-umami-addon --appName
+              @pantheon-systems/next-drupal-starter-umami-canary --cmsEndpoint
+              '' --noInstall --tailwindcss --force --silent"
           # next-drupal-starter default
           - local_path: 'starters/next-drupal-starter-default-canary-generated'
             split_repository: 'next-drupal-starter-default-canary'
             generator_cmd:
-              'next-drupal --appName
-              @pantheon-systems/next-drupal-starter-default-canary --noInstall
-              --tailwindcss --force --silent'
+              "next-drupal --appName
+              @pantheon-systems/next-drupal-starter-default-canary --cmsEndpoint
+              '' --noInstall --tailwindcss --force --silent"
           # gatsby-wordpress-starter
           - local_path: 'starters/gatsby-wordpress-starter-canary-generated'
             split_repository: 'gatsby-wordpress-starter-default-canary'
             generator_cmd:
-              'gatsby-wp --appName
+              "gatsby-wp --appName
               @pantheon-systems/gatsby-wordpress-starter-canary --noInstall
-              --tailwindcss --force --silent'
+              --cmsEndpoint '' --tailwindcss --force --silent"
           # next-wordpress-starter
           - local_path: 'starters/next-wordpress-starter-canary-generated'
             split_repository: 'next-wordpress-starter-default-canary'
             generator_cmd:
-              'next-wp --appName @pantheon-systems/next-wordpress-starter-canary
-              --noInstall --tailwindcss --force --silent'
+              "next-wp --appName @pantheon-systems/next-wordpress-starter-canary
+              --cmsEndpoint '' --noInstall --tailwindcss --force --silent"
 
           # canary docs site
           - local_path: 'web'

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -77,21 +77,21 @@ jobs:
           - local_path: 'starters/next-drupal-starter-generated'
             split_repository: 'next-drupal-starter'
             generator_cmd:
-              'next-drupal next-drupal-umami-addon --appName
-              @pantheon-systems/next-drupal-starter --noInstall --tailwindcss
-              --force --silent'
+              "next-drupal next-drupal-umami-addon --appName
+              @pantheon-systems/next-drupal-starter --cmsEndpoint '' --noInstall
+              --tailwindcss --force --silent"
           # gatsby-wordpress-starter
           - local_path: 'starters/gatsby-wordpress-starter-generated'
             split_repository: 'gatsby-wordpress-starter'
             generator_cmd:
-              'gatsby-wp --appName @pantheon-systems/gatsby-wordpress-starter
-              --noInstall --tailwindcss --force --silent'
+              "gatsby-wp --appName @pantheon-systems/gatsby-wordpress-starter
+              --cmsEndpoint '' --noInstall --tailwindcss --force --silent"
           # next-wordpress-starter
           - local_path: 'starters/next-wordpress-starter-generated'
             split_repository: 'next-wordpress-starter'
             generator_cmd:
-              'next-wp --appName @pantheon-systems/next-wordpress-starter
-              --noInstall --tailwindcss --force --silent'
+              "next-wp --appName @pantheon-systems/next-wordpress-starter
+              --cmsEndpoint '' --noInstall --tailwindcss --force --silent"
 
             # docs site
           - local_path: 'web'


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Set an empty `--cmsEndpoint` so that CI does not break
## Where were the changes made?
release workflows
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->