### PR TITLE
Decode req.url before regext.test in `preview` api route

### DIFF
--- a/.changeset/violet-donuts-lay.md
+++ b/.changeset/violet-donuts-lay.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-drupal] Handle encoded URI components in /api/preview

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
@@ -26,7 +26,8 @@ const preview = async (req, res) => {
 	// or the only store if using a monolingual backend
 	const [store] = globalDrupalStateStores.filter(({ defaultLocale }) => {
 		const regex = new RegExp(`/${defaultLocale}/`);
-		return defaultLocale ? regex.test(req.url) : true;
+		const decodedUrl = decodeURIComponent(req.url);
+		return defaultLocale ? regex.test(decodedUrl) : true;
 	});
 	// verify the content exists
 	let content;


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Decode the `req.url` before testing against the default locale. This is now required because the url comes back encoded from Cloudflare.
## Where were the changes made?
`next-drupal` templates
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested with the `05-18-23-preview` site in the QA workspace

## Additional information
Unclear what needs to happen on the WP side at this time.

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->