### PR TITLE
DB-6014: `wordpress-kit` hashed surrogate keys

### DIFF
--- a/.changeset/curly-spoons-yell.md
+++ b/.changeset/curly-spoons-yell.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/wordpress-kit': minor
+---
+
+The `GraphqlCLientFactory` now sets the `Fastly-Debug` header to obtain hashed
+surrogate keys instead of raw surrogate keys

--- a/.changeset/silly-pots-arrive.md
+++ b/.changeset/silly-pots-arrive.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-wp][gatsby-wp] Bump `wordpress-kit` version

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,4 +17,4 @@ public
 # handlebars templates
 *.hbs
 **/__tests__/fixtures/**
-**/create-pantheon-decoupled-kit/src/templates/**
+**/templates/**

--- a/packages/cms-kit/__tests__/setSurrogateKeyHeader.test.ts
+++ b/packages/cms-kit/__tests__/setSurrogateKeyHeader.test.ts
@@ -6,10 +6,12 @@ const mockResponse = vi.fn().mockImplementation(({ surrogateKeyHeader }) => ({
 	setHeader: () => vi.fn(),
 }));
 
+// Technically the raw key values below would be hashed, but it should have no
+// impact on the tests.
 const collectionKeys =
-	'config:filter.format.basic_html config:user.role.anonymous file:19 file:21 file:23 file:25 file:27 file:29 file:31 file:33 http_response media:10 media:11 media:12 media:13 media:14 media:15 media:16 media:17 node:10 node:11 node:12 node:13 node:14 node:15 node:16 node:17 node_list';
+	'oY1rHsX/3p6DpQK1dAe+ kGUbbVGynpd8ltN0W0Ce config:filter.format.basic_html config:user.role.anonymous file:19 file:21 file:23 file:25 file:27 file:29 file:31 file:33 http_response media:10 media:11 media:12 media:13 media:14 media:15 media:16 media:17 node:10 node:11 node:12 node:13 node:14 node:15 node:16 node:17 node_list';
 const resourceKeys =
-	'config:filter.format.basic_html config:user.role.anonymous http_response node:10';
+	'oY1rHsX/3p6DpQK1dAe+ kGUbbVGynpd8ltN0W0Ce config:filter.format.basic_html config:user.role.anonymous http_response node:10';
 const uniqueKeys =
 	'config:filter.format.basic_html config:user.role.anonymous file:19 file:21 file:23 file:25 file:27 file:29 file:31 file:33 http_response media:10 media:11 media:12 media:13 media:14 media:15 media:16 media:17 node:10 node:11 node:12 node:13 node:14 node:15 node:16 node:17 node_list';
 
@@ -46,8 +48,6 @@ test('ensure keys are unique', () => {
 	});
 	const setHeaderSpy = vi.spyOn(res, 'setHeader');
 
-	expect(setSurrogateKeyHeader(resourceKeys, res)).toBe(
-		removeFirstTwo(uniqueKeys),
-	);
+	expect(setSurrogateKeyHeader(resourceKeys, res)).toBe(uniqueKeys);
 	expect(setHeaderSpy).toHaveBeenCalledTimes(1);
 });

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/lib/setOutgoingHeaders.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/lib/setOutgoingHeaders.js
@@ -3,13 +3,13 @@ import {
 	setEdgeHeader,
 } from '@pantheon-systems/wordpress-kit';
 /**
- * Helper function to get all unique keys from multiple surrogate-key-raw headers
+ * Helper function to get all unique keys from multiple surrogate-key headers
  * @param {Response['headers']} headers headers from a fetch request
- * @returns {string} a string of unique keys from all surrogate-key-raw headers
+ * @returns {string} a string of unique keys from all surrogate-key headers
  */
 const getSurrogateKeys = ({ headers }) => {
 	const keys = headers
-		.map((header) => header.get('surrogate-key-raw'))
+		.map((header) => header.get('surrogate-key'))
 		.join(' ')
 		.split(' ');
 	const uniqueKeys = [...new Set(keys)].join(' ');

--- a/packages/wordpress-kit/__mocks__/server/basicPostsQuery.ts
+++ b/packages/wordpress-kit/__mocks__/server/basicPostsQuery.ts
@@ -8,7 +8,10 @@ export const basicPostsQuery = graphql.query<typeof basicPostsQueryData>(
 		if (req.headers.has('Fastly-Debug')) {
 			return res(
 				ctx.data(basicPostsQueryData),
-				ctx.set('Surrogate-Key', 'post-7 post-1 user-1 graphql-collection'),
+				ctx.set(
+					'Surrogate-Key',
+					'oY1rHsX/3p6DpQK1dAe+ kGUbbVGynpd8ltN0W0Ce CShM/FbGRgcTR9hRB+ak Be0KFtdPtEV9mVlGh8Dq glzcfBFhDdGngbGRhqnD 2dajCGdEluE9JO0ZYeBT',
+				),
 			);
 		}
 		return res(ctx.data(basicPostsQueryData));

--- a/packages/wordpress-kit/__mocks__/server/basicPostsQuery.ts
+++ b/packages/wordpress-kit/__mocks__/server/basicPostsQuery.ts
@@ -5,10 +5,10 @@ import basicPostsQueryData from '../../__tests__/data/basicPostsQuery.json';
 export const basicPostsQuery = graphql.query<typeof basicPostsQueryData>(
 	'BasicPostsQuery',
 	(req, res, ctx) => {
-		if (req.headers.has('Pantheon-SKey')) {
+		if (req.headers.has('Fastly-Debug')) {
 			return res(
 				ctx.data(basicPostsQueryData),
-				ctx.set('Surrogate-Key-Raw', 'post-7 post-1 user-1 graphql-collection'),
+				ctx.set('Surrogate-Key', 'post-7 post-1 user-1 graphql-collection'),
 			);
 		}
 		return res(ctx.data(basicPostsQueryData));

--- a/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
+++ b/packages/wordpress-kit/__tests__/GraphqlClientFactory.test.ts
@@ -26,7 +26,7 @@ test('request and response middleware add appropriate headers', async () => {
 		}
 	`);
 	expect(res.data).toEqual(basicPostsQuery);
-	expect(res.headers.has('surrogate-key-raw')).toBeTruthy();
+	expect(res.headers.has('surrogate-key')).toBeTruthy();
 });
 
 test('client is configured for GET requests', async () => {

--- a/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts
+++ b/packages/wordpress-kit/src/lib/graphqlClient/GraphqlClientFactory.ts
@@ -20,7 +20,7 @@ class GraphQLClientFactory {
 		this.options = {
 			...options,
 			headers: {
-				'Pantheon-SKey': '1',
+				'Fastly-Debug': '1',
 			},
 			jsonSerializer:
 				options?.method === 'GET'

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
@@ -25,8 +25,8 @@ sequenceDiagram
     participant B as Next.js + drupal-kit
     participant C as Drupal
     A->>B: Request a page that fetches from Drupal
-    B->>C: Add Pantheon-SKey header to request
-    C->>B: Surrogate-Key-Raw header included on response
+    B->>C: Add Fastly-Debug header to request
+    C->>B: Surrogate-Key header included on response
     B->>A: Set Surrogate-Key header on outgoing response to browser
 ```
 

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
@@ -28,9 +28,9 @@ sequenceDiagram
     participant B as Next.js + wordpress-kit
     participant C as WordPress
     A->>B: Request a page that fetches from WordPress
-    B->>C: Add Pantheon-SKey header to request via GET
-    C->>B: Surrogate-Key-Raw header included on response
-    B->>A: Set Surrogate-Key header on outgoing response to browser
+    B->>C: Add Fastly-Debug header to request via GET
+    C->>B: Surrogate-Key header included on response
+    B->>A: Set Surrogate header on outgoing response to browser
 ```
 
 The `GraphqlClientFactory` class from our `@pantheon-systems/wordpress-kit` npm


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
**Merge after #665**

- Update `wordpress-kit` GraphQLClientFactory to add `Fastly-Debug` header instead of `Pantheon-SKey`
- Update docs relating to `Surrogate-Key-Raw`, change to `Surrogate-Key`
## Where were the changes made?
`wordpress-kit`, `cli` templates, `docs`
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Locally with generated starter in monorepo
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->