### PR TITLE
DB-6289: Fix Broken Search Links

### DIFF
--- a/.changeset/pretty-waves-float.md
+++ b/.changeset/pretty-waves-float.md
@@ -1,0 +1,5 @@
+---
+"create-pantheon-decoupled-kit": patch
+---
+
+[next-drupal] Fix broken search result links

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/pages/search/[[...searchAlias]].jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/pages/search/[[...searchAlias]].jsx
@@ -1,13 +1,13 @@
+import { getDrupalSearchResults } from '@pantheon-systems/drupal-kit';
 import { NextSeo } from 'next-seo';
+import Link from 'next/link';
+import Layout from '../../components/layout';
+import PageHeader from '../../components/page-header';
 import { isMultiLanguage } from '../../lib/isMultiLanguage.js';
 import {
 	getCurrentLocaleStore,
 	globalDrupalStateStores,
 } from '../../lib/stores';
-import { getDrupalSearchResults } from '@pantheon-systems/drupal-kit';
-import Layout from '../../components/layout';
-import PageHeader from '../../components/page-header';
-import Link from 'next/link';
 import styles from './searchPage.module.css';
 
 export default function SearchPage({
@@ -38,15 +38,17 @@ export default function SearchPage({
 							<ul>
 								{searchResults?.map(({ title, body, path }) => (
 									<li key={path?.pid}>
-										<h2  className={styles.listTitle}>{title}</h2>
+										<h2 className={styles.listTitle}>{title}</h2>
 										{body.summary ? (
-											<div dangerouslySetInnerHTML={{ __html: body?.summary }} />
+											<div
+												dangerouslySetInnerHTML={{ __html: body?.summary }}
+											/>
 										) : null}
 										<Link
 											passHref
 											href={`${
 												multiLanguage ? `/${path?.langcode || locale}` : ''
-											}${path.searchAlias}`}
+											}${path.alias}`}
 											className={styles.link}
 										>
 											Read more →


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Changed search result article links to point to the correct object.

## Where were the changes made?
`cli < templates < next-drupal-search-api-addon`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
A new project was generated locally and seen to have working search result links.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->