### PR TITLE
DB-4188: add wordpress-kit code sample to surrogate key docs page

### DIFF
--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
@@ -34,7 +34,7 @@ sequenceDiagram
 ```
 
 The `GraphQLClientFactory` class from our `@pantheon-systems/wordpress-kit` npm
-package adds the `Pantheon-Skey` header to each request and uses the GET method
+package adds the `Fastly-Debug` header to each request and uses the GET method
 by default to take advantage of WPGraphQL Smart Cache network caching. Responses
 from WordPress will contain the `Surrogate-Key` header. With these keys, your
 frontend can be instructed to purge content from a cache when the content in
@@ -62,7 +62,7 @@ automatically.
   installed and configured
 - The route fetches data using the `@pantheon-systems/wordpress-kit` Graphql
   client or requests to WordPress are made using the GET method and include the
-  `Pantheon-SKey: 1` header
+  `Fastly-Debug: 1` header
   - in order to see the headers, you must use the `client.rawRequest()` method.
 - The headers must be added to the outgoing response from Next.js in
   `getServerSideProps` (see
@@ -71,3 +71,76 @@ automatically.
     [`next-wordpress-starter` includes a helper function](https://github.com/pantheon-systems/decoupled-kit-js/blob/f3eebf4b502cbad123ec8a7fcd4d4f8f0fb413eb/starters/next-wordpress-starter/lib/setOutgoingHeaders.js#L25)
     that combines headers from multiple requests and adds them to the outgoing
     response.
+
+For example, the following code could be used to set the headers necessary for
+cache purging on a post list page:
+
+1. In your post list page, import required utilities and create an instance of
+   the GraphQL Client:
+
+```js title="src/pages/posts/index.js"
+import {
+	gql,
+	GraphQLClientFactory,
+	setEdgeHeader,
+	setSurrogateKeyHeader,
+} from '@pantheon-systems/wordpress-kit';
+
+const client = new GraphQLClientFactory(
+	'https://dev-wordpress-purge-demo.pantheonsite.io/wp/graphql',
+	{
+		method: 'GET',
+	},
+).create();
+```
+
+2. In `getSeverSideProps` use the `client` instance to fetch data from
+   WordPress. Then use utilities provided by `wordpress-kit` to set caching
+   related headers on the outgoing response:
+
+```js title="src/pages/posts/index.js"
+export async function getServerSideProps({ res }) {
+	// Customize your query as needed
+	const query = gql`
+		query LatestPostsQuery($totalPosts: Int!) {
+			posts(first: $totalPosts) {
+				edges {
+					node {
+						id
+						uri
+						title
+						featuredImage {
+							node {
+								altText
+								sourceUrl
+							}
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	// Retrieve post data and surrogate key values from WordPress
+	const {
+		data: {
+			posts: { edges },
+		},
+		headers,
+	} = await client.rawRequest(query, { totalPosts: 100 });
+	const posts = edges.map(({ node }) => node);
+	const keys = headers.get('surrogate-key');
+
+	// Add unique surrogate keys to outgoing response
+	keys && setSurrogateKeyHeader(keys, res);
+	// Set cache control header to ensure response is cached at edge
+	setEdgeHeader({ res });
+
+	return { props: { posts } };
+}
+```
+
+Assuming that your backend is correctly configured, you should now see the
+`Surrogate-Key` header on the outgoing response for `/posts/`, which will allow
+the cache for this page to be purged automatically when any related content
+changes in WordPress.


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Added wordpress-kit code sample to surrogate key docs page.

## Where were the changes made?

docs.

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

Running docusaurus locally.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->