### PR TITLE
Fix missing next-wp styles

### DIFF
--- a/.changeset/ninety-cooks-melt.md
+++ b/.changeset/ninety-cooks-melt.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-wp] Fix global css template

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/styles/globals.css.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/styles/globals.css.hbs
@@ -1,0 +1,89 @@
+{{#if tailwindcss}}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+{{else}}
+:root {
+	/* spacing */
+	--px: 1px;
+	--0: 0;
+	--0_5: 0.125rem;
+	--1: 0.25rem;
+	--1_5: 0.375rem;
+	--2: 0.5rem;
+	--2_5: 0.625rem;
+	--3: 0.75rem;
+	--3_5: 0.875rem;
+	--4: 1rem;
+	--5: 1.25rem;
+	--6: 1.5rem;
+	--7: 1.75rem;
+	--8: 2rem;
+	--9: 2.25rem;
+	--10: 2.5rem;
+	--11: 2.75rem;
+	--12: 3rem;
+	--14: 3.5rem;
+	--16: 4rem;
+	--20: 5rem;
+	--24: 6rem;
+	--28: 7rem;
+	--32: 8rem;
+	--36: 9rem;
+	--40: 10rem;
+	--44: 11rem;
+	--48: 12rem;
+	--52: 13rem;
+	--56: 14rem;
+	--60: 15rem;
+	--64: 16rem;
+	--72: 18rem;
+	--80: 20rem;
+	--96: 24rem;
+
+	--x-auto: 0 auto;
+	--y-auto: auto 0;
+	--auto: auto;
+
+	/* screens */
+	--xs: 512px;
+	--sm: 640px;
+	--md: 768px;
+	--lg: 1024px;
+	--xl: 1280px;
+	--2xl: 1536px;
+
+	/* colors */
+	--white: #FFFFFF;
+	--light-gray: #E2E8F0;
+	--gray-600: #4B5563;
+	--blue-100: #DBEAFE;
+	--blue-200: #BFDBFE;
+	--blue-300: #93C5FD;
+	--blue-700: #1D4ED8;
+	--blue: #3B82F6;
+	--indigo: #6366F1;
+	--purple-300: #D8B4FE;
+	--purple: #9333EA;
+	--slate-200: #E2E8F0;
+	--black: #000000;
+	
+}
+
+body, html {
+	font-family: System-UI;
+	padding: 0;
+	margin: 0;
+	min-height: 100vh;
+	min-width: 100vw;
+	height: 100%;
+	overflow-x: hidden;
+}
+
+h1 {
+	margin-inline-end: 0;
+	margin-inline-start: 0;
+	margin-block-end: 0;
+	margin-block-start: 0;
+}
+{{/if}}

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/nextjs-shared/nextjsGridCSS.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/nextjs-shared/nextjsGridCSS.hbs
@@ -1,6 +1,6 @@
 .gradientPlaceholder {
 	border-radius: var(--1) var(--1) 0 0;
-	background-image: linear-gradient(to bottom, var(--light-blue), var(--blue));
+	background-image: linear-gradient(to bottom, var(--blue-100), var(--blue));
 	height: inherit;
 }
 

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/nextjs-shared/nextjsLayoutCSS.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/nextjs-shared/nextjsLayoutCSS.hbs
@@ -26,7 +26,7 @@
 }
 
 .footerCopy > a:hover {
-	color: var(--light-blue);
+	color: var(--blue-100);
 }
 
 {{#if search}}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Add styles + global css explicitly to `next-wp` templates and fixed some colors

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->