### PR TITLE
DB-6288: `getDrupalSearchResults` uses `example_index`

### DIFF
--- a/.changeset/stupid-terms-travel.md
+++ b/.changeset/stupid-terms-travel.md
@@ -1,0 +1,5 @@
+---
+"@pantheon-systems/drupal-kit": patch
+---
+
+[drupal-kit] Update `getDrupalSearchResults` to use `example_index` as the default index to fetch.

--- a/packages/drupal-kit/__mocks__/server/getDrupalSearchResultsResponseHandlers.ts
+++ b/packages/drupal-kit/__mocks__/server/getDrupalSearchResultsResponseHandlers.ts
@@ -1,21 +1,21 @@
 import { rest } from 'msw';
-import exampleSearchResultsDefaultIndex from '../../__tests__/data/exampleSearchResultsDefaultIndex.json';
 import exampleSearchResultsAltIndex from '../../__tests__/data/exampleSearchResultsAltIndex.json';
+import exampleSearchResultsDefaultIndex from '../../__tests__/data/exampleSearchResultsDefaultIndex.json';
 
 const apiEndpoint = 'https://default.pantheonsite.io';
 
 const defaultSearchResultsResponseHandler = rest.get<
 	typeof exampleSearchResultsDefaultIndex
->(`${apiEndpoint}/en/jsonapi/index/articles_index`, (req, res, ctx) => {
-	if (req.url.searchParams.get('filter[fulltext]') === 'milk') {
+>(`${apiEndpoint}/en/jsonapi/index/example_index`, (req, res, ctx) => {
+	if (req.url.searchParams.get('filter[fulltext]') === 'chocolate') {
 		return res(ctx.status(200), ctx.json(exampleSearchResultsDefaultIndex));
 	}
 	return;
 });
 const exampleSearchResultsResponseHandler = rest.get<
 	typeof exampleSearchResultsAltIndex
->(`${apiEndpoint}/en/jsonapi/index/example_index`, (req, res, ctx) => {
-	if (req.url.searchParams.get('filter[fulltext]') === 'chocolate') {
+>(`${apiEndpoint}/en/jsonapi/index/articles_index`, (req, res, ctx) => {
+	if (req.url.searchParams.get('filter[fulltext]') === 'milk') {
 		return res(ctx.status(200), ctx.json(exampleSearchResultsAltIndex));
 	}
 	return;

--- a/packages/drupal-kit/__tests__/getDrupalSearchResults.test.ts
+++ b/packages/drupal-kit/__tests__/getDrupalSearchResults.test.ts
@@ -16,16 +16,16 @@ describe('getDrupalSearchResults()', () => {
 	});
 	const mockContextDefault = {
 		locale: 'en',
-		query: 'milk',
+		query: 'chocolate',
 		apiUrl: 'https://default.pantheonsite.io',
 		response: mockResponse(),
 	};
 	const mockContextAlt = {
 		locale: 'en',
-		query: 'chocolate',
+		query: 'milk',
 		apiUrl: 'https://default.pantheonsite.io',
 		response: mockResponse(),
-		index: 'example_index',
+		index: 'articles_index',
 	};
 	it('should return matching search results from the default index', async () => {
 		const { locale, query, apiUrl, response } = mockContextDefault;

--- a/packages/drupal-kit/src/lib/getDrupalSearchResults.ts
+++ b/packages/drupal-kit/src/lib/getDrupalSearchResults.ts
@@ -1,6 +1,6 @@
-import { defaultFetch } from './defaultFetch.js';
-import { ServerResponse } from 'node:http';
 import type { TJsonApiBody } from 'jsona/lib/JsonaTypes';
+import { ServerResponse } from 'node:http';
+import { defaultFetch } from './defaultFetch.js';
 
 interface GetDrupalSearchResultsParams {
 	apiUrl: string;
@@ -25,7 +25,7 @@ export const getDrupalSearchResults = async ({
 	locale,
 	query,
 	response,
-	index = 'articles_index',
+	index = 'example_index',
 }: GetDrupalSearchResultsParams) => {
 	const res = await defaultFetch(
 		`${apiUrl}/${locale}/jsonapi/index/${index}?filter[fulltext]=${encodeURIComponent(


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- `getDrupalSearchResults` now uses `example_index` as it's default index to fetch. 

## Where were the changes made?
- `drupal-kit`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
A new Search API starter was generated through the cli and observed to successfully query the `example_index`.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->