### PR TITLE
Add changeset to bump nextjs-kit version in the CLI

### DIFF
--- a/.changeset/rotten-hotels-provide.md
+++ b/.changeset/rotten-hotels-provide.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `@pantheon-systems/nextjs-kit` version


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
added a changeset for the CLI
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information
Ensure CLI is published on the next release so the templates receive the latest version of nextjs-kit
<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->