### PR TITLE
DB-5574: getObject generic

### DIFF
--- a/.changeset/clever-ties-smile.md
+++ b/.changeset/clever-ties-smile.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/drupal-kit': minor
+---
+
+Overload getObject methods to accept a generic that will be used as the return
+type

--- a/.changeset/light-socks-protect.md
+++ b/.changeset/light-socks-protect.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `@pantheon-systems/drupal-kit` and `@pantheon-systems/cms-kit`

--- a/.changeset/perfect-dolphins-relax.md
+++ b/.changeset/perfect-dolphins-relax.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/cms-kit': patch
+---
+
+Fix minor TypeScript error regarding iterating over Sets

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,5 +3,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 pnpm --workspace-concurrency=1 --filter './packages/**' lint-staged
-pnpm --filter './starters/**' lint
-pnpm test
+pnpm --filter './packages/**' test

--- a/packages/cms-kit/src/utils/setSurrogateKeyHeader.ts
+++ b/packages/cms-kit/src/utils/setSurrogateKeyHeader.ts
@@ -25,9 +25,8 @@ const setSurrogateKeyHeader = (
 			const surrogateKeys = surrogateKeyHeader?.split(' ');
 			const newSurrogateKeys = keys?.split(' ') as string[];
 			// Destructure into a new array in order to de-dupe the array
-			const uniqueKeysArr = [
-				...new Set([...surrogateKeys, ...newSurrogateKeys]),
-			];
+			const uniqueKeysArr = [];
+			uniqueKeysArr.push(...new Set([...surrogateKeys, ...newSurrogateKeys]));
 			const uniqueSurrogateKeys = uniqueKeysArr.join(' ');
 			res.setHeader('Surrogate-Key', uniqueSurrogateKeys);
 			return uniqueSurrogateKeys;

--- a/packages/drupal-kit/src/lib/PantheonDrupalState.ts
+++ b/packages/drupal-kit/src/lib/PantheonDrupalState.ts
@@ -3,7 +3,11 @@ import { DrupalState } from '@gdwc/drupal-state';
 import defaultFetch from './defaultFetch';
 
 import type { TJsonApiBody } from 'jsona/lib/JsonaTypes';
-import type { DrupalStateConfig } from '@gdwc/drupal-state/src/types/types';
+import type {
+	DrupalStateConfig,
+	GetObjectByPathParams,
+	GetObjectParams,
+} from '@gdwc/drupal-state/src/types/types';
 
 /**
  * Configures DrupalState to integrate
@@ -61,6 +65,17 @@ class PantheonDrupalState extends DrupalState {
 			this.onError,
 			res,
 		)) as TJsonApiBody;
+	}
+
+	async getObject<ReturnedData>(
+		args: GetObjectParams,
+	): Promise<ReturnedData | void> {
+		return (await super.getObject({ ...args })) as ReturnedData | void;
+	}
+	async getObjectByPath<ReturnedData>(
+		args: GetObjectByPathParams,
+	): Promise<ReturnedData | void> {
+		return (await super.getObjectByPath({ ...args })) as ReturnedData | void;
 	}
 }
 

--- a/scripts/generate-starters.ts
+++ b/scripts/generate-starters.ts
@@ -3,24 +3,29 @@ import { execSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
 const generateStarters = () => {
+	const cmsEndpoint = '';
+	const options = '--force --noInstall --tailwindcss';
 	const inputs = [
 		{
 			appName: 'next-drupal-starter',
 			outDir: './starters/next-drupal-starter',
 			generators: 'next-drupal next-drupal-umami-addon',
-			options: '--force --noInstall --tailwindcss',
+			cmsEndpoint,
+			options,
 		},
 		{
 			appName: 'next-wordpress-starter',
 			outDir: './starters/next-wordpress-starter',
 			generators: 'next-wp',
-			options: '--force --noInstall --tailwindcss',
+			cmsEndpoint,
+			options,
 		},
 		{
 			appName: 'gatsby-wordpress-starter',
 			outDir: './starters/gatsby-wordpress-starter',
 			generators: 'gatsby-wp',
-			options: '--force --noInstall --tailwindcss',
+			cmsEndpoint,
+			options,
 		},
 	];
 
@@ -30,9 +35,11 @@ const generateStarters = () => {
 				`node ./packages/create-pantheon-decoupled-kit/dist/bin.js ${generators} \
 --appName ${appName} \
 --outDir ${outDir} \
+--cmsEndpoint ${cmsEndpoint} \
 ${options}`,
 				{ cwd: resolve(process.cwd()), encoding: 'utf-8' },
 			);
+			console.log(`${appName} generated`);
 		} catch (error) {
 			console.error(error);
 		}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- `cms-kit`: TypeScript was yelling about this Set being iterated over. I'm not sure how this is different but it no longer complains.
- `drupal-kit`: Override the getObject methods to take in a generic and return data of that type.
- monorepo: A few QoL updates for the monorepo. no longer run tests or lint in the `starters` workspace on commit hook since we don't really care if those are broken now. Also, add `cmsEndpoint` to the generate-starters script.
## Where were the changes made?
`cms-kit`, `drupal-kit`, scripts, and pre-commit hook.
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
tests pass, no TS errors when using these methods in the starters
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->