### PR TITLE
Add .prettierrc to next-wp template

### DIFF
--- a/.changeset/seven-moose-sit.md
+++ b/.changeset/seven-moose-sit.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-wp] Add .prettierrc

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/.prettierrc
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/.prettierrc
@@ -1,0 +1,10 @@
+{
+	"useTabs": true,
+	"singleQuote": true,
+	"semi": true,
+	"proseWrap": "always",
+	"trailingComma": "all",
+	"printWidth": 80,
+	"arrowParens": "always",
+	"bracketSameLine": false
+}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
The `next-wp` did not have a `.prettierrc` so the `prettier:fix` command failed in CI. This should solve it.
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
`next-wp` template
## How have the changes been tested?
locally create and successfully formatted the output.
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->