### PR TITLE
[docs ] Fix incorrect link in docs footer

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -144,7 +144,7 @@ const config = {
 							},
 							{
 								label: 'Create a Decoupled WordPress Backend',
-								to: '/docs/backend-starters/decoupled-drupal/creating-a-new-project',
+								to: '/docs/backend-starters/decoupled-wordpress/creating-a-new-project',
 							},
 						],
 					},


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
changed `decoupled-drupal` -> `decoupled-wordpress`
## Where were the changes made?
docs
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->