### PR TITLE
Fix gatsby wp `getPosts` template

### DIFF
--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/lib/createPagesUtils/getPosts.ts.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/lib/createPagesUtils/getPosts.ts.ts
@@ -1,8 +1,9 @@
 import type { TemplateFn } from '@cli/types';
 import { wpPostsQuery } from '@partials/gatsby-wp/wpPostsQuery';
 
-const ts: TemplateFn =
-	() => /* ts */ `import { type GatsbyGraphQLHelper } from '../types';
+const ts: TemplateFn = ({
+	utils,
+}) => /* ts */ `import { type GatsbyGraphQLHelper } from '../types';
 
 /**
  * Query the Gatsby GraphQL layer for WordPress Posts
@@ -16,7 +17,7 @@ export const getPosts = async ({
 }: GatsbyGraphQLHelper): Promise<Queries.WpPostConnection['edges'] | void> => {
 	const graphqlResult = await graphql<{
 		allWpPost: Queries.WpPostConnection;
-	}>(/* GraphQL */${wpPostsQuery(false)});
+	}>(/* GraphQL */${utils.backticks(wpPostsQuery(false))});
 
 	if (graphqlResult.errors) {
 		reporter.panicOnBuild(


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Forgot to wrap this query in the backticks util the first time. No changeset because this is going to get grouped in with the rest of the releases on this branch and it doesn't seem worthy of the changelog in the long term.
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->