### PR TITLE
DB-6039: [gatsby-wp-acf-addon] Use css modules by default

### DIFF
--- a/.changeset/strange-shrimps-learn.md
+++ b/.changeset/strange-shrimps-learn.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[gatsby-wp-acf-addon] Use css modules by default, retain tailwindcss option

--- a/packages/create-pantheon-decoupled-kit/.eslintrc
+++ b/packages/create-pantheon-decoupled-kit/.eslintrc
@@ -2,5 +2,6 @@
 	"extends": "@pantheon-systems/eslint-config",
 	"parserOptions": {
 		"project": ["./tsconfig.json"]
-	}
+	},
+	"ignorePatterns": ["/src/templates/**/*.jsx"]
 }

--- a/packages/create-pantheon-decoupled-kit/src/actions/convertCSSModules.ts
+++ b/packages/create-pantheon-decoupled-kit/src/actions/convertCSSModules.ts
@@ -11,8 +11,7 @@ import { rootDir } from '..';
 import { Action, isString } from '../types';
 
 export const convertCSSModules: Action = async ({ data }) => {
-	if (data?.noInstall || !data?.tailwindcss)
-		return 'skipping CSS module conversion';
+	if (!data?.tailwindcss) return 'skipping CSS module conversion';
 	if (!data.outDir || !isString(data?.outDir))
 		throw new Error('outDir is not valid');
 	data.silent ||

--- a/packages/create-pantheon-decoupled-kit/src/generators/gatsby-wp-acf-addon.generator.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/gatsby-wp-acf-addon.generator.ts
@@ -1,13 +1,22 @@
-import { addWithDiff, runLint } from '../actions';
-import type { DecoupledKitGenerator } from '../types';
-import { outDirPrompt } from '../utils/sharedPrompts';
+import { addWithDiff, convertCSSModules, runLint } from '../actions';
+import type { DecoupledKitGenerator, DefaultAnswers } from '../types';
+import { outDirPrompt, tailwindcssPrompt } from '../utils/sharedPrompts';
 
-export const gatsbyWpAcfAddon: DecoupledKitGenerator = {
-	name: 'gatsby-wp-acf-addon',
-	description:
-		'Example implementation of the WordPress Advanced Custom Fields plugin for the gatsby-wordpress starter',
-	prompts: [outDirPrompt(`${process.cwd()}/gatsby-wp-acf-addon`)],
-	templates: ['gatsby-wp-acf-addon'],
-	actions: [addWithDiff, runLint],
-	cmsType: 'wp',
-};
+interface GatsbyWpAcfAddonAnswers extends DefaultAnswers {
+	outDir: string;
+	tailwindcss: boolean;
+}
+
+export const gatsbyWpAcfAddon: DecoupledKitGenerator<GatsbyWpAcfAddonAnswers> =
+	{
+		name: 'gatsby-wp-acf-addon',
+		description:
+			'Example implementation of the WordPress Advanced Custom Fields plugin for the gatsby-wordpress starter',
+		prompts: [
+			outDirPrompt(`${process.cwd()}/gatsby-wp-acf-addon`),
+			tailwindcssPrompt,
+		],
+		templates: ['gatsby-wp-acf-addon'],
+		actions: [addWithDiff, convertCSSModules, runLint],
+		cmsType: 'wp',
+	};

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.jsx
@@ -1,20 +1,19 @@
-import React from 'react'
 import { graphql } from 'gatsby'
 
-import Layout from '../components/layout'
-import Seo from '../components/seo'
-import Post from '../components/post'
 import { PostGrid } from '../components/grid'
+import Layout from '../components/layout'
+import Post from '../components/post'
+import Seo from '../components/seo'
+import * as styles from './post.module.css'
 
 const PostTemplate = ({ data: { previous, next, post } }) => {
-
 	return (
 		<Layout>
 			<Post post={post} next={next} previous={previous} />
 			{post.relatedContent?.relatedPosts ? (
 				<section>
-					<header className="prose text-2xl mx-auto mt-20">
-						<h2 className="text-center mx-auto">Related Content</h2>
+					<header className={styles.header}>
+						<h2 className={styles.headerTitle}>Related Content</h2>
 					</header>
 					<PostGrid
 						data={post.relatedContent.relatedPosts.map(item => ({

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.module.css.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp-acf-addon/src/templates/post.module.css.hbs
@@ -1,0 +1,15 @@
+.header {
+	{{#if tailwindcss}}
+	@apply prose;
+	{{/if}}
+	font-size: var(--6);
+	margin-right: auto;
+	margin-left: auto;
+	margin-top: var(--20);
+}
+
+.headerTitle {
+	text-align: center;
+	margin-right: auto;
+	margin-left: auto;
+}

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/components/page.module.css.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/components/page.module.css.hbs
@@ -3,7 +3,8 @@
 	margin-bottom: 0;
 	margin-left: auto;
 	margin-right: auto;
-	max-width: var(--md);
+	max-width: var(--lg);
+	min-width: var(--md);
 }
 
 .mainTitle {
@@ -57,13 +58,21 @@
 	padding-right: var(--6);
 }
 
-.next {
+.link, .prev, .next {
+	font-size: var(--5);
+	text-decoration-line: underline;
 	color: var(--black);
+}
+
+.prev, .next {
+	font-weight: 500;
+}
+
+.next {
 	margin-left: auto;
 }
 
 .prev {
-	color: var(--black);
 	margin-right: auto;
 }
 

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/components/post.module.css.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/components/post.module.css.hbs
@@ -3,7 +3,8 @@
 	margin-left: auto;
 	margin-right: auto;
 	margin-bottom: 0;
-	min-width: var(--lg);
+	max-width: var(--lg);
+	min-width: var(--md);
 }
 
 .mainTitle {
@@ -51,7 +52,6 @@
 	overflow-wrap: break-word;
 	font-size: var(--5);
 }
-
 
 .hr {
 	width: 100%;


### PR DESCRIPTION

 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Specify eslint ignore files in cli .eslintrc
- Add css modules for gatsby-wp-acf-addon
- Make page & post widths consistent

## Where were the changes made?
`cli`, `gatsby-wp-acf-addon` templates
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Locally w/watch script
## Additional information
Added the `.jsx` files to the ignorePatterns in `.eslintrc` of the cli to avoid errors on those files. They are still able to be formatted by prettier. The gatsby acf addon however doesn't have the gatsby `.prettierrc` so if you format it it will add semicolons etc. In case you need to format that one file you can temporarly add the `.prettierrc` to the addon dir.
<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->