### PR TITLE
DB-6038: Update Imports in Pagination Page

### DIFF
--- a/.changeset/famous-bugs-drum.md
+++ b/.changeset/famous-bugs-drum.md
@@ -1,0 +1,5 @@
+---
+"create-pantheon-decoupled-kit": patch
+---
+
+- [next-wp] Update imports for Pagination example

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/pages/examples/pagination/[[...page]].jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/pages/examples/pagination/[[...page]].jsx
@@ -1,6 +1,9 @@
 import { Paginator } from '@pantheon-systems/nextjs-kit';
 import { NextSeo } from 'next-seo';
 import Layout from '../../../components/layout';
+import { getFooterMenu } from '../../../lib/Menus';
+import { paginationPostsQuery } from '../../../lib/PostsPagination';
+import { setOutgoingHeaders } from '../../../lib/setOutgoingHeaders';
 
 import styles from './pagination.module.css';
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

- Add imports that were removed from the pagination example in the `next-wp-starter`

## Where were the changes made?
next-wp template

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
- Tested locally and observed import errors go away.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->