### PR TITLE
Revert canary release of eslint-config, add changeset for proper package

### DIFF
--- a/.changeset/four-foxes-check.md
+++ b/.changeset/four-foxes-check.md
@@ -1,5 +1,5 @@
 ---
-'@pantheon-systems/eslint-config': patch
+'@pantheon-systems/eslint-config-decoupled-kit': patch
 ---
 
 Added the react/jsx-runtime rule to the react config

--- a/configs/eslint/CHANGELOG.md
+++ b/configs/eslint/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @pantheon-systems/eslint-config
-
-## 0.0.1-canary.0
-
-### Patch Changes
-
-- ab24262f: Added the react/jsx-runtime rule to the react config

--- a/configs/eslint/package.json
+++ b/configs/eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pantheon-systems/eslint-config",
-	"version": "0.0.1-canary.0",
+	"version": "0.0.0",
 	"description": "Eslint configs for the @pantheon-systems decoupled SDK npm packages",
 	"license": "GPL-3.0-or-later",
 	"private": true,

--- a/packages/cms-kit/package.json
+++ b/packages/cms-kit/package.json
@@ -50,7 +50,7 @@
 		"lint-staged": "lint-staged"
 	},
 	"devDependencies": {
-		"@pantheon-systems/eslint-config": "0.0.1-canary.0",
+		"@pantheon-systems/eslint-config": "*",
 		"@pantheon-systems/workspace-configs": "*",
 		"@vitest/coverage-c8": "^0.29.8",
 		"prettier": "^2.8.7",

--- a/packages/configs/eslint/package.json
+++ b/packages/configs/eslint/package.json
@@ -21,7 +21,7 @@
 	},
 	"devDependencies": {
 		"@pantheon-systems/workspace-configs": "*",
-		"@pantheon-systems/eslint-config": "0.0.1-canary.0"
+		"@pantheon-systems/eslint-config": "*"
 	},
 	"peerDependencies": {
 		"@typescript-eslint/parser": "^5.49.0",

--- a/packages/configs/other/package.json
+++ b/packages/configs/other/package.json
@@ -21,7 +21,7 @@
 		"lint-staged": "lint-staged"
 	},
 	"devDependencies": {
-		"@pantheon-systems/eslint-config": "0.0.1-canary.0",
+		"@pantheon-systems/eslint-config": "*",
 		"@pantheon-systems/workspace-configs": "*"
 	},
 	"peerDependencies": {

--- a/packages/create-pantheon-decoupled-kit/package.json
+++ b/packages/create-pantheon-decoupled-kit/package.json
@@ -44,7 +44,7 @@
 		"lint-staged": "lint-staged"
 	},
 	"devDependencies": {
-		"@pantheon-systems/eslint-config": "0.0.1-canary.0",
+		"@pantheon-systems/eslint-config": "*",
 		"@pantheon-systems/workspace-configs": "*",
 		"@types/diff": "^5.0.3",
 		"@types/fs-extra": "^11.0.1",

--- a/packages/drupal-kit/package.json
+++ b/packages/drupal-kit/package.json
@@ -43,7 +43,7 @@
 		"lint-staged": "lint-staged"
 	},
 	"devDependencies": {
-		"@pantheon-systems/eslint-config": "0.0.1-canary.0",
+		"@pantheon-systems/eslint-config": "*",
 		"@pantheon-systems/workspace-configs": "*",
 		"@types/isomorphic-fetch": "^0.0.36",
 		"@vitest/coverage-c8": "^0.29.8",

--- a/packages/nextjs-kit/package.json
+++ b/packages/nextjs-kit/package.json
@@ -42,7 +42,7 @@
 		"lint-staged": "lint-staged"
 	},
 	"devDependencies": {
-		"@pantheon-systems/eslint-config": "0.0.1-canary.0",
+		"@pantheon-systems/eslint-config": "*",
 		"@pantheon-systems/workspace-configs": "*",
 		"@rollup/plugin-typescript": "^11.0.0",
 		"@tailwindcss/typography": "^0.5.9",

--- a/packages/wordpress-kit/package.json
+++ b/packages/wordpress-kit/package.json
@@ -47,7 +47,7 @@
 		"tailwindcss": "^3.1.6"
 	},
 	"devDependencies": {
-		"@pantheon-systems/eslint-config": "0.0.1-canary.0",
+		"@pantheon-systems/eslint-config": "*",
 		"@pantheon-systems/workspace-configs": "*",
 		"@vitest/coverage-c8": "^0.29.8",
 		"msw": "^1.2.1",


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
A changeset for the wrong config package was released. This should revert the behavior and apply the changeset to the appropriate package. Nothing was accidentally published because the private field is set in the package.json
## Where were the changes made?
- Fix changeset
- Revert changes made by the canary release to our workspace config
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->