### PR TITLE
DB-6013: Update `setSurrogateKeyHeader` and `drupal-kit` `defaultFetch`

### DIFF
--- a/.changeset/blue-needles-sit.md
+++ b/.changeset/blue-needles-sit.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/drupal-kit': minor
+---
+
+The `DrupalState` `defaultFetch` now sets the `Fastly-Debug` header to obtain
+hashed surrogate keys instead of raw surrogate keys

--- a/.changeset/mean-falcons-destroy.md
+++ b/.changeset/mean-falcons-destroy.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/cms-kit': minor
+---
+
+Update `setSurrogateKeyHeaders` to remove the first two keys which are not
+wanted for proper cache purging

--- a/.changeset/small-feet-camp.md
+++ b/.changeset/small-feet-camp.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-drupal] Bump `drupal-kit` version

--- a/packages/cms-kit/__tests__/setSurrogateKeyHeader.test.ts
+++ b/packages/cms-kit/__tests__/setSurrogateKeyHeader.test.ts
@@ -1,8 +1,8 @@
 import setSurrogateKeyHeader from '../src/utils/setSurrogateKeyHeader';
 import { vi } from 'vitest';
 // Mock the response object
-const mockResponse = vi.fn().mockImplementation(({ surrogateKeyRaw }) => ({
-	getHeader: () => surrogateKeyRaw,
+const mockResponse = vi.fn().mockImplementation(({ surrogateKeyHeader }) => ({
+	getHeader: () => surrogateKeyHeader,
 	setHeader: () => vi.fn(),
 }));
 
@@ -13,29 +13,41 @@ const resourceKeys =
 const uniqueKeys =
 	'config:filter.format.basic_html config:user.role.anonymous file:19 file:21 file:23 file:25 file:27 file:29 file:31 file:33 http_response media:10 media:11 media:12 media:13 media:14 media:15 media:16 media:17 node:10 node:11 node:12 node:13 node:14 node:15 node:16 node:17 node_list';
 
+const removeFirstTwo = (str: string) => str.split(' ').slice(2).join(' ');
+
 test('add headers for a single API request', () => {
 	// If the surrogate-key header is not set, you get back what you put in.
-	const res = mockResponse({ surrogateKeyRaw: undefined });
+	const res = mockResponse({ surrogateKeyHeader: undefined });
 	const setHeaderSpy = vi.spyOn(res, 'setHeader');
 
-	expect(setSurrogateKeyHeader(collectionKeys, res)).toBe(collectionKeys);
+	expect(setSurrogateKeyHeader(collectionKeys, res)).toBe(
+		removeFirstTwo(collectionKeys),
+	);
 	expect(setHeaderSpy).toHaveBeenCalledTimes(1);
 });
 
 test('add headers for a second API request', () => {
 	// If the surrogate-key header is set, new keys will be appended.
 	const res = mockResponse({
-		surrogateKeyRaw: collectionKeys,
+		surrogateKeyHeader: collectionKeys,
 	});
+	const setHeaderSpy = vi.spyOn(res, 'setHeader');
+
 	expect(setSurrogateKeyHeader('node:100', res)).toBe(
-		`${collectionKeys} node:100`,
+		removeFirstTwo(`${collectionKeys} node:100`),
 	);
+	expect(setHeaderSpy).toHaveBeenCalledTimes(1);
 });
 
 test('ensure keys are unique', () => {
 	// If a key is already in the header, we don't add it again.
 	const res = mockResponse({
-		surrogateKeyRaw: collectionKeys,
+		surrogateKeyHeader: collectionKeys,
 	});
-	expect(setSurrogateKeyHeader(resourceKeys, res)).toBe(uniqueKeys);
+	const setHeaderSpy = vi.spyOn(res, 'setHeader');
+
+	expect(setSurrogateKeyHeader(resourceKeys, res)).toBe(
+		removeFirstTwo(uniqueKeys),
+	);
+	expect(setHeaderSpy).toHaveBeenCalledTimes(1);
 });

--- a/packages/cms-kit/src/utils/setSurrogateKeyHeader.ts
+++ b/packages/cms-kit/src/utils/setSurrogateKeyHeader.ts
@@ -18,12 +18,19 @@ const setSurrogateKeyHeader = (
 	keys: string | null,
 	res: ServerResponse,
 ): string | void => {
+	const removeFirstTwo = (str: string) => {
+		const arr = str.split(' ');
+		const result = arr.length > 2 ? arr.slice(2) : arr;
+		return result;
+	};
+
 	if (hasHeaders(res)) {
-		const surrogateKeyHeader = res.getHeader('Surrogate-Key-Raw');
+		const surrogateKeyHeader = res.getHeader('Surrogate-Key');
 
 		if (typeof surrogateKeyHeader === 'string') {
-			const surrogateKeys = surrogateKeyHeader?.split(' ');
-			const newSurrogateKeys = keys?.split(' ') as string[];
+			const surrogateKeys = removeFirstTwo(surrogateKeyHeader);
+			const newSurrogateKeys = removeFirstTwo(keys as string);
+
 			// Destructure into a new array in order to de-dupe the array
 			const uniqueKeysArr = [];
 			uniqueKeysArr.push(...new Set([...surrogateKeys, ...newSurrogateKeys]));
@@ -31,9 +38,10 @@ const setSurrogateKeyHeader = (
 			res.setHeader('Surrogate-Key', uniqueSurrogateKeys);
 			return uniqueSurrogateKeys;
 		} else if (typeof keys === 'string') {
+			const filteredKeys = removeFirstTwo(keys).join(' ');
 			// if the header is not present already and we have keys, set the header
-			res.setHeader('Surrogate-Key', keys);
-			return keys;
+			res.setHeader('Surrogate-Key', filteredKeys);
+			return filteredKeys;
 		}
 	}
 };

--- a/packages/cms-kit/vite.config.js
+++ b/packages/cms-kit/vite.config.js
@@ -25,6 +25,7 @@ export default defineConfig(() => {
 			},
 		},
 		test: {
+			outputTruncateLength: Infinity,
 			globals: true,
 			coverage: {
 				reportsDirectory: `./coverage`,

--- a/packages/drupal-kit/src/lib/defaultFetch.ts
+++ b/packages/drupal-kit/src/lib/defaultFetch.ts
@@ -29,8 +29,7 @@ const defaultFetch = (
 	// and set appropriate cache-control headers on the active response.
 	if (res && typeof res !== 'boolean') {
 		// Ensure api response contains surrogate key headers.
-		headers.set('Pantheon-SKey', '1');
-
+		headers.set('Fastly-Debug', '1');
 		res.setHeader('Cache-Control', cacheControl);
 	}
 
@@ -43,9 +42,9 @@ const defaultFetch = (
 	// Parse the response to bubble up surrogate keys if possible.
 	fetchPromise
 		.then((response) => {
-			if (res && response.headers.has('Surrogate-Key-Raw')) {
+			if (res && response.headers.has('Surrogate-Key')) {
 				setSurrogateKeyHeader(
-					response.headers.get('Surrogate-Key-Raw'),
+					response.headers.get('Surrogate-Key'),
 					res as ServerResponse,
 				);
 			}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- update `setSurrogateKeyHeader` to remove the first two keys if there are more than 2. I'm not positive this logic is correct for all cases and it's hard to debug the hashed values because they are hashed. I was going off of the assumption that the test input wouldn't change, but maybe the `resourceKeys` in the `cms-kit` test is no longer valid?
- Update `defaultFetch` to get and set the `Surrogate-Key` header instead of `Surrogate-Key-Raw`
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested locally with a generated starter inside the monorepo.
## Additional information

<!--- Add any other context about the feature or fix here. --->
Fastly sets `Surrogate-Key` not `Surrogate-Key-Raw`. I could see the desire to do the hashing ourselves if debugging becomes an issue.
<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->