### PR TITLE
Add @types/react & @types/react-dom to nextjs-kit devDeps

### DIFF
--- a/.changeset/mighty-impalas-appear.md
+++ b/.changeset/mighty-impalas-appear.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump nextjs-kit version

--- a/.changeset/rich-cows-arrive.md
+++ b/.changeset/rich-cows-arrive.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/nextjs-kit': patch
+---
+
+Added React types to devDependencies

--- a/packages/nextjs-kit/package.json
+++ b/packages/nextjs-kit/package.json
@@ -47,6 +47,8 @@
 		"@pantheon-systems/workspace-configs": "*",
 		"@tailwindcss/typography": "^0.5.9",
 		"@testing-library/react": "14.0.0",
+		"@types/react": "^18.2.6",
+		"@types/react-dom": "^18.2.4",
 		"@vitest/coverage-c8": "^0.29.8",
 		"autoprefixer": "^10.4.14",
 		"eslint-plugin-prettier": "^4.2.1",

--- a/packages/nextjs-kit/src/components/grid.tsx
+++ b/packages/nextjs-kit/src/components/grid.tsx
@@ -10,7 +10,7 @@ export const Grid = ({
 	children,
 }: {
 	cols?: number;
-	children?: JSX.Element[];
+	children?: React.ReactNode;
 }) => {
 	return (
 		<div
@@ -57,7 +57,7 @@ export const Grid = ({
  * ```
  */
 export const withGrid = <Props extends object>(
-	Component: React.ElementType,
+	Component: React.ComponentType,
 ) => {
 	/**
 	 * @param props.data - The to be passed to the Component as the content prop
@@ -74,7 +74,7 @@ export const withGrid = <Props extends object>(
 	}: {
 		data?: Type[];
 		cols?: number;
-		FallbackComponent?: React.ElementType;
+		FallbackComponent?: React.ComponentType;
 	} & { [Property in keyof Props]: Props[Property] }): JSX.Element => {
 		return (
 			<>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,10 +100,10 @@ importers:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.13.0
-        version: 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
+        version: 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^5.49.0
-        version: 5.57.0(eslint@8.37.0)(typescript@5.0.4)
+        version: 5.57.0(eslint@8.37.0)(typescript@4.9.5)
       eslint:
         specifier: '>=8'
         version: 8.37.0
@@ -155,10 +155,10 @@ importers:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.13.0
-        version: 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4)
+        version: 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^5.49.0
-        version: 5.57.0(eslint@8.37.0)(typescript@5.0.4)
+        version: 5.57.0(eslint@8.37.0)(typescript@4.9.5)
       eslint:
         specifier: '>=8'
         version: 8.37.0
@@ -340,6 +340,12 @@ importers:
       '@testing-library/react':
         specifier: 14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@types/react':
+        specifier: ^18.2.6
+        version: 18.2.6
+      '@types/react-dom':
+        specifier: ^18.2.4
+        version: 18.2.4
       '@vitest/coverage-c8':
         specifier: ^0.29.8
         version: 0.29.8(vitest@0.29.8)
@@ -424,13 +430,13 @@ importers:
         version: 2.1.11(@lezer/common@1.0.2)(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/core':
         specifier: 2.4.0
-        version: 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+        version: 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/preset-classic':
         specifier: 2.4.0
-        version: 2.4.0(@algolia/client-search@4.16.0)(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+        version: 2.4.0(@algolia/client-search@4.16.0)(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/theme-mermaid':
         specifier: 2.4.0
-        version: 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+        version: 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@mdx-js/react':
         specifier: ^1.6.22
         version: 1.6.22(react@17.0.0)
@@ -458,7 +464,7 @@ importers:
         version: 16.0.3
       typedoc:
         specifier: ^0.23.24
-        version: 0.23.28(typescript@5.0.4)
+        version: 0.23.28(typescript@4.9.5)
       typedoc-plugin-markdown:
         specifier: 3.14.0
         version: 3.14.0(typedoc@0.23.28)
@@ -2523,7 +2529,7 @@ packages:
       - '@algolia/client-search'
     dev: false
 
-  /@docusaurus/core@2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/core@2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -2582,7 +2588,7 @@ packages:
       postcss-loader: 7.1.0(postcss@8.4.23)(webpack@5.77.0)
       prompts: 2.4.2
       react: 17.0.0
-      react-dev-utils: 12.0.1(eslint@8.37.0)(typescript@5.0.4)(webpack@5.77.0)
+      react-dev-utils: 12.0.1(eslint@8.37.0)(typescript@4.9.5)(webpack@5.77.0)
       react-dom: 17.0.0(react@17.0.0)
       react-helmet-async: 1.3.0(react-dom@17.0.0)(react@17.0.0)
       react-loadable: /@docusaurus/react-loadable@5.5.2(react@17.0.0)
@@ -2630,7 +2636,7 @@ packages:
       cssnano-preset-advanced: 5.3.10(postcss@8.4.23)
       postcss: 8.4.23
       postcss-sort-media-queries: 4.3.0(postcss@8.4.23)
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: false
 
   /@docusaurus/logger@2.4.0:
@@ -2638,7 +2644,7 @@ packages:
     engines: {node: '>=16.14'}
     dependencies:
       chalk: 4.1.2
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: false
 
   /@docusaurus/mdx-loader@2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.0)(react@17.0.0):
@@ -2662,7 +2668,7 @@ packages:
       react-dom: 17.0.0(react@17.0.0)
       remark-emoji: 2.2.0
       stringify-object: 3.3.0
-      tslib: 2.5.0
+      tslib: 2.5.2
       unified: 9.2.2
       unist-util-visit: 2.0.3
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.77.0)
@@ -2699,14 +2705,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-blog@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/plugin-content-blog@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/logger': 2.4.0
       '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
@@ -2742,14 +2748,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-docs@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/plugin-content-docs@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/logger': 2.4.0
       '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.0)(react@17.0.0)
@@ -2785,14 +2791,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-content-pages@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/plugin-content-pages@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
@@ -2820,14 +2826,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-debug@2.4.0(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/plugin-debug@2.4.0(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
       fs-extra: 10.1.0
@@ -2855,14 +2861,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-analytics@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/plugin-google-analytics@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
       react: 17.0.0
@@ -2886,14 +2892,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-gtag@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/plugin-google-gtag@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
       react: 17.0.0
@@ -2917,14 +2923,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-google-tag-manager@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/plugin-google-tag-manager@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
       react: 17.0.0
@@ -2948,14 +2954,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/plugin-sitemap@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/plugin-sitemap@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/logger': 2.4.0
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
@@ -2984,25 +2990,25 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic@2.4.0(@algolia/client-search@4.16.0)(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/preset-classic@2.4.0(@algolia/client-search@4.16.0)(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-content-blog': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-content-pages': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-debug': 2.4.0(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-google-analytics': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-google-gtag': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-google-tag-manager': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-sitemap': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/theme-classic': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/theme-search-algolia': 2.4.0(@algolia/client-search@4.16.0)(@docusaurus/types@2.4.0)(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-content-blog': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-content-pages': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-debug': 2.4.0(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-google-analytics': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-google-gtag': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-google-tag-manager': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-sitemap': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/theme-classic': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/theme-search-algolia': 2.4.0(@algolia/client-search@4.16.0)(@docusaurus/types@2.4.0)(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       react: 17.0.0
       react-dom: 17.0.0(react@17.0.0)
@@ -3037,20 +3043,20 @@ packages:
       react: 17.0.0
     dev: false
 
-  /@docusaurus/theme-classic@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/theme-classic@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.0)(react@17.0.0)
-      '@docusaurus/plugin-content-blog': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-content-pages': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/plugin-content-blog': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-content-pages': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/theme-translations': 2.4.0
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
@@ -3089,7 +3095,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-common@2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/theme-common@2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -3098,9 +3104,9 @@ packages:
     dependencies:
       '@docusaurus/mdx-loader': 2.4.0(@docusaurus/types@2.4.0)(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.0)(react@17.0.0)
-      '@docusaurus/plugin-content-blog': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/plugin-content-pages': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/plugin-content-blog': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/plugin-content-pages': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
       '@docusaurus/utils-common': 2.4.0(@docusaurus/types@2.4.0)
       '@types/history': 4.7.11
@@ -3133,16 +3139,16 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-mermaid@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/theme-mermaid@2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-qB4cMDn93iwQ5JzhLgHsME5DgUbISMKgk6nP6tEWqepP3S/WXR1L/uRAH8xXbuRhJgzERHM/f6riyv0cNIQeTg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/module-type-aliases': 2.4.0(react-dom@17.0.0)(react@17.0.0)
-      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
       '@mdx-js/react': 1.6.22(react@17.0.0)
@@ -3168,7 +3174,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-search-algolia@2.4.0(@algolia/client-search@4.16.0)(@docusaurus/types@2.4.0)(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+  /@docusaurus/theme-search-algolia@2.4.0(@algolia/client-search@4.16.0)(@docusaurus/types@2.4.0)(@types/react@17.0.58)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5):
     resolution: {integrity: sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -3176,10 +3182,10 @@ packages:
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
       '@docsearch/react': 3.3.3(@algolia/client-search@4.16.0)(@types/react@17.0.58)(react-dom@17.0.0)(react@17.0.0)
-      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/core': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/logger': 2.4.0
-      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
-      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/plugin-content-docs': 2.4.0(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
+      '@docusaurus/theme-common': 2.4.0(@docusaurus/types@2.4.0)(eslint@8.37.0)(react-dom@17.0.0)(react@17.0.0)(typescript@4.9.5)
       '@docusaurus/theme-translations': 2.4.0
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
       '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
@@ -3255,7 +3261,7 @@ packages:
         optional: true
     dependencies:
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: false
 
   /@docusaurus/utils-validation@2.4.0(@docusaurus/types@2.4.0):
@@ -3266,7 +3272,7 @@ packages:
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
       joi: 17.9.1
       js-yaml: 4.1.0
-      tslib: 2.5.0
+      tslib: 2.5.2
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -3299,7 +3305,7 @@ packages:
       micromatch: 4.0.5
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
-      tslib: 2.5.0
+      tslib: 2.5.2
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.77.0)
       webpack: 5.77.0
     transitivePeerDependencies:
@@ -3734,7 +3740,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
       eslint: 8.37.0
-      eslint-visitor-keys: 3.4.0
+      eslint-visitor-keys: 3.4.1
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.41.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -3743,7 +3749,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
       eslint: 8.41.0
-      eslint-visitor-keys: 3.4.0
+      eslint-visitor-keys: 3.4.1
     dev: true
 
   /@eslint-community/regexpp@4.5.0:
@@ -3894,7 +3900,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -3927,7 +3933,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -4006,7 +4012,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       jest-mock: 27.5.1
     dev: false
 
@@ -4043,7 +4049,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -4096,7 +4102,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -4275,7 +4281,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       '@types/yargs': 16.0.5
       chalk: 4.1.2
     dev: false
@@ -4898,13 +4904,13 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/bonjour@3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/chai-subset@1.3.3:
@@ -4921,13 +4927,13 @@ packages:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}
     dependencies:
       '@types/express-serve-static-core': 4.17.33
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/cookie@0.4.1:
@@ -4967,7 +4973,7 @@ packages:
   /@types/express-serve-static-core@4.17.33:
     resolution: {integrity: sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: false
@@ -5010,7 +5016,7 @@ packages:
   /@types/http-proxy@1.17.10:
     resolution: {integrity: sha512-Qs5aULi+zV1bwKAg5z1PWnDXWmsn+LxIvUGv6E2+OOMYhclZMO+OXd9pYVf2gLykf2I7IV2u7oTHwChPNsvJ7g==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/inquirer@9.0.3:
@@ -5071,13 +5077,13 @@ packages:
   /@types/jsonfile@6.1.1:
     resolution: {integrity: sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: true
 
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/klaw@3.0.3:
@@ -5117,6 +5123,7 @@ packages:
 
   /@types/node@20.2.3:
     resolution: {integrity: sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==}
+    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -5190,7 +5197,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/retry@0.12.0:
@@ -5200,7 +5207,7 @@ packages:
   /@types/sax@1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.16.14
     dev: false
 
   /@types/scheduler@0.16.3:
@@ -5223,19 +5230,19 @@ packages:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/set-cookie-parser@2.4.2:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: true
 
   /@types/sockjs@0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/stack-utils@2.0.1:
@@ -5244,7 +5251,7 @@ packages:
   /@types/through@0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: true
 
   /@types/unist@2.0.6:
@@ -5258,7 +5265,7 @@ packages:
   /@types/ws@8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /@types/yargs-parser@21.0.0:
@@ -5303,7 +5310,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@5.0.4):
+  /@typescript-eslint/eslint-plugin@5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.37.0)(typescript@4.9.5):
     resolution: {integrity: sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5315,18 +5322,18 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.0
-      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.37.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 5.57.0
-      '@typescript-eslint/type-utils': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 5.57.0(eslint@8.37.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@4.9.5)
       debug: 4.3.4
       eslint: 8.37.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5351,7 +5358,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.57.0(eslint@8.37.0)(typescript@5.0.4):
+  /@typescript-eslint/parser@5.57.0(eslint@8.37.0)(typescript@4.9.5):
     resolution: {integrity: sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5363,10 +5370,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.57.0
       '@typescript-eslint/types': 5.57.0
-      '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.57.0(typescript@4.9.5)
       debug: 4.3.4
       eslint: 8.37.0
-      typescript: 5.0.4
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5398,7 +5405,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@5.57.0(eslint@8.37.0)(typescript@5.0.4):
+  /@typescript-eslint/type-utils@5.57.0(eslint@8.37.0)(typescript@4.9.5):
     resolution: {integrity: sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5408,12 +5415,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.57.0(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.57.0(eslint@8.37.0)(typescript@4.9.5)
       debug: 4.3.4
       eslint: 8.37.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5443,7 +5450,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.57.0(typescript@5.0.4):
+  /@typescript-eslint/typescript-estree@5.57.0(typescript@4.9.5):
     resolution: {integrity: sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5458,8 +5465,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5484,7 +5491,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.57.0(eslint@8.37.0)(typescript@5.0.4):
+  /@typescript-eslint/utils@5.57.0(eslint@8.37.0)(typescript@4.9.5):
     resolution: {integrity: sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5495,7 +5502,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.57.0
       '@typescript-eslint/types': 5.57.0
-      '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.57.0(typescript@4.9.5)
       eslint: 8.37.0
       eslint-scope: 5.1.1
       semver: 7.3.8
@@ -6036,7 +6043,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.5
-      caniuse-lite: 1.0.30001473
+      caniuse-lite: 1.0.30001489
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -6052,7 +6059,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.5
-      caniuse-lite: 1.0.30001473
+      caniuse-lite: 1.0.30001489
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -6405,7 +6412,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001473
+      caniuse-lite: 1.0.30001489
       electron-to-chromium: 1.4.348
       node-releases: 2.0.10
       update-browserslist-db: 1.0.10(browserslist@4.21.5)
@@ -6516,7 +6523,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: false
 
   /camelcase-css@2.0.1:
@@ -6548,9 +6555,6 @@ packages:
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: false
-
-  /caniuse-lite@1.0.30001473:
-    resolution: {integrity: sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==}
 
   /caniuse-lite@1.0.30001489:
     resolution: {integrity: sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==}
@@ -7131,7 +7135,7 @@ packages:
       postcss-modules-scope: 3.0.0(postcss@8.4.23)
       postcss-modules-values: 4.0.0(postcss@8.4.23)
       postcss-value-parser: 4.2.0
-      semver: 7.3.8
+      semver: 7.5.1
       webpack: 5.77.0
     dev: false
 
@@ -7893,7 +7897,7 @@ packages:
       typedoc: '>=0.23.0'
       typedoc-plugin-markdown: '>=3.13.0'
     dependencies:
-      typedoc: 0.23.28(typescript@5.0.4)
+      typedoc: 0.23.28(typescript@4.9.5)
       typedoc-plugin-markdown: 3.14.0(typedoc@0.23.28)
     dev: true
 
@@ -7972,7 +7976,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: false
 
   /dot-prop@5.3.0:
@@ -8588,7 +8592,7 @@ packages:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       require-like: 0.1.2
     dev: false
 
@@ -8996,7 +9000,7 @@ packages:
       signal-exit: 4.0.1
     dev: false
 
-  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.37.0)(typescript@5.0.4)(webpack@5.77.0):
+  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.37.0)(typescript@4.9.5)(webpack@5.77.0):
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -9022,9 +9026,9 @@ packages:
       memfs: 3.4.13
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.3.8
+      semver: 7.5.1
       tapable: 1.1.3
-      typescript: 5.0.4
+      typescript: 4.9.5
       webpack: 5.77.0
     dev: false
 
@@ -9816,7 +9820,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
@@ -10335,7 +10339,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -10583,7 +10587,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -10601,7 +10605,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: false
@@ -10634,7 +10638,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -10675,7 +10679,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -10783,7 +10787,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
     dev: false
 
   /jest-mock@29.5.0:
@@ -10890,7 +10894,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -11006,7 +11010,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       graceful-fs: 4.2.11
     dev: false
 
@@ -11076,7 +11080,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -11124,7 +11128,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -11149,7 +11153,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -11158,7 +11162,7 @@ packages:
     resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 18.16.14
       jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -11608,7 +11612,7 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
     dependencies:
-      chalk: 4.1.1
+      chalk: 4.1.2
       is-unicode-supported: 0.1.0
     dev: true
 
@@ -11645,7 +11649,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: false
 
   /lowercase-keys@1.0.1:
@@ -12156,7 +12160,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: false
 
   /node-emoji@1.11.0:
@@ -12407,7 +12411,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       bl: 4.1.0
-      chalk: 4.1.1
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.7.0
       is-interactive: 1.0.0
@@ -12534,7 +12538,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: false
 
   /parent-module@1.0.1:
@@ -12593,7 +12597,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.5.2
     dev: false
 
   /patch-package@6.5.1:
@@ -12899,7 +12903,7 @@ packages:
       cosmiconfig: 8.1.3
       klona: 2.0.6
       postcss: 8.4.23
-      semver: 7.3.8
+      semver: 7.5.1
       webpack: 5.77.0
     dev: false
 
@@ -13499,7 +13503,7 @@ packages:
       pure-color: 1.3.0
     dev: false
 
-  /react-dev-utils@12.0.1(eslint@8.37.0)(typescript@5.0.4)(webpack@5.77.0):
+  /react-dev-utils@12.0.1(eslint@8.37.0)(typescript@4.9.5)(webpack@5.77.0):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -13518,7 +13522,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.37.0)(typescript@5.0.4)(webpack@5.77.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.37.0)(typescript@4.9.5)(webpack@5.77.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -13533,7 +13537,7 @@ packages:
       shell-quote: 1.8.0
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      typescript: 5.0.4
+      typescript: 4.9.5
       webpack: 5.77.0
     transitivePeerDependencies:
       - eslint
@@ -15258,14 +15262,14 @@ packages:
       typescript: 4.9.4
     dev: true
 
-  /tsutils@3.21.0(typescript@5.0.4):
+  /tsutils@3.21.0(typescript@4.9.5):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.4
+      typescript: 4.9.5
     dev: false
 
   /tsx@3.12.6:
@@ -15377,7 +15381,7 @@ packages:
       typedoc: '>=0.23.0'
     dependencies:
       handlebars: 4.7.7
-      typedoc: 0.23.28(typescript@5.0.4)
+      typedoc: 0.23.28(typescript@4.9.5)
     dev: true
 
   /typedoc@0.23.28(typescript@4.9.4):
@@ -15394,7 +15398,7 @@ packages:
       typescript: 4.9.4
     dev: true
 
-  /typedoc@0.23.28(typescript@5.0.4):
+  /typedoc@0.23.28(typescript@4.9.5):
     resolution: {integrity: sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==}
     engines: {node: '>= 14.14'}
     hasBin: true
@@ -15405,7 +15409,7 @@ packages:
       marked: 4.3.0
       minimatch: 7.4.4
       shiki: 0.14.1
-      typescript: 5.0.4
+      typescript: 4.9.5
     dev: true
 
   /typescript@4.9.4:
@@ -15417,11 +15421,6 @@ packages:
   /typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
-    hasBin: true
-
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
     hasBin: true
 
   /ua-parser-js@0.7.35:
@@ -15602,7 +15601,7 @@ packages:
       is-yarn-global: 0.3.0
       latest-version: 5.1.0
       pupa: 2.1.1
-      semver: 7.3.8
+      semver: 7.5.1
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
     dev: false


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
`nextjs-kit` was failing to build locally. After adding `@types/react` and `@types/react-dom` to the package `devDependencies`, it seems to be building successfully. Also adjusted a few of the types.
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
built package locally and tested locally with `generate-starters` 
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->