### PR TITLE
DB-5244: Add tagged template support in addWithDiff + tests

### DIFF
--- a/.changeset/tiny-bugs-live.md
+++ b/.changeset/tiny-bugs-live.md
@@ -1,0 +1,8 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Add support for tagged template literal templates in addition to handlebars
+templates. This is in effort to smooth out developer experience when writing
+templates for the generators. This change is meant to be backwards compatible so
+handlebars templates should still work.

--- a/packages/create-pantheon-decoupled-kit/__tests__/fixtures/addWithDiff/populated/test-anotherFileWithDiff.js
+++ b/packages/create-pantheon-decoupled-kit/__tests__/fixtures/addWithDiff/populated/test-anotherFileWithDiff.js
@@ -1,4 +1,4 @@
 console.log(`
 This is a multiline input!
-test input
+Testing the diff
 `)

--- a/packages/create-pantheon-decoupled-kit/__tests__/fixtures/addWithDiff/populated/test-ts-template.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/fixtures/addWithDiff/populated/test-ts-template.ts
@@ -1,0 +1,3 @@
+const x = 'I am a string';
+console.log(x);
+

--- a/packages/create-pantheon-decoupled-kit/__tests__/fixtures/addWithDiff/populated/test-withDiff.js
+++ b/packages/create-pantheon-decoupled-kit/__tests__/fixtures/addWithDiff/populated/test-withDiff.js
@@ -1,1 +1,1 @@
-console.log('Hello World')
+console.log('this line will be rendered to the template')

--- a/packages/create-pantheon-decoupled-kit/__tests__/taggedTemplateHelpers.test.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/taggedTemplateHelpers.test.ts
@@ -1,0 +1,44 @@
+import { taggedTemplateHelpers as helpers } from '../src/utils/index';
+
+describe('if', () => {
+	it('should return the value if the condition is true', () => {
+		const value = 'Some string here';
+		const result = helpers.if(true, value);
+		expect(result).toEqual(value);
+	});
+	it('should return an empty string if the condition is false', () => {
+		const value = 'This is only a test.';
+		const result = helpers.if(false, value);
+		expect(result).toEqual('');
+	});
+});
+
+describe('pkgNameHelper', () => {
+	it('should not transform a valid package.json name', () => {
+		const name = '@valid-org/valid-package-name';
+		const result = helpers.pkgName(name);
+		expect(result).toEqual(name);
+	});
+	it('should transform an invalid package.json name', () => {
+		const name = 'Invalid packageName_test';
+		const result = helpers.pkgName(name);
+		expect(result).toEqual('invalid-package-name-test');
+	});
+});
+
+describe('wpGraphqlHelper', () => {
+	it('should append /wp/graphql on to the supplied string', () => {
+		const input = 'https://my-cms-endpoint.pantheonsite.io';
+		const result = helpers.wpGraphql(input);
+		expect(result).toEqual(
+			'https://my-cms-endpoint.pantheonsite.io/wp/graphql',
+		);
+	});
+	it('should not append if the string already ends with /wp/graphql', () => {
+		const input = 'https://my-cms-endpoint.pantheonsite.io/wp/graphql/';
+		const result = helpers.wpGraphql(input);
+		expect(result).toEqual(
+			'https://my-cms-endpoint.pantheonsite.io/wp/graphql/',
+		);
+	});
+});

--- a/packages/create-pantheon-decoupled-kit/__tests__/templates/addWithDiff/test-can-be-empty.ts.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/templates/addWithDiff/test-can-be-empty.ts.ts
@@ -1,0 +1,5 @@
+import { TemplateFn } from '@cli/src/types';
+const ts: TemplateFn = ({ data, utils }) =>
+	/* ts */ `${utils.if(!data.empty, `console.log('Hello world');`)}`;
+
+export default ts;

--- a/packages/create-pantheon-decoupled-kit/__tests__/templates/addWithDiff/test-ts-template.ts.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/templates/addWithDiff/test-ts-template.ts.ts
@@ -1,0 +1,9 @@
+import { TemplateFn } from '@cli/src/types';
+const stringAsVar = /* ts */ `console.log('I am another string');`;
+
+const ts: TemplateFn = ({ data, utils }) => /* ts */ `const x = 'I am a string';
+${utils.if(data.y, /* ts */ `console.log(x);`)}
+${utils.if(data.z && data.y, stringAsVar)}
+`;
+
+export default ts;

--- a/packages/create-pantheon-decoupled-kit/src/types.ts
+++ b/packages/create-pantheon-decoupled-kit/src/types.ts
@@ -1,6 +1,7 @@
 import type { Answers, QuestionCollection } from 'inquirer';
 import type { ParsedArgs } from 'minimist';
 import type { SpyInstance } from 'vitest';
+import { taggedTemplateHelpers as helpers } from './utils';
 
 declare module 'vitest' {
 	export interface TestContext {
@@ -95,6 +96,31 @@ interface ActionConfig {
 
 interface ActionRunnerConfig extends ActionConfig {
 	actions: Action[];
+}
+
+/**
+ * Helper utilities for template literal templates
+ */
+type Helpers = typeof helpers;
+
+/**
+ * Arguments for the {@link TemplateFn}
+ */
+interface TemplateFnArgs<Data extends Input> {
+	data: Data;
+	utils: Helpers;
+}
+
+/**
+ * A tagged template literal function with data and utils context
+ */
+export declare type TemplateFn = <Data extends Input>({
+	data,
+	utils,
+}: TemplateFnArgs<Data>) => string;
+
+export interface TemplateImport {
+	default: TemplateFn;
 }
 
 // TYPE PREDICATES

--- a/packages/create-pantheon-decoupled-kit/src/utils/index.ts
+++ b/packages/create-pantheon-decoupled-kit/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './handlebars';
+export { taggedTemplateHelpers } from './taggedTemplateHelpers';
 export { dedupeTemplates } from './dedupeTemplates';
 export { actionRunner } from './actionRunner';
 export { helpMenu } from './helpMenu';

--- a/packages/create-pantheon-decoupled-kit/src/utils/taggedTemplateHelpers.ts
+++ b/packages/create-pantheon-decoupled-kit/src/utils/taggedTemplateHelpers.ts
@@ -1,0 +1,39 @@
+export const taggedTemplateHelpers = {
+	/**
+	 * @param condition - a single key of an {@link Input}
+	 * @param value - the value to render if the condition is true
+	 * @returns the value if it a string, or an empty string
+	 */
+	if: (condition: unknown, value: string) => (condition ? value : ''),
+	/**
+	 * Transforms input into a valid package.json `name`
+	 * @param value - the value to transform
+	 * @returns a valid package.json name
+	 */
+	pkgName: (value: string): string => {
+		// see https://github.com/dword-design/package-name-regex/blob/2fcb7887bdcf2815ce38f51f9bc333101ab2fd31/src/index.js#L1
+		const npmNameRegex =
+			/^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+		// turn the string into dash-case if it is not a valid package.json name
+		return npmNameRegex.test(value)
+			? value
+			: value
+					.replace(/([A-Z])([A-Z])/g, '$1-$2')
+					.replace(/([a-z])([A-Z])/g, '$1-$2')
+					.replace(/[\s_]+/g, '-')
+					.toLowerCase();
+	},
+	/**
+	 * Appends '/wp/graphql' to the input
+	 * @param value - the value to append to
+	 * @returns `${value}/wp/graphql or txt if it already ends with /wp/graphql
+	 */
+	wpGraphql: (value: string): string => {
+		const wpGraphqlUrlRegex = /\/wp\/graphql\/?$/;
+		// trim trailing /
+		return wpGraphqlUrlRegex.test(value)
+			? value
+			: `${value.replace(/\/$/, '')}/wp/graphql`;
+	},
+};


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Add support for tagged template literal templates
- Add helpers for the tagged template literal templates
  - These are the same as the handlebars helpers, but the types are slightly different so I figured it was worth separating them. Especially since we will deprecate and remove the handlebars stuff eventually.
- Add tests for the new template format

## Where were the changes made?
`cli` `addWithDiff`
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
tests!
## Additional information
Part 1 of DB-5244 in effort of keeping PRs more reviewable.
<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->