### PR TITLE
DB-5914: Fix GraphQLFactory options type

### DIFF
--- a/.changeset/olive-wolves-call.md
+++ b/.changeset/olive-wolves-call.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/eslint-config-decoupled-kit': patch
+---
+
+[next-wp][gatsby-wp] Bump `@pantheon-systems/wordpress-kit` version

--- a/.changeset/weak-dragons-agree.md
+++ b/.changeset/weak-dragons-agree.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/wordpress-kit': patch
+---
+
+Fixed the type used for GraphQLClientFactory options

--- a/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts
+++ b/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts
@@ -1,9 +1,9 @@
 import { GraphQLClient } from 'graphql-request';
-import type { PatchedRequestInit } from 'graphql-request/dist/types';
+import type { RequestConfig } from 'graphql-request/src/types';
 /**
- * Creates instances of `graphql-request` GraphQLClient with the given options
- * @params endpoint - A WordPress GraphQL endpoint
- * @params options - A RequestInit object. {@link PatchedRequestInit}
+ * Creates instances of `graphql-request` {@link GraphQLClient} with the given options.
+ * @params endpoint - A WordPress GraphQL endpoint.
+ * @params options - A {@link RequestConfig} object.
  */
 class GraphQLClientFactory {
 	/**
@@ -11,11 +11,11 @@ class GraphQLClientFactory {
 	 */
 	endpoint: string;
 	/**
-	 * {@link PatchedRequestInit}
+	 * {@link RequestOptions}
 	 */
-	options: PatchedRequestInit;
+	options: RequestConfig;
 
-	constructor(endpoint: string, options: PatchedRequestInit = {}) {
+	constructor(endpoint: string, options: RequestConfig) {
 		this.endpoint = endpoint;
 		this.options = {
 			...options,
@@ -23,7 +23,7 @@ class GraphQLClientFactory {
 				'Pantheon-SKey': '1',
 			},
 			jsonSerializer:
-				options.method === 'GET'
+				options?.method === 'GET'
 					? { parse: JSON.parse, stringify: JSON.stringify }
 					: undefined,
 		};

--- a/web/docs/Packages/wordpress-kit/classes/GraphqlClientFactory.md
+++ b/web/docs/Packages/wordpress-kit/classes/GraphqlClientFactory.md
@@ -1,37 +1,37 @@
 ---
-id: "GraphqlClientFactory"
-title: "Class: GraphqlClientFactory"
-sidebar_label: "GraphqlClientFactory"
+id: 'GraphqlClientFactory'
+title: 'Class: GraphqlClientFactory'
+sidebar_label: 'GraphqlClientFactory'
 sidebar_position: 0
 custom_edit_url: null
 ---
 
-Creates instances of `graphql-request` GraphQLClient with the given options
+Creates instances of `graphql-request` GraphQLClient with the given options.
 
 **`Params`**
 
-endpoint - A WordPress GraphQL endpoint
+endpoint - A WordPress GraphQL endpoint.
 
 **`Params`**
 
-options - A RequestInit object. PatchedRequestInit
+options - A RequestConfig object.
 
 ## Constructors
 
 ### constructor
 
-• **new GraphqlClientFactory**(`endpoint`, `options?`)
+• **new GraphqlClientFactory**(`endpoint`, `options`)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `endpoint` | `string` |
-| `options` | `PatchedRequestInit` |
+| Name       | Type            |
+| :--------- | :-------------- |
+| `endpoint` | `string`        |
+| `options`  | `RequestConfig` |
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts#L18)
+[packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/4c02f3b62/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts#L18)
 
 ## Properties
 
@@ -43,19 +43,19 @@ A WordPress GraphQL endpoint
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts#L12)
+[packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/4c02f3b62/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts#L12)
 
-___
+---
 
 ### options
 
-• **options**: `PatchedRequestInit`
+• **options**: `RequestConfig`
 
-PatchedRequestInit
+RequestOptions
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts#L16)
+[packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/4c02f3b62/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts#L16)
 
 ## Methods
 
@@ -63,7 +63,8 @@ PatchedRequestInit
 
 ▸ **create**(): `GraphQLClient`
 
-Creates an instance of `graphql-request` GraphQLClient based on the endpoint and options
+Creates an instance of `graphql-request` GraphQLClient based on the endpoint and
+options
 
 #### Returns
 
@@ -71,4 +72,4 @@ Creates an instance of `graphql-request` GraphQLClient based on the endpoint and
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts:34](https://github.com/pantheon-systems/decoupled-kit-js/blob/b8ccc359/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts#L34)
+[packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts:34](https://github.com/pantheon-systems/decoupled-kit-js/blob/4c02f3b62/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts#L34)


### PR DESCRIPTION

 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Use proper type from graphql-request in GraphQLClient factory in wp-kit
- Generate new api ref for this class
- Add changesets. Bump included for create- so that the canary version includes the latest wp-kit version.

## Where were the changes made?
`wordpress-kit`. API ref docs were also regenerated.
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tests pass, no more TS errors

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->