### PR TITLE
Fix wordpress-kit exports

### DIFF
--- a/.changeset/thick-hotels-check.md
+++ b/.changeset/thick-hotels-check.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump wordpress-kit version

--- a/.changeset/tidy-rocks-brake.md
+++ b/.changeset/tidy-rocks-brake.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/wordpress-kit': patch
+---
+
+Fix exports and vite config

--- a/packages/wordpress-kit/package.json
+++ b/packages/wordpress-kit/package.json
@@ -16,13 +16,13 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"require": "./dist/drupal-kit.js",
-			"import": "./dist/drupal-kit.mjs"
+			"require": "./dist/wordpress-kit.js",
+			"import": "./dist/wordpress-kit.mjs"
 		}
 	},
 	"types": "./dist/index.d.ts",
-	"module": "./dist/drupal-kit.mjs",
-	"main": "./dist/drupal-kit.js",
+	"module": "./dist/wordpress-kit.mjs",
+	"main": "./dist/wordpress-kit.js",
 	"prettier": "@pantheon-systems/workspace-configs/prettier",
 	"typedoc": {
 		"entryPoint": "./src/index.ts"

--- a/packages/wordpress-kit/src/tailwindcssPlugin/index.ts
+++ b/packages/wordpress-kit/src/tailwindcssPlugin/index.ts
@@ -1,4 +1,4 @@
-import plugin from 'tailwindcss/plugin';
+import plugin from 'tailwindcss/plugin.js';
 import {
 	Quote,
 	ImageComponent,

--- a/packages/wordpress-kit/vite.config.js
+++ b/packages/wordpress-kit/vite.config.js
@@ -19,9 +19,9 @@ export default defineConfig(() => {
 		build: {
 			lib: {
 				entry: './src/index.ts',
-				name: 'drupal-kit',
+				name: 'wordpress-kit',
 				formats: ['cjs', 'es'],
-				fileName: (format) => `drupal-kit.${format === 'es' ? 'mjs' : 'js'}`,
+				fileName: (format) => `wordpress-kit.${format === 'es' ? 'mjs' : 'js'}`,
 			},
 			rollupOptions: {
 				external,


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
"You got your drupal-kit in my wordpress-kit!"
Fix some typos
add the `.js` extension to the tailwind/plugin import – this is what actually broke the build of the canary site.
## Where were the changes made?
`wordpress-kit`
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->