### PR TITLE
[docs] Docs update npm init

### DIFF
--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/README.md
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/README.md
@@ -14,7 +14,7 @@ For a quick start, follow the instructions below:
 1. In your terminal, run the following command:
 
 ```bash
-npm init pantheon-decoupled-kit gatsby-wp
+npm init pantheon-decoupled-kit -- gatsby-wp
 ```
 
 2. Follow the prompts in your terminal to complete the setup.

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/README.md
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/README.md
@@ -14,7 +14,7 @@ For a quick start, follow the instructions below:
 1. In your terminal, run the following command:
 
 ```bash
-npm init pantheon-decoupled-kit next-drupal
+npm init pantheon-decoupled-kit -- next-drupal
 ```
 
 2. Follow the prompts in your terminal to complete the setup.

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/README.md
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/README.md
@@ -14,7 +14,7 @@ For a quick start, follow the instructions below:
 1. In your terminal, run the following command:
 
 ```bash
-npm init pantheon-decoupled-kit next-wp
+npm init pantheon-decoupled-kit -- next-wp
 ```
 
 2. Follow the prompts in your terminal to complete the setup.

--- a/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/intro.md
+++ b/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/intro.md
@@ -41,7 +41,7 @@ To create a new project using `create-pantheon-decoupled-kit`:
 1. In your terminal, run the following command:
 
 ```bash
-npm init pantheon-decoupled-kit gatsby-wordpress
+npm init pantheon-decoupled-kit -- gatsby-wordpress
 ```
 
 2. Follow the prompts in your terminal to complete the setup.

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/intro.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/intro.md
@@ -40,7 +40,7 @@ To create a new project using `create-pantheon-decoupled-kit`:
 1. In your terminal, run the following command:
 
 ```bash
-npm init pantheon-decoupled-kit next-drupal
+npm init pantheon-decoupled-kit -- next-drupal
 ```
 
 2. Follow the prompts in your terminal to complete the setup.

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/intro.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/intro.md
@@ -39,7 +39,7 @@ To create a new project using `create-pantheon-decoupled-kit`:
 1. In your terminal, run the following command:
 
 ```bash
-npm init pantheon-decoupled-kit next-wp
+npm init pantheon-decoupled-kit -- next-wp
 ```
 
 2. Follow the prompts in your terminal to complete the setup.

--- a/web/docs/Frontend Starters/create-pantheon-decoupled-kit.md
+++ b/web/docs/Frontend Starters/create-pantheon-decoupled-kit.md
@@ -43,7 +43,7 @@ If you know which generators you would like to run ahead of time, you can pass
 in generator names as space-separated positional arguments. For example:
 
 ```shell
-npm init pantheon-decoupled-kit next-wp next-wp-acf-addon
+npm init pantheon-decoupled-kit -- next-wp next-wp-acf-addon
 ```
 
 The above command will generate a project with the `next-wp` generator, and the
@@ -92,8 +92,8 @@ To skip any prompts, use a double-dash argument when running the command. For
 example:
 
 ```shell
-  # include generators as space separated positional arguments
-npm init pantheon-decoupled-kit next-drupal next-drupal-umami-addon \
+  # include generators as space separated positional arguments. npm v9 requires a double dash before the cli arguments
+npm init pantheon-decoupled-kit -- next-drupal next-drupal-umami-addon \
   # path to the project. This directory will be created if it does not exist
   --outDir ./my-new-project-dir \
   # package.json compatible name for the project

--- a/web/docs/Frontend Starters/create-pantheon-decoupled-kit.md
+++ b/web/docs/Frontend Starters/create-pantheon-decoupled-kit.md
@@ -92,7 +92,7 @@ To skip any prompts, use a double-dash argument when running the command. For
 example:
 
 ```shell
-  # include generators as space separated positional arguments. npm v9 requires a double dash before the cli arguments
+  # include generators as space separated positional arguments. npm init requires a double dash to allow forwarding options to the command
 npm init pantheon-decoupled-kit -- next-drupal next-drupal-umami-addon \
   # path to the project. This directory will be created if it does not exist
   --outDir ./my-new-project-dir \

--- a/web/docs/Packages/cms-kit/modules.md
+++ b/web/docs/Packages/cms-kit/modules.md
@@ -1,7 +1,7 @@
 ---
-id: "modules"
-title: "decoupled-kit-js"
-sidebar_label: "Exports"
+id: 'modules'
+title: 'decoupled-kit-js'
+sidebar_label: 'Exports'
 sidebar_position: 0.5
 custom_edit_url: null
 ---
@@ -16,10 +16,10 @@ Adds an aggregated list of surrogate keys in the working response.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `keys` | ``null`` \| `string` | Value for surrogate-key header in API response. |
-| `res` | `ServerResponse`<`IncomingMessage`\> | The active http.ServerResponse object. |
+| Name   | Type                                 | Description                                     |
+| :----- | :----------------------------------- | :---------------------------------------------- |
+| `keys` | `null` \| `string`                   | Value for surrogate-key header in API response. |
+| `res`  | `ServerResponse`<`IncomingMessage`\> | The active http.ServerResponse object.          |
 
 #### Returns
 
@@ -29,4 +29,4 @@ The current known unique set of surrogate keys.
 
 #### Defined in
 
-[src/utils/setSurrogateKeyHeader.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/cms-kit/src/utils/setSurrogateKeyHeader.ts#L17)
+[src/utils/setSurrogateKeyHeader.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/cms-kit/src/utils/setSurrogateKeyHeader.ts#L17)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/index.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/index.md
@@ -1,7 +1,7 @@
 ---
-id: 'index'
-title: 'decoupled-kit-js'
-sidebar_label: 'Readme'
+id: "index"
+title: "decoupled-kit-js"
+sidebar_label: "Readme"
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -62,10 +62,6 @@ generators may be run at a given time. See `watch.example.ts` for an example of
 ## API Reference
 
 <!-- TODO: link to API reference -->
-
-See
-[decoupledkit.pantheon.io](https://decoupledkit.pantheon.io/docs/Packages/create-pantheon-decoupled-kit/)
-for the API reference documentation.
 
 ## Contributing
 

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DecoupledKitGenerator.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DecoupledKitGenerator.md
@@ -1,6 +1,6 @@
 ---
 id: 'DecoupledKitGenerator'
-title: 'Interface: DecoupledKitGenerator<Prompts>'
+title: 'Interface: DecoupledKitGenerator<Prompts, Data>'
 sidebar_label: 'DecoupledKitGenerator'
 sidebar_position: 0
 custom_edit_url: null
@@ -10,9 +10,10 @@ Generators need prompts to get user data not provided by CLI arguments
 
 ## Type parameters
 
-| Name      | Type              |
-| :-------- | :---------------- |
-| `Prompts` | extends `Answers` |
+| Name      | Type                                  |
+| :-------- | :------------------------------------ |
+| `Prompts` | [`DefaultAnswers`](DefaultAnswers.md) |
+| `Data`    | `unknown`                             |
 
 ## Properties
 
@@ -24,7 +25,7 @@ An array of actions to run with the prompts and templates
 
 #### Defined in
 
-[src/types.ts:35](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L35)
+[src/types.ts:42](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L42)
 
 ---
 
@@ -37,19 +38,19 @@ the templates when de-duping.
 
 #### Defined in
 
-[src/types.ts:44](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L44)
+[src/types.ts:51](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L51)
 
 ---
 
 ### data
 
-• `Optional` **data**: `DataRecord`
+• `Optional` **data**: `Data`
 
 Any extra data that should be passed from the generator to the actions
 
 #### Defined in
 
-[src/types.ts:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L39)
+[src/types.ts:46](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L46)
 
 ---
 
@@ -61,7 +62,7 @@ Description of the generator
 
 #### Defined in
 
-[src/types.ts:22](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L22)
+[src/types.ts:25](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L25)
 
 ---
 
@@ -73,19 +74,39 @@ Generator's name. This should be kebab case.
 
 #### Defined in
 
-[src/types.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L18)
+[src/types.ts:21](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L21)
+
+---
+
+### nextSteps
+
+• `Optional` **nextSteps**: `string`[]
+
+Any message(s) to be rendered after actions are successfully completed.
+
+#### Defined in
+
+[src/types.ts:55](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L55)
 
 ---
 
 ### prompts
 
-• **prompts**: `QuestionCollection`<`Prompts`\>[]
+• **prompts**: `QuestionCollection`<[`DefaultAnswers`](DefaultAnswers.md)\>[]
 
 An array of inquirer prompts
 
+**`Template`**
+
+the type of the required user input
+
+**`Default`**
+
+DefaultAnswers - { outDir: string }
+
 #### Defined in
 
-[src/types.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L26)
+[src/types.ts:31](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L31)
 
 ---
 
@@ -98,4 +119,4 @@ generator does not have templates.
 
 #### Defined in
 
-[src/types.ts:31](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L31)
+[src/types.ts:38](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L38)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DefaultAnswers.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DefaultAnswers.md
@@ -1,16 +1,14 @@
 ---
-id: "DefaultAnswers"
-title: "Interface: DefaultAnswers"
-sidebar_label: "DefaultAnswers"
+id: 'DefaultAnswers'
+title: 'Interface: DefaultAnswers'
+sidebar_label: 'DefaultAnswers'
 sidebar_position: 0
 custom_edit_url: null
 ---
 
-Input from command line arguments and/or prompts
-
 ## Hierarchy
 
-- [`Input`](../modules.md#input)
+- `Answers`
 
   ↳ **`DefaultAnswers`**
 
@@ -22,4 +20,4 @@ Input from command line arguments and/or prompts
 
 #### Defined in
 
-[src/types.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L70)
+[src/types.ts:83](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L83)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateData.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateData.md
@@ -1,7 +1,7 @@
 ---
-id: "TemplateData"
-title: "Interface: TemplateData"
-sidebar_label: "TemplateData"
+id: 'TemplateData'
+title: 'Interface: TemplateData'
+sidebar_label: 'TemplateData'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -14,9 +14,9 @@ custom_edit_url: null
 
 #### Defined in
 
-[src/types.ts:62](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L62)
+[src/types.ts:75](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L75)
 
-___
+---
 
 ### templateDirs
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[src/types.ts:61](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L61)
+[src/types.ts:74](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L74)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/modules.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/modules.md
@@ -1,7 +1,7 @@
 ---
-id: "modules"
-title: "decoupled-kit-js"
-sidebar_label: "Exports"
+id: 'modules'
+title: 'decoupled-kit-js'
+sidebar_label: 'Exports'
 sidebar_position: 0.5
 custom_edit_url: null
 ---
@@ -23,13 +23,13 @@ custom_edit_url: null
 
 ▸ (`config`): `Promise`<`string`\> \| `string`
 
-An action that takes in the data, templates, and an instance of handlebars
-and does an action, like installing dependencies or formatting generated code
+An action that takes in the data, templates, and an instance of handlebars and
+does an action, like installing dependencies or formatting generated code
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type           |
+| :------- | :------------- |
 | `config` | `ActionConfig` |
 
 ##### Returns
@@ -38,9 +38,9 @@ and does an action, like installing dependencies or formatting generated code
 
 #### Defined in
 
-[src/types.ts:51](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L51)
+[src/types.ts:62](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L62)
 
-___
+---
 
 ### ActionRunner
 
@@ -52,8 +52,8 @@ ___
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                 |
+| :------- | :------------------- |
 | `config` | `ActionRunnerConfig` |
 
 ##### Returns
@@ -62,19 +62,19 @@ ___
 
 #### Defined in
 
-[src/types.ts:53](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L53)
+[src/types.ts:64](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L64)
 
-___
+---
 
 ### Input
 
-Ƭ **Input**: `ParsedArgs` & `Answers`
+Ƭ **Input**: { [Property in keyof InputIndex]: InputIndex[Property] }
 
-Input from command line arguments and/or prompts
+Input from command line arguments, prompts, and generator data
 
 #### Defined in
 
-[src/types.ts:58](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L58)
+[src/types.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L70)
 
 ## Variables
 
@@ -90,7 +90,17 @@ Handlebars HelperDelegate
 
 #### Defined in
 
-[src/utils/handlebars.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L10)
+[src/utils/handlebars.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L10)
+
+---
+
+### rootDir
+
+• `Const` **rootDir**: `string`
+
+#### Defined in
+
+[src/index.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/index.ts#L8)
 
 ## Functions
 
@@ -100,8 +110,8 @@ Handlebars HelperDelegate
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type                 |
+| :------- | :------------------- |
 | `config` | `ActionRunnerConfig` |
 
 #### Returns
@@ -110,24 +120,20 @@ Handlebars HelperDelegate
 
 #### Defined in
 
-[src/types.ts:53](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L53)
+[src/types.ts:64](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L64)
 
-___
+---
 
-### addWithDiff
+### addDependencies
 
-▸ **addWithDiff**(`config`): `string` \| `Promise`<`string`\>
+▸ **addDependencies**(`config`): `string` \| `Promise`<`string`\>
 
-1. dedupe the templates, favoring addons in case 2 paths collide
-2. check if the destination path exists or create it. (path to destination + template name minus .hbs) example: ./test/myTest.js
-3. check the diff against the new file and the rendered template or file to copy if source is not a handlebars template
-4. if the --force option is not defined, ask the user if we should overwrite this file (yes to all, yes, skip, abort) if force is true we write everything.
-5. skip or write the file based on input. If yes to all, set force to true.
+Adds any dependencies and/or devDependencies from the data field
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type           |
+| :------- | :------------- |
 | `config` | `ActionConfig` |
 
 #### Returns
@@ -136,27 +142,57 @@ ___
 
 #### Defined in
 
-[src/types.ts:51](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L51)
+[src/types.ts:62](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L62)
 
-___
+---
 
-### dedupeTemplates
+### addWithDiff
 
-▸ **dedupeTemplates**(`templateData`): `Promise`<[`MergedPaths`](interfaces/MergedPaths.md)\>
+▸ **addWithDiff**(`config`): `string` \| `Promise`<`string`\>
 
-In case there is a template path that exists in two or more generators,
-we want to favor the addon. This way, we avoid writing to a
-file multiple times
-
-**`See`**
-
- - Template
- - [MergedPaths](interfaces/MergedPaths.md)
+1. dedupe the templates, favoring addons in case 2 paths collide
+2. check if the destination path exists or create it. (path to destination +
+   template name minus .hbs) example: ./test/myTest.js
+3. check the diff against the new file and the rendered template or file to copy
+   if source is not a handlebars template
+4. if the --force option is not defined, ask the user if we should overwrite
+   this file (yes to all, yes, skip, abort) if force is true we write
+   everything.
+5. skip or write the file based on input. If yes to all, set force to true.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name     | Type           |
+| :------- | :------------- |
+| `config` | `ActionConfig` |
+
+#### Returns
+
+`string` \| `Promise`<`string`\>
+
+#### Defined in
+
+[src/types.ts:62](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L62)
+
+---
+
+### dedupeTemplates
+
+▸ **dedupeTemplates**(`templateData`):
+`Promise`<[`MergedPaths`](interfaces/MergedPaths.md)\>
+
+In case there is a template path that exists in two or more generators, we want
+to favor the addon. This way, we avoid writing to a file multiple times
+
+**`See`**
+
+- Template
+- [MergedPaths](interfaces/MergedPaths.md)
+
+#### Parameters
+
+| Name           | Type                                           | Description           |
+| :------------- | :--------------------------------------------- | :-------------------- |
 | `templateData` | [`TemplateData`](interfaces/TemplateData.md)[] | An array of Templates |
 
 #### Returns
@@ -167,9 +203,9 @@ MergedPaths
 
 #### Defined in
 
-[src/utils/dedupeTemplates.ts:71](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/utils/dedupeTemplates.ts#L71)
+[src/utils/dedupeTemplates.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/utils/dedupeTemplates.ts#L70)
 
-___
+---
 
 ### getHandlebarsInstance
 
@@ -183,8 +219,8 @@ resolves to {rootDir}/templates/partials
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name      | Type     | Description                           |
+| :-------- | :------- | :------------------------------------ |
 | `rootDir` | `string` | dir to look for the partials dir from |
 
 #### Returns
@@ -195,9 +231,9 @@ an instance of handlebars our with helpers and partials registered
 
 #### Defined in
 
-[src/utils/handlebars.ts:107](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L107)
+[src/utils/handlebars.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L119)
 
-___
+---
 
 ### helpMenu
 
@@ -205,9 +241,9 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `generators` | readonly [[`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<`NextWPAnswers`\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<`GatsbyWPAnswers`\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<`NextDrupalAnswers`\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md)\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md)\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md)\>] |
+| Name         | Type                                                                                                                           |
+| :----------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| `generators` | [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md), `unknown`\>[] |
 
 #### Returns
 
@@ -215,9 +251,9 @@ ___
 
 #### Defined in
 
-[src/utils/helpMenu.ts:3](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/utils/helpMenu.ts#L3)
+[src/utils/helpMenu.ts:3](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/utils/helpMenu.ts#L3)
 
-___
+---
 
 ### isString
 
@@ -225,9 +261,9 @@ ___
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `arg` | `unknown` | a variable |
+| Name  | Type      | Description |
+| :---- | :-------- | :---------- |
+| `arg` | `unknown` | a variable  |
 
 #### Returns
 
@@ -237,9 +273,9 @@ true if the variable is a string, false otherwise
 
 #### Defined in
 
-[src/types.ts:94](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L94)
+[src/types.ts:102](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L102)
 
-___
+---
 
 ### main
 
@@ -253,26 +289,30 @@ decoupledKitGenerators.
 
 **`Remarks`**
 
-positional args are assumed to be generator names. Multiple generators can be queued up this way. Any number of prompts may be skipped by passing in the prompt name via flag.
+positional args are assumed to be generator names. Multiple generators can be
+queued up this way. Any number of prompts may be skipped by passing in the
+prompt name via flag.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `args` | `ParsedArgs` | ParsedArgs |
-| `DecoupledKitGenerators` | readonly [[`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<`NextWPAnswers`\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<`GatsbyWPAnswers`\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<`NextDrupalAnswers`\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md)\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md)\>, [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md)\>] | An array of decoupledKitGenerators. |
+| Name                     | Type                                                                                                                           | Description                         |
+| :----------------------- | :----------------------------------------------------------------------------------------------------------------------------- | :---------------------------------- |
+| `args`                   | `ParsedArgs`                                                                                                                   | ParsedArgs                          |
+| `DecoupledKitGenerators` | [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md), `unknown`\>[] | An array of decoupledKitGenerators. |
 
 #### Returns
 
 `Promise`<`void`\>
 
-Runs the actions for the generators given as positional params or if none are found, prompts user to select valid generator from list of DecoupledKitGenerators
+Runs the actions for the generators given as positional params or if none are
+found, prompts user to select valid generator from list of
+DecoupledKitGenerators
 
 #### Defined in
 
-[src/index.ts:49](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/index.ts#L49)
+[src/index.ts:44](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/index.ts#L44)
 
-___
+---
 
 ### parseArgs
 
@@ -290,8 +330,8 @@ Parses CLI arguments using `minimist`
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name      | Type       | Description          |
+| :-------- | :--------- | :------------------- |
 | `cliArgs` | `string`[] | an array of strings. |
 
 #### Returns
@@ -300,21 +340,21 @@ Parses CLI arguments using `minimist`
 
 #### Defined in
 
-[src/index.ts:21](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/index.ts#L21)
+[src/index.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/index.ts#L16)
 
-___
+---
 
 ### runInstall
 
 ▸ **runInstall**(`config`): `string` \| `Promise`<`string`\>
 
-An action that takes in the data, templates, and an instance of handlebars
-and does an action, like installing dependencies or formatting generated code
+An action that takes in the data, templates, and an instance of handlebars and
+does an action, like installing dependencies or formatting generated code
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type           |
+| :------- | :------------- |
 | `config` | `ActionConfig` |
 
 #### Returns
@@ -323,21 +363,21 @@ and does an action, like installing dependencies or formatting generated code
 
 #### Defined in
 
-[src/types.ts:51](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L51)
+[src/types.ts:62](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L62)
 
-___
+---
 
 ### runLint
 
 ▸ **runLint**(`config`): `string` \| `Promise`<`string`\>
 
-An action that takes in the data, templates, and an instance of handlebars
-and does an action, like installing dependencies or formatting generated code
+An action that takes in the data, templates, and an instance of handlebars and
+does an action, like installing dependencies or formatting generated code
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type           |
+| :------- | :------------- |
 | `config` | `ActionConfig` |
 
 #### Returns
@@ -346,4 +386,4 @@ and does an action, like installing dependencies or formatting generated code
 
 #### Defined in
 
-[src/types.ts:51](https://github.com/pantheon-systems/decoupled-kit-js/blob/89c6e8b8e/packages/create-pantheon-decoupled-kit/src/types.ts#L51)
+[src/types.ts:62](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/create-pantheon-decoupled-kit/src/types.ts#L62)

--- a/web/docs/Packages/drupal-kit/classes/DrupalState.md
+++ b/web/docs/Packages/drupal-kit/classes/DrupalState.md
@@ -1,13 +1,12 @@
 ---
-id: "DrupalState"
-title: "Class: DrupalState"
-sidebar_label: "DrupalState"
+id: 'DrupalState'
+title: 'Class: DrupalState'
+sidebar_label: 'DrupalState'
 sidebar_position: 0
 custom_edit_url: null
 ---
 
-Configures DrupalState to integrate
-with a Decoupled Drupal CMS on Pantheon
+Configures DrupalState to integrate with a Decoupled Drupal CMS on Pantheon
 
 **`See`**
 
@@ -23,13 +22,13 @@ DrupalStateConfig for the full list parameters
 
 ### constructor
 
-• **new DrupalState**(`__namedParameters`)
+• **new DrupalState**(`«destructured»`)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `__namedParameters` | `DrupalStateConfig` |
+| Name             | Type                |
+| :--------------- | :------------------ |
+| `«destructured»` | `DrupalStateConfig` |
 
 #### Overrides
 
@@ -37,23 +36,25 @@ DrupalState.constructor
 
 #### Defined in
 
-[drupal-kit/src/lib/PantheonDrupalState.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L14)
+[drupal-kit/src/lib/PantheonDrupalState.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L14)
 
 ## Methods
 
 ### fetchData
 
-▸ **fetchData**(`endpoint`, `res?`, `anon?`): `Promise`<`void` \| `TJsonApiBody`\>
+▸ **fetchData**(`endpoint`, `res?`, `anon?`): `Promise`<`void` \|
+`TJsonApiBody`\>
 
-If a query is provided, fetches data using apollo-link-json-api, otherwise uses out fetch method.
+If a query is provided, fetches data using apollo-link-json-api, otherwise uses
+out fetch method.
 
 #### Parameters
 
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `endpoint` | `string` | `undefined` | the assembled JSON:API endpoint |
-| `res` | `boolean` \| `ServerResponse`<`IncomingMessage`\> | `false` | response object |
-| `anon` | `boolean` | `false` | - |
+| Name       | Type                                              | Default value | Description                     |
+| :--------- | :------------------------------------------------ | :------------ | :------------------------------ |
+| `endpoint` | `string`                                          | `undefined`   | the assembled JSON:API endpoint |
+| `res`      | `boolean` \| `ServerResponse`<`IncomingMessage`\> | `false`       | response object                 |
+| `anon`     | `boolean`                                         | `false`       | -                               |
 
 #### Returns
 
@@ -67,4 +68,4 @@ DrupalState.fetchData
 
 #### Defined in
 
-[drupal-kit/src/lib/PantheonDrupalState.ts:42](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L42)
+[drupal-kit/src/lib/PantheonDrupalState.ts:42](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L42)

--- a/web/docs/Packages/drupal-kit/interfaces/authInit.md
+++ b/web/docs/Packages/drupal-kit/interfaces/authInit.md
@@ -1,7 +1,7 @@
 ---
-id: "authInit"
-title: "Interface: authInit"
-sidebar_label: "authInit"
+id: 'authInit'
+title: 'Interface: authInit'
+sidebar_label: 'authInit'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -16,10 +16,10 @@ Object representing a fetch initialization object with an Authorization header
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
+| Name             | Type     |
+| :--------------- | :------- |
 | `Authorization?` | `string` |
 
 #### Defined in
 
-[drupal-kit/src/types/index.ts:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/drupal-kit/src/types/index.ts#L5)
+[drupal-kit/src/types/index.ts:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/drupal-kit/src/types/index.ts#L5)

--- a/web/docs/Packages/drupal-kit/modules.md
+++ b/web/docs/Packages/drupal-kit/modules.md
@@ -40,7 +40,36 @@ a promise containing the data for the JSON:API response
 
 #### Defined in
 
-[drupal-kit/src/lib/defaultFetch.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/drupal-kit/src/lib/defaultFetch.ts#L17)
+[drupal-kit/src/lib/defaultFetch.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/drupal-kit/src/lib/defaultFetch.ts#L16)
+
+---
+
+### getDrupalSearchResults
+
+▸ **getDrupalSearchResults**(`«destructured»`): `Promise`<`TJsonApiBody`\>
+
+Helper function to query the Drupal Search API.
+
+**`See`**
+
+[https://www.drupal.org/docs/contributed-modules/search-api](https://www.drupal.org/docs/contributed-modules/search-api)
+for more information about the Drupal Search API.
+
+#### Parameters
+
+| Name             | Type                           |
+| :--------------- | :----------------------------- |
+| `«destructured»` | `GetDrupalSearchResultsParams` |
+
+#### Returns
+
+`Promise`<`TJsonApiBody`\>
+
+An array of search results matching the query.
+
+#### Defined in
+
+[drupal-kit/src/lib/getDrupalSearchResults.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/drupal-kit/src/lib/getDrupalSearchResults.ts#L23)
 
 ---
 
@@ -65,4 +94,4 @@ The current known unique set of surrogate keys.
 
 #### Defined in
 
-cms-kit/dist/src/utils/setSurrogateKeyHeader.d.ts:8
+[cms-kit/src/utils/setSurrogateKeyHeader.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/cms-kit/src/utils/setSurrogateKeyHeader.ts#L17)

--- a/web/docs/Packages/nextjs-kit/interfaces/ContentProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/ContentProps.md
@@ -1,7 +1,7 @@
 ---
-id: "ContentProps"
-title: "Interface: ContentProps"
-sidebar_label: "ContentProps"
+id: 'ContentProps'
+title: 'Interface: ContentProps'
+sidebar_label: 'ContentProps'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -14,9 +14,9 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/contentWithImage.tsx#L8)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/contentWithImage.tsx#L8)
 
-___
+---
 
 ### contentClassName
 
@@ -24,9 +24,9 @@ ___
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/contentWithImage.tsx#L14)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/contentWithImage.tsx#L14)
 
-___
+---
 
 ### date
 
@@ -34,9 +34,9 @@ ___
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/contentWithImage.tsx#L9)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/contentWithImage.tsx#L9)
 
-___
+---
 
 ### imageProps
 
@@ -44,16 +44,16 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `alt?` | `string` |
-| `src` | `string` \| `StaticImport` |
+| Name   | Type                       |
+| :----- | :------------------------- |
+| `alt?` | `string`                   |
+| `src`  | `string` \| `StaticImport` |
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/contentWithImage.tsx#L10)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/contentWithImage.tsx#L10)
 
-___
+---
 
 ### title
 
@@ -61,4 +61,4 @@ ___
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/contentWithImage.tsx#L7)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/contentWithImage.tsx#L7)

--- a/web/docs/Packages/nextjs-kit/interfaces/FooterMenuProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/FooterMenuProps.md
@@ -1,7 +1,7 @@
 ---
-id: "FooterMenuProps"
-title: "Interface: FooterMenuProps"
-sidebar_label: "FooterMenuProps"
+id: 'FooterMenuProps'
+title: 'Interface: FooterMenuProps'
+sidebar_label: 'FooterMenuProps'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -14,9 +14,9 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/footer.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/footer.tsx#L7)
+[packages/nextjs-kit/src/components/footer.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/footer.tsx#L7)
 
-___
+---
 
 ### footerMenuItems
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/footer.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/footer.tsx#L6)
+[packages/nextjs-kit/src/components/footer.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/footer.tsx#L6)

--- a/web/docs/Packages/nextjs-kit/interfaces/HeaderProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/HeaderProps.md
@@ -1,7 +1,7 @@
 ---
-id: "HeaderProps"
-title: "Interface: HeaderProps"
-sidebar_label: "HeaderProps"
+id: 'HeaderProps'
+title: 'Interface: HeaderProps'
+sidebar_label: 'HeaderProps'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -14,4 +14,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/header.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/header.tsx#L6)
+[packages/nextjs-kit/src/components/header.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/header.tsx#L6)

--- a/web/docs/Packages/nextjs-kit/interfaces/LinkProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/LinkProps.md
@@ -1,7 +1,7 @@
 ---
-id: "LinkProps"
-title: "Interface: LinkProps"
-sidebar_label: "LinkProps"
+id: 'LinkProps'
+title: 'Interface: LinkProps'
+sidebar_label: 'LinkProps'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -18,9 +18,9 @@ The href to apply to the link.
 
 #### Defined in
 
-[packages/nextjs-kit/src/types/index.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/types/index.ts#L30)
+[packages/nextjs-kit/src/types/index.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/types/index.ts#L30)
 
-___
+---
 
 ### linkText
 
@@ -30,4 +30,4 @@ The text to display in the link
 
 #### Defined in
 
-[packages/nextjs-kit/src/types/index.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/types/index.ts#L26)
+[packages/nextjs-kit/src/types/index.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/types/index.ts#L26)

--- a/web/docs/Packages/nextjs-kit/interfaces/PaginationProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/PaginationProps.md
@@ -1,7 +1,7 @@
 ---
-id: "PaginationProps"
-title: "Interface: PaginationProps<Type>"
-sidebar_label: "PaginationProps"
+id: 'PaginationProps'
+title: 'Interface: PaginationProps<Type>'
+sidebar_label: 'PaginationProps'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -10,8 +10,8 @@ Options type for [Paginator](../modules.md#paginator)
 
 ## Type parameters
 
-| Name | Description |
-| :------ | :------ |
+| Name   | Description                                        |
+| :----- | :------------------------------------------------- |
 | `Type` | type to use for the data passed in to be paginated |
 
 ## Properties
@@ -24,36 +24,37 @@ The React component to render for each datum
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/paginator.tsx#L39)
+[packages/nextjs-kit/src/components/paginator.tsx:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/paginator.tsx#L39)
 
-___
+---
 
 ### breakpoints
 
 • **breakpoints**: `Object`
 
-* start: where to start the breakpoint
+- start: where to start the breakpoint
 
 end: where to end the breakpoint
 
 add: how many buttons to add when the breakpoint is clicked
 
-(`add` * x) + `start` = `end` where x is a number of clicks it takes to fill in all of the buttons
-For example: If there are 25 buttons and the start = 5 and end = 25, then add should be 5 or 10.
+(`add` \* x) + `start` = `end` where x is a number of clicks it takes to fill in
+all of the buttons For example: If there are 25 buttons and the start = 5 and
+end = 25, then add should be 5 or 10.
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `add` | `number` |
-| `end` | `number` |
+| Name    | Type     |
+| :------ | :------- |
+| `add`   | `number` |
+| `end`   | `number` |
 | `start` | `number` |
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:27](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/paginator.tsx#L27)
+[packages/nextjs-kit/src/components/paginator.tsx:27](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/paginator.tsx#L27)
 
-___
+---
 
 ### data
 
@@ -63,9 +64,9 @@ The type of data to paginate
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/paginator.tsx#L12)
+[packages/nextjs-kit/src/components/paginator.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/paginator.tsx#L12)
 
-___
+---
 
 ### itemsPerPage
 
@@ -75,16 +76,17 @@ Number of items per page
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/paginator.tsx#L16)
+[packages/nextjs-kit/src/components/paginator.tsx:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/paginator.tsx#L16)
 
-___
+---
 
 ### routing
 
 • **routing**: `boolean`
 
-If true, uses Next.js shallow routing [https://nextjs.org/docs/routing/shallow-routing](https://nextjs.org/docs/routing/shallow-routing)
+If true, uses Next.js shallow routing
+[https://nextjs.org/docs/routing/shallow-routing](https://nextjs.org/docs/routing/shallow-routing)
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:35](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/paginator.tsx#L35)
+[packages/nextjs-kit/src/components/paginator.tsx:35](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/paginator.tsx#L35)

--- a/web/docs/Packages/nextjs-kit/interfaces/PreviewRibbonProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/PreviewRibbonProps.md
@@ -1,7 +1,7 @@
 ---
-id: "PreviewRibbonProps"
-title: "Interface: PreviewRibbonProps"
-sidebar_label: "PreviewRibbonProps"
+id: 'PreviewRibbonProps'
+title: 'Interface: PreviewRibbonProps'
+sidebar_label: 'PreviewRibbonProps'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -14,4 +14,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/previewRibbon.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/previewRibbon.tsx#L6)
+[packages/nextjs-kit/src/components/previewRibbon.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/previewRibbon.tsx#L6)

--- a/web/docs/Packages/nextjs-kit/interfaces/RecipeProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/RecipeProps.md
@@ -1,7 +1,7 @@
 ---
-id: "RecipeProps"
-title: "Interface: RecipeProps"
-sidebar_label: "RecipeProps"
+id: 'RecipeProps'
+title: 'Interface: RecipeProps'
+sidebar_label: 'RecipeProps'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -14,9 +14,9 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/recipe.tsx#L8)
+[packages/nextjs-kit/src/components/recipe.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/recipe.tsx#L8)
 
-___
+---
 
 ### children
 
@@ -24,9 +24,9 @@ ___
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/recipe.tsx#L15)
+[packages/nextjs-kit/src/components/recipe.tsx:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/recipe.tsx#L15)
 
-___
+---
 
 ### imageProps
 
@@ -34,16 +34,16 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `alt?` | `string` |
-| `src` | `string` \| `StaticImport` |
+| Name   | Type                       |
+| :----- | :------------------------- |
+| `alt?` | `string`                   |
+| `src`  | `string` \| `StaticImport` |
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/recipe.tsx#L11)
+[packages/nextjs-kit/src/components/recipe.tsx:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/recipe.tsx#L11)
 
-___
+---
 
 ### ingredients
 
@@ -51,9 +51,9 @@ ___
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/recipe.tsx#L9)
+[packages/nextjs-kit/src/components/recipe.tsx:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/recipe.tsx#L9)
 
-___
+---
 
 ### instructions
 
@@ -61,9 +61,9 @@ ___
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/recipe.tsx#L10)
+[packages/nextjs-kit/src/components/recipe.tsx:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/recipe.tsx#L10)
 
-___
+---
 
 ### title
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/recipe.tsx#L7)
+[packages/nextjs-kit/src/components/recipe.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/recipe.tsx#L7)

--- a/web/docs/Packages/nextjs-kit/interfaces/SortOptions.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/SortOptions.md
@@ -1,7 +1,7 @@
 ---
-id: "SortOptions"
-title: "Interface: SortOptions"
-sidebar_label: "SortOptions"
+id: 'SortOptions'
+title: 'Interface: SortOptions'
+sidebar_label: 'SortOptions'
 sidebar_position: 0
 custom_edit_url: null
 ---
@@ -18,21 +18,21 @@ The data to be sorted
 
 #### Defined in
 
-[packages/nextjs-kit/src/types/index.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/types/index.ts#L8)
+[packages/nextjs-kit/src/types/index.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/types/index.ts#L8)
 
-___
+---
 
 ### direction
 
-• **direction**: ``"desc"`` \| ``"asc"`` \| ``"ASC"`` \| ``"DESC"``
+• **direction**: `"desc"` \| `"asc"` \| `"ASC"` \| `"DESC"`
 
 The direction to sort the data
 
 #### Defined in
 
-[packages/nextjs-kit/src/types/index.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/types/index.ts#L16)
+[packages/nextjs-kit/src/types/index.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/types/index.ts#L16)
 
-___
+---
 
 ### key
 
@@ -42,4 +42,4 @@ The key on which to sort
 
 #### Defined in
 
-[packages/nextjs-kit/src/types/index.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/types/index.ts#L12)
+[packages/nextjs-kit/src/types/index.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/types/index.ts#L12)

--- a/web/docs/Packages/nextjs-kit/modules.md
+++ b/web/docs/Packages/nextjs-kit/modules.md
@@ -1,7 +1,7 @@
 ---
-id: "modules"
-title: "decoupled-kit-js"
-sidebar_label: "Exports"
+id: 'modules'
+title: 'decoupled-kit-js'
+sidebar_label: 'Exports'
 sidebar_position: 0.5
 custom_edit_url: null
 ---
@@ -21,7 +21,8 @@ custom_edit_url: null
 
 ### FooterMenuItem
 
-Ƭ **FooterMenuItem**: [`LinkProps`](interfaces/LinkProps.md) & { [key in Parent]?: string \| null }
+Ƭ **FooterMenuItem**: [`LinkProps`](interfaces/LinkProps.md) & { [key in
+Parent]?: string \| null }
 
 An item in a footer menu.
 
@@ -31,57 +32,60 @@ This should account for Drupal and WordPress menus
 
 #### Defined in
 
-[packages/nextjs-kit/src/types/index.ts:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/types/index.ts#L39)
+[packages/nextjs-kit/src/types/index.ts:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/types/index.ts#L39)
 
-___
+---
 
 ### Parent
 
-Ƭ **Parent**: ``"parent"`` \| ``"parentId"``
+Ƭ **Parent**: `"parent"` \| `"parentId"`
 
 #### Defined in
 
-[packages/nextjs-kit/src/types/index.ts:33](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/types/index.ts#L33)
+[packages/nextjs-kit/src/types/index.ts:33](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/types/index.ts#L33)
 
 ## Functions
 
 ### ContentWithImage
 
-▸ **ContentWithImage**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+▸ **ContentWithImage**(`props`, `context?`): `null` \| `ReactElement`<`any`,
+`any`\>
 
 **`See`**
 
-[https://nextjs.org/docs/api-reference/next/image](https://nextjs.org/docs/api-reference/next/image) for more information.
+[https://nextjs.org/docs/api-reference/next/image](https://nextjs.org/docs/api-reference/next/image)
+for more information.
 
 **`Remarks`**
 
-`imageProps` is an optional prop to be used if there is an image associated with the content.
-If `imageProps.src` is a supplied as a prop. Alt text is not required; however,
-it is strongly recommended to add alt text to all images for accessibility and SEO.
-If alt text is not supplied, the title of the content will be used.
+`imageProps` is an optional prop to be used if there is an image associated with
+the content. If `imageProps.src` is a supplied as a prop. Alt text is not
+required; however, it is strongly recommended to add alt text to all images for
+accessibility and SEO. If alt text is not supplied, the title of the content
+will be used.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `PropsWithChildren`<[`ContentProps`](interfaces/ContentProps.md)\> | The props needed for the ContentWithImage component |
-| `context?` | `any` | - |
+| Name       | Type                                         | Description                                         |
+| :--------- | :------------------------------------------- | :-------------------------------------------------- |
+| `props`    | [`ContentProps`](interfaces/ContentProps.md) | The props needed for the ContentWithImage component |
+| `context?` | `any`                                        | -                                                   |
 
 #### Returns
 
-``null`` \| `ReactElement`<`any`, `any`\>
+`null` \| `ReactElement`<`any`, `any`\>
 
 A component with a featured image and content passed by the user
 
 #### Defined in
 
-node_modules/.pnpm/@types+react@17.0.40/node_modules/@types/react/index.d.ts:550
+node_modules/.pnpm/@types+react@18.0.31/node_modules/@types/react/index.d.ts:521
 
-___
+---
 
 ### Footer
 
-▸ **Footer**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+▸ **Footer**(`props`, `context?`): `null` \| `ReactElement`<`any`, `any`\>
 
 This is a Footer component.
 
@@ -104,50 +108,51 @@ const footerMenuItems = [
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `PropsWithChildren`<[`FooterMenuProps`](interfaces/FooterMenuProps.md)\> | The props needed for the footer component |
-| `context?` | `any` | - |
+| Name       | Type                                               | Description                               |
+| :--------- | :------------------------------------------------- | :---------------------------------------- |
+| `props`    | [`FooterMenuProps`](interfaces/FooterMenuProps.md) | The props needed for the footer component |
+| `context?` | `any`                                              | -                                         |
 
 #### Returns
 
-``null`` \| `ReactElement`<`any`, `any`\>
+`null` \| `ReactElement`<`any`, `any`\>
 
 A footer component with a nav menu
 
 #### Defined in
 
-node_modules/.pnpm/@types+react@17.0.40/node_modules/@types/react/index.d.ts:550
+node_modules/.pnpm/@types+react@18.0.31/node_modules/@types/react/index.d.ts:521
 
-___
+---
 
 ### Grid
 
-▸ **Grid**(`__namedParameters`): `Element`
+▸ **Grid**(`«destructured»`): `Element`
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `__namedParameters` | `Object` |
-| `__namedParameters.children?` | `Element`[] |
-| `__namedParameters.cols?` | `number` |
+| Name             | Type        |
+| :--------------- | :---------- |
+| `«destructured»` | `Object`    |
+| › `children?`    | `Element`[] |
+| › `cols?`        | `number`    |
 
 #### Returns
 
 `Element`
 
-A style and positioning helper grid component that can be used with the withGrid HOC component
+A style and positioning helper grid component that can be used with the withGrid
+HOC component
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/grid.tsx:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/grid.tsx#L10)
+[packages/nextjs-kit/src/components/grid.tsx:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/grid.tsx#L10)
 
-___
+---
 
 ### Header
 
-▸ **Header**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+▸ **Header**(`props`, `context?`): `null` \| `ReactElement`<`any`, `any`\>
 
 This is a Header component.
 
@@ -169,22 +174,22 @@ const navItems = [
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `PropsWithChildren`<[`HeaderProps`](interfaces/HeaderProps.md)\> | The props needed for the header component |
-| `context?` | `any` | - |
+| Name       | Type                                       | Description                               |
+| :--------- | :----------------------------------------- | :---------------------------------------- |
+| `props`    | [`HeaderProps`](interfaces/HeaderProps.md) | The props needed for the header component |
+| `context?` | `any`                                      | -                                         |
 
 #### Returns
 
-``null`` \| `ReactElement`<`any`, `any`\>
+`null` \| `ReactElement`<`any`, `any`\>
 
 A header component with a nav menu
 
 #### Defined in
 
-node_modules/.pnpm/@types+react@17.0.40/node_modules/@types/react/index.d.ts:550
+node_modules/.pnpm/@types+react@18.0.31/node_modules/@types/react/index.d.ts:521
 
-___
+---
 
 ### Paginator
 
@@ -192,7 +197,8 @@ ___
 
 **`See`**
 
-[https://github.com/pantheon-systems/decoupled-kit-js/tree/canary/starters/next-drupal-starter/pages/examples/pagination/[[...page]].js](https://github.com/pantheon-systems/decoupled-kit-js/tree/canary/starters/next-drupal-starter/pages/examples/pagination/[[...page]].js) for a full example implementation
+[https://github.com/pantheon-systems/decoupled-kit-js/tree/canary/starters/next-drupal-starter/pages/examples/pagination/[[...page]].js](https://github.com/pantheon-systems/decoupled-kit-js/tree/canary/starters/next-drupal-starter/pages/examples/pagination/[[...page]].js)
+for a full example implementation
 
 **`Example`**
 
@@ -208,14 +214,14 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name   | Type             |
+| :----- | :--------------- |
 | `Type` | extends `object` |
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name    | Type                                                        | Description                                  |
+| :------ | :---------------------------------------------------------- | :------------------------------------------- |
 | `props` | [`PaginationProps`](interfaces/PaginationProps.md)<`Type`\> | The props needed for the paginator component |
 
 #### Returns
@@ -226,64 +232,67 @@ Component with data rendered by the passed in Component and page buttons
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:82](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/paginator.tsx#L82)
+[packages/nextjs-kit/src/components/paginator.tsx:82](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/paginator.tsx#L82)
 
-___
+---
 
 ### PreviewRibbon
 
-▸ **PreviewRibbon**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+▸ **PreviewRibbon**(`props`, `context?`): `null` \| `ReactElement`<`any`,
+`any`\>
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `props` | `PropsWithChildren`<[`PreviewRibbonProps`](interfaces/PreviewRibbonProps.md)\> |
-| `context?` | `any` |
+| Name       | Type                                                     |
+| :--------- | :------------------------------------------------------- |
+| `props`    | [`PreviewRibbonProps`](interfaces/PreviewRibbonProps.md) |
+| `context?` | `any`                                                    |
 
 #### Returns
 
-``null`` \| `ReactElement`<`any`, `any`\>
+`null` \| `ReactElement`<`any`, `any`\>
 
 #### Defined in
 
-node_modules/.pnpm/@types+react@17.0.40/node_modules/@types/react/index.d.ts:550
+node_modules/.pnpm/@types+react@18.0.31/node_modules/@types/react/index.d.ts:521
 
-___
+---
 
 ### Recipe
 
-▸ **Recipe**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+▸ **Recipe**(`props`, `context?`): `null` \| `ReactElement`<`any`, `any`\>
 
 **`See`**
 
-[https://nextjs.org/docs/api-reference/next/image](https://nextjs.org/docs/api-reference/next/image) for more information.
+[https://nextjs.org/docs/api-reference/next/image](https://nextjs.org/docs/api-reference/next/image)
+for more information.
 
 **`Remarks`**
 
-`imageProps` is an optional prop to be used if there is an image associated with the content.
-If `imageProps.src` is a supplied as a prop. Alt text is not required; however,
-it is strongly recommended to add alt text to all images for accessibility and SEO.
-If alt text is not supplied, the title of the content will be used.
+`imageProps` is an optional prop to be used if there is an image associated with
+the content. If `imageProps.src` is a supplied as a prop. Alt text is not
+required; however, it is strongly recommended to add alt text to all images for
+accessibility and SEO. If alt text is not supplied, the title of the content
+will be used.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `props` | `PropsWithChildren`<[`RecipeProps`](interfaces/RecipeProps.md)\> | The props needed for the Recipe component |
-| `context?` | `any` | - |
+| Name       | Type                                       | Description                               |
+| :--------- | :----------------------------------------- | :---------------------------------------- |
+| `props`    | [`RecipeProps`](interfaces/RecipeProps.md) | The props needed for the Recipe component |
+| `context?` | `any`                                      | -                                         |
 
 #### Returns
 
-``null`` \| `ReactElement`<`any`, `any`\>
+`null` \| `ReactElement`<`any`, `any`\>
 
 A recipe component with content and an optional image passed by the user
 
 #### Defined in
 
-node_modules/.pnpm/@types+react@17.0.40/node_modules/@types/react/index.d.ts:550
+node_modules/.pnpm/@types+react@18.0.31/node_modules/@types/react/index.d.ts:521
 
-___
+---
 
 ### sortChar
 
@@ -293,8 +302,8 @@ Sorts any character object on a specific key in a direction of the users choice.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type                                       |
+| :-------- | :----------------------------------------- |
 | `sortObj` | [`SortOptions`](interfaces/SortOptions.md) |
 
 #### Returns
@@ -305,20 +314,21 @@ An array of data sorted by the given key and direction
 
 #### Defined in
 
-[packages/nextjs-kit/src/lib/sortChar.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/lib/sortChar.ts#L12)
+[packages/nextjs-kit/src/lib/sortChar.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/lib/sortChar.ts#L12)
 
-___
+---
 
 ### sortDate
 
 ▸ **sortDate**(`sortObj`): `Record`<`string`, `string` \| `number`\>[]
 
-Sorts any date field of an object on a specific key in a direction of the users choice.
+Sorts any date field of an object on a specific key in a direction of the users
+choice.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name      | Type                                       |
+| :-------- | :----------------------------------------- |
 | `sortObj` | [`SortOptions`](interfaces/SortOptions.md) |
 
 #### Returns
@@ -329,17 +339,20 @@ An array of data sorted by the given key and direction
 
 #### Defined in
 
-[packages/nextjs-kit/src/lib/sortDate.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/lib/sortDate.ts#L11)
+[packages/nextjs-kit/src/lib/sortDate.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/lib/sortDate.ts#L11)
 
-___
+---
 
 ### withGrid
 
-▸ **withGrid**(`Component`): <Type\>(`__namedParameters`: { `FallbackComponent?`: `ElementType`<`any`\> ; `cols?`: `number` ; `data?`: `Type`[]  }) => `Element`
+▸ **withGrid**(`Component`): <Type\>(`__namedParameters`: {
+`FallbackComponent?`: `ElementType`<`any`\> ; `cols?`: `number` ; `data?`:
+`Type`[] }) => `Element`
 
 **`Remarks`**
 
-The Component used must accept the data to be displayed as `content` to function properly
+The Component used must accept the data to be displayed as `content` to function
+properly
 
 **`Example`**
 
@@ -373,8 +386,8 @@ const MyPage = ({ myArticles }) => {
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name        | Type                  | Description                                                           |
+| :---------- | :-------------------- | :-------------------------------------------------------------------- |
 | `Component` | `ElementType`<`any`\> | A component that takes in content that is to be displayed on the grid |
 
 #### Returns
@@ -383,7 +396,7 @@ const MyPage = ({ myArticles }) => {
 
 A Higher Order Component that returns the data mapped to the Component in a grid
 
-▸ <`Type`\>(`__namedParameters`): `Element`
+▸ <`Type`\>(`«destructured»`): `Element`
 
 **`Default`**
 
@@ -391,18 +404,18 @@ A Higher Order Component that returns the data mapped to the Component in a grid
 
 ##### Type parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name   | Type             |
+| :----- | :--------------- |
 | `Type` | extends `object` |
 
 ##### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `__namedParameters` | `Object` |
-| `__namedParameters.FallbackComponent?` | `ElementType`<`any`\> |
-| `__namedParameters.cols?` | `number` |
-| `__namedParameters.data?` | `Type`[] |
+| Name                   | Type                  |
+| :--------------------- | :-------------------- |
+| `«destructured»`       | `Object`              |
+| › `FallbackComponent?` | `ElementType`<`any`\> |
+| › `cols?`              | `number`              |
+| › `data?`              | `Type`[]              |
 
 ##### Returns
 
@@ -412,4 +425,4 @@ The component passed to withGrid in a grid with the given number of columns
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/grid.tsx:61](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/nextjs-kit/src/components/grid.tsx#L61)
+[packages/nextjs-kit/src/components/grid.tsx:61](https://github.com/pantheon-systems/decoupled-kit-js/blob/5ccd9d50b/packages/nextjs-kit/src/components/grid.tsx#L61)


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Docs with `npm init` commands that use args have been updated to include the double dash that is required to forward args to the command
- Generated api reference - I meant to do this last sprint and we're a bit behind. Seems like an OK time to do this.
## Where were the changes made?
`web/docs`, project generator READMEs
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->