### PR TITLE
DB-6083: CMS Type Aliases

### DIFF
--- a/packages/create-pantheon-decoupled-kit/src/index.ts
+++ b/packages/create-pantheon-decoupled-kit/src/index.ts
@@ -1,7 +1,13 @@
 import chalk from 'chalk';
 import inquirer, { QuestionCollection } from 'inquirer';
 import minimist, { Opts as MinimistOptions, ParsedArgs } from 'minimist';
-import { DecoupledKitGenerator, TemplateData, isString } from './types';
+import {
+	DecoupledKitGenerator,
+	DrupalCMS,
+	TemplateData,
+	WordpressCMS,
+	isString,
+} from './types';
 import { actionRunner, getHandlebarsInstance, helpMenu } from './utils/index';
 
 import pkg from '../package.json' assert { type: 'json' };
@@ -85,6 +91,14 @@ export const main = async (
 		return;
 	});
 
+	function isDrupalCms(value: string): value is DrupalCMS {
+		return ['drupal', 'd9', 'd10'].includes(value);
+	}
+
+	function isWpCms(value: string): value is WordpressCMS {
+		return ['wordpress', 'wp'].includes(value);
+	}
+
 	const generatorsToRun: string[] = [];
 	// If no generators are found in positional params
 	// ask which generators should be run
@@ -93,14 +107,20 @@ export const main = async (
 		const cmsType = isString(args.cmsType) ? args.cmsType.toLowerCase() : null;
 
 		if (cmsType) {
-			if (['wp', 'drupal', 'any'].indexOf(cmsType) == -1) {
+			if (
+				['wp', 'wordpress', 'drupal', 'd9', 'd10', 'any'].indexOf(cmsType) == -1
+			) {
 				console.log(
 					chalk.yellow(`Invalid cmsType: ${cmsType}. Showing all generators.`),
 				);
 			} else {
 				generatorsOfCmsType = generators
 					.filter((generator) => {
-						return generator.cmsType === cmsType || generator.cmsType === 'any';
+						return (
+							isDrupalCms(generator.cmsType) === isDrupalCms(cmsType) ||
+							isWpCms(generator.cmsType) === isWpCms(cmsType) ||
+							generator.cmsType === 'any'
+						);
 					})
 					.map(({ name }) => name);
 			}

--- a/packages/create-pantheon-decoupled-kit/src/types.ts
+++ b/packages/create-pantheon-decoupled-kit/src/types.ts
@@ -56,8 +56,14 @@ export interface DecoupledKitGenerator<
 	/**
 	 * Identifies a generators compatible CMS(s).
 	 */
-	cmsType: 'wp' | 'drupal' | 'any';
+	cmsType: DrupalCMS | WordpressCMS | 'any';
 }
+
+/**
+ * Valid CMS Type Options
+ */
+export type DrupalCMS = 'd9' | 'd10' | 'drupal';
+export type WordpressCMS = 'wp' | 'wordpress';
 
 /**
  * An action that takes in the data, templates, and an instance of handlebars

--- a/packages/create-pantheon-decoupled-kit/src/utils/helpMenu.ts
+++ b/packages/create-pantheon-decoupled-kit/src/utils/helpMenu.ts
@@ -22,5 +22,5 @@ Options:
         --outDir               The directory where the output is generated.
         --appName              The name of the new app.
         --cmsEndpoint          The URL of your CMS backend.
-        --cmsType              The name of your CMS provider. As of now, wp | drupal are supported.`;
+        --cmsType              The name of your CMS provider. As of now, wp, wordpress, drupal, d9, and d10 are all valid options.`;
 };


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Aliases added for WordPress and Drupal CMS types

## Where were the changes made?
`cli`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
The new aliases of `wordpress`, `d9`, and `d10` were returning the correct starters when used as value for the `cmsType` option.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->