### PR TITLE
Move required deps to dependencies from devDeps

### DIFF
--- a/.changeset/twelve-hats-grin.md
+++ b/.changeset/twelve-hats-grin.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Fix incorrect dependencies

--- a/packages/create-pantheon-decoupled-kit/package.json
+++ b/packages/create-pantheon-decoupled-kit/package.json
@@ -44,7 +44,6 @@
 		"lint-staged": "lint-staged"
 	},
 	"devDependencies": {
-		"@csstools/postcss-global-data": "^1.0.3",
 		"@pantheon-systems/eslint-config": "*",
 		"@pantheon-systems/workspace-configs": "*",
 		"@types/diff": "^5.0.3",
@@ -54,18 +53,17 @@
 		"@types/minimist": "^1.2.2",
 		"@types/which-pm-runs": "^1.0.0",
 		"@vitest/coverage-c8": "^0.29.8",
-		"autoprefixer": "^10.4.14",
 		"chalk": "^5.2.0",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.17.14",
-		"postcss": "^8.4.21",
-		"postcss-custom-properties": "^13.1.5",
 		"prettier": "^2.8.7",
 		"rimraf": "^4.4.1",
 		"tsx": "^3.12.6",
 		"vitest": "^0.29.8"
 	},
 	"dependencies": {
+		"@csstools/postcss-global-data": "^1.0.3",
+		"autoprefixer": "^10.4.14",
 		"diff": "^5.1.0",
 		"fs-extra": "^11.1.1",
 		"glob": "^10.2.3",
@@ -73,6 +71,8 @@
 		"inquirer": "^9.1.5",
 		"klaw": "^4.1.0",
 		"minimist": "^1.2.8",
+		"postcss": "^8.4.21",
+		"postcss-custom-properties": "^13.1.5",
 		"which-pm-runs": "^1.1.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,12 @@ importers:
 
   packages/create-pantheon-decoupled-kit:
     dependencies:
+      '@csstools/postcss-global-data':
+        specifier: ^1.0.3
+        version: 1.0.3(postcss@8.4.21)
+      autoprefixer:
+        specifier: ^10.4.14
+        version: 10.4.14(postcss@8.4.21)
       diff:
         specifier: ^5.1.0
         version: 5.1.0
@@ -221,13 +227,16 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+      postcss:
+        specifier: ^8.4.21
+        version: 8.4.21
+      postcss-custom-properties:
+        specifier: ^13.1.5
+        version: 13.1.5(postcss@8.4.21)
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
     devDependencies:
-      '@csstools/postcss-global-data':
-        specifier: ^1.0.3
-        version: 1.0.3(postcss@8.4.21)
       '@pantheon-systems/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint
@@ -255,9 +264,6 @@ importers:
       '@vitest/coverage-c8':
         specifier: ^0.29.8
         version: 0.29.8(vitest@0.29.8)
-      autoprefixer:
-        specifier: ^10.4.14
-        version: 10.4.14(postcss@8.4.21)
       chalk:
         specifier: ^5.2.0
         version: 5.2.0
@@ -267,12 +273,6 @@ importers:
       esbuild:
         specifier: 0.17.14
         version: 0.17.14
-      postcss:
-        specifier: ^8.4.21
-        version: 8.4.21
-      postcss-custom-properties:
-        specifier: ^13.1.5
-        version: 13.1.5(postcss@8.4.21)
       prettier:
         specifier: ^2.8.7
         version: 2.8.7
@@ -2306,7 +2306,7 @@ packages:
     dependencies:
       '@csstools/css-parser-algorithms': 2.1.1(@csstools/css-tokenizer@2.1.1)
       '@csstools/css-tokenizer': 2.1.1
-    dev: true
+    dev: false
 
   /@csstools/css-parser-algorithms@2.1.1(@csstools/css-tokenizer@2.1.1):
     resolution: {integrity: sha512-viRnRh02AgO4mwIQb2xQNJju0i+Fh9roNgmbR5xEuG7J3TGgxjnE95HnBLgsFJOJOksvcfxOUCgODcft6Y07cA==}
@@ -2315,12 +2315,12 @@ packages:
       '@csstools/css-tokenizer': ^2.1.1
     dependencies:
       '@csstools/css-tokenizer': 2.1.1
-    dev: true
+    dev: false
 
   /@csstools/css-tokenizer@2.1.1:
     resolution: {integrity: sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA==}
     engines: {node: ^14 || ^16 || >=18}
-    dev: true
+    dev: false
 
   /@csstools/postcss-global-data@1.0.3(postcss@8.4.21):
     resolution: {integrity: sha512-x2fZOl7RJJtKC9ZfG+1bdrQKeRfP1a3Ff4uF2/fykNUKly8E8Q7lw7oegsEnqenSEDC1xjk6qXJ/fcJkTAdcNg==}
@@ -2329,7 +2329,7 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.21
-    dev: true
+    dev: false
 
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -12180,7 +12180,7 @@ packages:
       '@csstools/css-tokenizer': 2.1.1
       postcss: 8.4.21
       postcss-value-parser: 4.2.0
-    dev: true
+    dev: false
 
   /postcss-discard-comments@5.1.2(postcss@8.4.21):
     resolution: {integrity: sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Add some `devDependencies` to `dependencies`.
## Where were the changes made?
`cli`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information
Canary split action failed due to missing dependencies. This should fix it.
<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->