### PR TITLE
DB-5949: Search API Addon CSS Modules

### DIFF
--- a/packages/create-pantheon-decoupled-kit/src/generators/next-drupal-search-api-addon.generator.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/next-drupal-search-api-addon.generator.ts
@@ -1,7 +1,7 @@
 import { addWithDiff, runLint } from '../actions';
 import type { DecoupledKitGenerator, DefaultAnswers } from '../types';
 import chalk from 'chalk';
-import { outDirPrompt } from '../utils/sharedPrompts';
+import { outDirPrompt, tailwindcssPrompt } from '../utils/sharedPrompts';
 
 interface NextDrupalSearchApiAddonAnswers {
 	search: true;
@@ -14,12 +14,18 @@ export const nextDrupalSearchApiAddon: DecoupledKitGenerator<
 	name: 'next-drupal-search-api-addon',
 	description:
 		'Example implementation of the Drupal Search API for the next-drupal starter',
-	prompts: [outDirPrompt(`${process.cwd()}/next-drupal-search-api-addon`)],
+	prompts: [
+		outDirPrompt(`${process.cwd()}/next-drupal-search-api-addon`),
+		tailwindcssPrompt,
+	],
 	addon: true,
 	data: {
 		search: true,
 	},
-	templates: ['next-drupal-search-api-addon'],
+	templates: [
+		'next-drupal-search-api-addon',
+		'tailwindless-drupal-search-api-addon',
+	],
 	actions: [addWithDiff, runLint],
 	nextSteps: [
 		`${chalk.cyan(

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/components/search-input.jsx.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/components/search-input.jsx.hbs
@@ -1,5 +1,8 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+{{#unless tailwindcss}}
+import styles from './searchInput.module.css';
+{{/unless}}
 
 const SearchInput = () => {
 	const router = useRouter();
@@ -20,13 +23,21 @@ const SearchInput = () => {
 
 	return (
 		<form onSubmit={onSearch}>
+			{{#if tailwindcss}}
 			<div className="relative flex w-full items-stretch">
+			{{else}}
+			<div className={styles.container}>
+			{{/if}}
 				<label  htmlFor="search">
 					<input
+						{{#if tailwindcss}}
 						className="-mr-0.5 h-full rounded-l border border-solid border-neutral-300 bg-transparent px-3 text-base font-normal text-neutral-700 outline-none transition duration-200 ease-in-out focus:border-primary focus:text-neutral-700 focus:shadow-[inset_0_0_0_1px_rgb(59,113,202)]"
+						{{else}}
+						className={styles.searchInput}
+						{{/if}}
 						type="search"
 						value={searchQuery || ''}
-						onChange={(event) => setSearchQuery(event.target.value)} 
+						onChange={(event) => setSearchQuery(event.target.value)}
 						placeholder="Search"
 						id="search"
 						aria-label="Search Bar"
@@ -34,7 +45,11 @@ const SearchInput = () => {
 				</label>
 
 				<button
+					{{#if tailwindcss}}
 					className="relative flex items-center rounded-r !bg-blue-600 px-6 py-2.5 text-white shadow-md hover:!bg-blue-700 hover:shadow-lg focus:!bg-primary-700 focus:shadow-lg focus:outline-none focus:ring-0 active:!bg-blue-800 active:shadow-lg"
+					{{else}}
+					className={styles.searchBtn}
+					{{/if}}
 					type="submit"
 					id="submit-btn"
 					aria-label="Submit Search"
@@ -43,7 +58,12 @@ const SearchInput = () => {
 						xmlns="http://www.w3.org/2000/svg"
 						viewBox="0 0 20 20"
 						fill="currentColor"
-						className="h-5 w-5">
+						{{#if tailwindcss}}
+						className="h-5 w-5"
+						{{else}}
+						className={styles.icon}
+						{{/if}}
+						>
 						<path
 						fillRule="evenodd"
 						d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/pages/search/[[...alias]].jsx.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/pages/search/[[...alias]].jsx.hbs
@@ -8,6 +8,9 @@ import { getDrupalSearchResults } from '@pantheon-systems/drupal-kit';
 import Layout from '../../components/layout';
 import PageHeader from '../../components/page-header';
 import Link from 'next/link';
+{{#unless tailwindcss}}
+import styles from './searchPage.module.css';
+{{/unless}}
 
 export default function SearchPage({
 	hrefLang,
@@ -27,26 +30,42 @@ export default function SearchPage({
 			/>
 			<PageHeader title="Search Results" />
 			{error ? (
+				{{#if tailwindcss}}
 				<div className="flex flex-col mx-auto text-xl prose text-center mt-12">
+				{{else}}
+				<div className={styles.altResult}>
+				{{/if}}
 					<span>An error occurred while fetching search results</span>
 				</div>
 			) : (
+				{{#if tailwindcss}}
 				<section className="prose lg:prose-xl mt-10 flex flex-col mx-auto max-h-screen">
+				{{else}}
+				<section className={styles.section}>
+				{{/if}}
+					{{#if tailwindcss}}
 					<div className="max-w-lg mx-auto lg:max-w-screen-lg">
+					{{else}}
+					<div className={styles.container}>
+					{{/if}}
 						{searchResults?.length > 0 ? (
 							<ul>
 								{searchResults?.map(({ title, body, path }) => (
 									<li className="prose justify-items-start mt-8" key={path?.pid}>
 										<h2>{title}</h2>
 										{body.summary ? (
-											<div dangerouslySetInnerHTML={{ __html: body?.summary }} />
+											<div dangerouslySetInnerHTML=\{{ __html: body?.summary }} />
 										) : null}
 										<Link
 											passHref
 											href={`${
 												multiLanguage ? `/${path?.langcode || locale}` : ''
 											}${path.alias}`}
+											{{#if tailwindcss}}
 											className="font-normal underline"
+											{{else}}
+											className={styles.link}
+											{{/if}}
 										>
 											Read more →
 										</Link>
@@ -54,12 +73,14 @@ export default function SearchPage({
 								))}
 							</ul>
 						) : (
-							<div className="mt-12 mx-auto max-w-[50vw]">
-								<p className="text-xl text-center">
-									{expectedResults
-										? 'No Results Found'
-										: 'Enter a term to start searching'}
-								</p>
+							{{#if tailwindcss}}
+							<div className="flex flex-col mx-auto text-xl prose text-center mt-12">
+							{{else}}
+							<div className={styles.altResult}>
+							{{/if}}
+								{expectedResults
+									? 'No Results Found'
+									: 'Enter a term to start searching'}
 							</div>
 						)}
 					</div>

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/next-drupal/nextDrupalLayout.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/next-drupal/nextDrupalLayout.hbs
@@ -39,7 +39,9 @@ export default function Layout({ children, footerMenu, preview = false }) {
 			{{#if search}}
 			<div className={styles.searchHeaderContainer}>
 			<Header navItems={navItems} />
-				<SearchInput />
+				<div>
+					<SearchInput />
+				</div>
 			</div>
 			{{else}}
 			<Header navItems={navItems} />

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/nextjs-shared/nextjsLayoutCSS.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/nextjs-shared/nextjsLayoutCSS.hbs
@@ -28,3 +28,18 @@
 .footerCopy > a:hover {
 	color: var(--light-blue);
 }
+
+{{#if search}}
+.searchHeaderContainer {
+    display: flex; 
+    margin-left: auto;
+    margin-right: auto;
+    flex-direction: row; 
+    flex-wrap: wrap; 
+    justify-content: center; 
+}
+
+.searchHeaderContainer > div {
+    padding-top: 2.25rem; 
+}
+{{/if}}

--- a/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-drupal-search-api-addon/components/searchInput.module.css
+++ b/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-drupal-search-api-addon/components/searchInput.module.css
@@ -1,0 +1,50 @@
+.container {
+    display: flex; 
+    position: relative; 
+    align-items: stretch; 
+    width: 100%; 
+}
+
+.searchInput {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem; 
+    margin-right: -0.125rem; 
+    background-color: transparent; 
+    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform; 
+    transition-duration: 200ms; 
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); 
+    font-size: 1rem;
+    line-height: 1.5rem; 
+    font-weight: 400; 
+    height: 100%; 
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem; 
+    border-width: 1px; 
+    border-style: solid; 
+    outline: 0; 
+}
+
+.searchBtn {
+    display: flex; 
+    position: relative; 
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem; 
+    padding-left: 1.5rem;
+    padding-right: 1.5rem; 
+    color: #ffffff; 
+    background-color: rgb(37 99 235);
+    align-items: center; 
+    border-top-right-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem; 
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); 
+}
+
+.searchBtn:hover {
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); 
+    background-color: rgb(29 78 216);
+}
+
+.icon {
+    width: 1.25rem; 
+    height: 1.25rem; 
+}

--- a/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-drupal-search-api-addon/pages/search/searchPage.module.css
+++ b/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-drupal-search-api-addon/pages/search/searchPage.module.css
@@ -1,0 +1,45 @@
+.altResult {
+    display: flex; 
+    margin-left: auto;
+    margin-right: auto; 
+    margin-top: 3rem; 
+    font-size: 1.25rem;
+    line-height: 1.75rem; 
+    text-align: center; 
+    flex-direction: column; 
+}
+
+.section {
+    display: flex; 
+    margin-left: auto;
+    margin-right: auto; 
+    margin-top: 2.5rem; 
+    flex-direction: column; 
+    max-height: 100vh; 
+}
+
+.container {
+    margin-left: auto;
+    margin-right: auto; 
+    max-width: 32rem; 
+}
+
+.container > ul h2 {
+	font-weight: 700;
+    font-size: var(--7);
+	margin-bottom: var(--8);
+    justify-items: start; 
+}
+
+.link {
+	text-decoration: underline;
+}
+
+@media (min-width: 1024px) { 
+    .section {
+		min-width: var(--md);
+	}
+    .container {
+        max-width: 1024px; 
+    }
+}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Add tailwindless next-drupal-search-api-addon templates

## Where were the changes made?
cli > templates > partials, next-drupal-search-api-addon, tailwindless-drupal-search-api-addon
cli > generators > next-drupal-search-api-addon

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
The Search API Addon was used locally without tailwind and appeared to have the same styling and functionality as the tailwind version.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->