### PR TITLE
Fix subpath exports for nextjs-kit

### DIFF
--- a/.changeset/dirty-garlics-switch.md
+++ b/.changeset/dirty-garlics-switch.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/nextjs-kit': patch
+---
+
+[nextjs-kit] Restructure bundle to enable the use of package components in RSC.

--- a/packages/nextjs-kit/package.json
+++ b/packages/nextjs-kit/package.json
@@ -22,6 +22,41 @@
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.js"
 		},
+		"./dist/components/header": {
+			"types": "./dist/components/header.d.ts",
+			"import": "./dist/components/header.mjs",
+			"require": "./dist/components/header.js"
+		},
+		"./dist/components/footer": {
+			"types": "./dist/components/footer.d.ts",
+			"import": "./dist/components/footer.mjs",
+			"require": "./dist/components/footer.js"
+		},
+		"./dist/components/contentWithImage": {
+			"types": "./dist/components/contentWithImage.d.ts",
+			"import": "./dist/components/contentWithImage.mjs",
+			"require": "./dist/components/contentWithImage.js"
+		},
+		"./dist/components/grid": {
+			"types": "./dist/components/grid.d.ts",
+			"import": "./dist/components/grid.mjs",
+			"require": "./dist/components/grid.js"
+		},
+		"./dist/components/paginator": {
+			"types": "./dist/components/paginator.d.ts",
+			"import": "./dist/components/paginator.mjs",
+			"require": "./dist/components/paginator.js"
+		},
+		"./dist/components/previewRibbon": {
+			"types": "./dist/components/previewRibbon.d.ts",
+			"import": "./dist/components/previewRibbon.mjs",
+			"require": "./dist/components/previewRibbon.js"
+		},
+		"./dist/components/recipe": {
+			"types": "./dist/components/recipe.d.ts",
+			"import": "./dist/components/recipe.mjs",
+			"require": "./dist/components/recipe.js"
+		},
 		"./style.css": "./dist/style.css"
 	},
 	"prettier": "@pantheon-systems/workspace-configs/prettier",

--- a/packages/nextjs-kit/tsup.config.ts
+++ b/packages/nextjs-kit/tsup.config.ts
@@ -3,7 +3,7 @@ import pkgJson from './package.json';
 
 export default defineConfig({
 	tsconfig: './tsconfig.build.json',
-	entry: ['./src/**/*.ts', './src/style.css'],
+	entry: ['./src/**/*.ts', './src/**/*.tsx', './src/style.css'],
 	splitting: true,
 	treeshake: true,
 	dts: true,


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Porting over the changes to the `nextjs-kit` bundle in #738 over to canary so we can test locally a bit easier using the canary release.
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested with the nextjs app directory

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->