### PR TITLE
DB-6041: Use css-modules for the umami addon

### DIFF
--- a/.changeset/mighty-bears-wave.md
+++ b/.changeset/mighty-bears-wave.md
@@ -1,0 +1,6 @@
+---
+'create-pantheon-decoupled-kit': minor
+---
+
+Use css modules by default for the next-drupal-umami-addon, retain tailwindcss
+option

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -27,7 +27,7 @@ jobs:
             generator_cmd:
               "next-drupal next-drupal-umami-addon --appName
               @pantheon-systems/next-drupal-starter-umami-canary --cmsEndpoint
-              '' --noInstall --tailwindcss --force --silent"
+              '' --tailwindcss --force --silent"
           # next-drupal-starter default
           - local_path: 'starters/next-drupal-starter-default-canary-generated'
             split_repository: 'next-drupal-starter-default-canary'

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -78,7 +78,7 @@ jobs:
             split_repository: 'next-drupal-starter'
             generator_cmd:
               "next-drupal next-drupal-umami-addon --appName
-              @pantheon-systems/next-drupal-starter --cmsEndpoint '' --noInstall
+              @pantheon-systems/next-drupal-starter --cmsEndpoint ''
               --tailwindcss --force --silent"
           # gatsby-wordpress-starter
           - local_path: 'starters/gatsby-wordpress-starter-generated'
@@ -91,7 +91,7 @@ jobs:
             split_repository: 'next-wordpress-starter'
             generator_cmd:
               "next-wp --appName @pantheon-systems/next-wordpress-starter
-              --cmsEndpoint '' --noInstall --tailwindcss --force --silent"
+              --cmsEndpoint '' --tailwindcss --force --silent"
 
             # docs site
           - local_path: 'web'

--- a/packages/create-pantheon-decoupled-kit/src/generators/next-drupal-umami-addon.generator.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/next-drupal-umami-addon.generator.ts
@@ -1,4 +1,4 @@
-import { addWithDiff, runLint } from '../actions';
+import { addWithDiff, convertCSSModules, runLint } from '../actions';
 import type { DecoupledKitGenerator, DefaultAnswers } from '../types';
 import {
 	cmsEndpointPrompt,
@@ -31,6 +31,6 @@ export const nextDrupalUmamiAddon: DecoupledKitGenerator<
 	},
 	addon: true,
 	templates: ['next-drupal-umami-addon'],
-	actions: [addWithDiff, runLint],
+	actions: [addWithDiff, convertCSSModules, runLint],
 	cmsType: 'drupal',
 };

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-umami-addon/components/grid.module.css.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-umami-addon/components/grid.module.css.hbs
@@ -1,3 +1,1 @@
-{{#unless tailwindcss}}
 {{> nextjsGridCSS umami=true}}
-{{/unless}}

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-umami-addon/components/recipeGridItem.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-umami-addon/components/recipeGridItem.jsx
@@ -1,10 +1,8 @@
-import Link from 'next/link';
 import Image from 'next/image';
+import Link from 'next/link';
 import { IMAGE_URL } from '../lib/constants';
-import { GradientPlaceholder } from './grid'
-{{#unless tailwindcss}}
+import { GradientPlaceholder } from './grid';
 import styles from './grid.module.css';
-{{/unless}}
 
 // For use with withGrid
 export const RecipeGridItem = ({ content: recipe, multiLanguage, locale }) => {
@@ -16,39 +14,22 @@ export const RecipeGridItem = ({ content: recipe, multiLanguage, locale }) => {
 				recipe.path.alias
 			}`}
 		>
-			{{#if tailwindcss}}
-			<div className="flex flex-col rounded-lg shadow-lg overflow-hidden cursor-pointer border-2 h-full hover:border-indigo-500">
-				<div className="flex-shrink-0 relative h-40">
-			{{else}}
 			<div className={styles.card}>
 				<div className={styles.cardImg}>
-			{{/if}}
 					{imgSrc !== null ? (
 						<Image
 							src={IMAGE_URL + imgSrc}
 							fill
-							style=\{{ objectFit: 'cover' }}
+							style={{ objectFit: 'cover' }}
 							alt={recipe.title}
 						/>
 					) : (
 						<GradientPlaceholder />
 					)}
 				</div>
-				{{#if tailwindcss}}
-				<h2 className="my-4 mx-6 text-xl leading-7 font-semibold text-gray-900">
-					{recipe.title} &rarr;
-				</h2>
-				{{else}}
-				<h2 className={styles.cardTitle}>
-					{recipe.title} &rarr;
-				</h2>
-				{{/if}}
+				<h2 className={styles.cardTitle}>{recipe.title} &rarr;</h2>
 				{recipe?.field_recipe_category?.length > 0 ? (
-					{{#if tailwindcss}}
-					<span className="text-right pb-2 pr-3 text-sm text-slate-400">
-					{{else}}
 					<span className={styles.recipeCategory}>
-					{{/if}}
 						{recipe?.field_recipe_category[0].name}
 					</span>
 				) : null}

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/components/grid.jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/components/grid.jsx
@@ -2,9 +2,9 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { IMAGE_URL } from '../lib/constants';
 import { withGrid } from '@pantheon-systems/nextjs-kit';
-import styles from "./grid.module.css";
+import styles from './grid.module.css';
 
-const GradientPlaceholder = () => (
+export const GradientPlaceholder = () => (
 	<div className={styles.gradientPlaceholder} />
 );
 
@@ -35,9 +35,7 @@ export const ArticleGridItem = ({
 						<GradientPlaceholder />
 					)}
 				</div>
-				<h2 className={styles.cardTitle}>
-					{article.title} &rarr;
-				</h2>
+				<h2 className={styles.cardTitle}>{article.title} &rarr;</h2>
 			</div>
 		</Link>
 	);

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/next-drupal/nextDrupalCatchAllView.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/next-drupal/nextDrupalCatchAllView.hbs
@@ -24,7 +24,7 @@ export default function CatchAllRoute({
 			return (
 				<>
 					<article className={styles.container}>
-						<h1>{title}</h1>
+						<h1 className={styles.containerTitle}>{title}</h1>
 						<Link passHref href="/pages">
 							Pages &rarr;
 						</Link>
@@ -95,7 +95,7 @@ export default function CatchAllRoute({
 		{{/if}}
 		return (
 			<>
-				<h2 className="text-xl text-center mt-14">No content found 🏜</h2>
+				<h2 className={styles.noContent}>No content found 🏜</h2>
 			</>
 		);
 	};

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/next-drupal/sharedNextDrupalConfig.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/next-drupal/sharedNextDrupalConfig.hbs
@@ -84,6 +84,7 @@ module.exports = async () => {
 				},
 			];
 		},
+		transpilePackages: ['@pantheon-systems/drupal-kit'],
 	};
 
 	return nextConfig;

--- a/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-next/pages/catch-all.module.css.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-next/pages/catch-all.module.css.hbs
@@ -1,35 +1,41 @@
 {{#if drupal}}
-	.container {
-		display: flex;
-		flex-direction: column;
-		margin: var(--10) auto 0;
-		max-width: var(--md);
-	}
+.container {
+	display: flex;
+	flex-direction: column;
+	margin: var(--10) auto 0;
+	max-width: var(--md);
+}
 
-	.container > h1 {
-		font-size: var(--14);
-		font-weight: 800;
-		margin-bottom: var(--12);
-	}
+.containerTitle {
+	font-size: var(--14);
+	font-weight: 800;
+	margin-bottom: var(--12);
+}
 
-	.container >  h1 + a {
-		text-decoration-line: underline;
-		font-size: var(--5);
-	}
+.container >  h1 + a {
+	text-decoration-line: underline;
+	font-size: var(--5);
+}
 
-	.content {
-		margin-top: var(--12);
-		color: var(--text-body);
-	}
+.content {
+	margin-top: var(--12);
+	color: var(--text-body);
+}
 
-	.content > * > a {
-		text-decoration-line: underline;
-		font-weight: 500;
-	}
+.content > * > a {
+	text-decoration-line: underline;
+	font-weight: 500;
+}
 
-	.content > p {
-		margin-bottom: var(--4);
-		font-size: var(--5);
-	}
+.content > p {
+	margin-bottom: var(--4);
+	font-size: var(--5);
+}
+
+.noContent {
+	margin-top: var(--14);
+	font-size: var(--6);
+	text-align: center;
+}
 
 {{/if}}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Use css modules by default for the Umami addon
- add convertCSS action to umami addon

## Where were the changes made?
next-drupal-umami-addon templates

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Locally w/watch script
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->