### PR TITLE
Next config change no longer necessary for Drupal surrogate key example

### DIFF
--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
@@ -64,13 +64,7 @@ automatically.
 For example, the following code could be used to set the headers necessary for
 cache purging on an article list page:
 
-1. In `next.config.js`, add the following to the `nextConfig` object:
-
-```js title="next.config.js"
-transpilePackages: ['@pantheon-systems/drupal-kit'],
-```
-
-2. In your article list page, create an instance of DrupalState:
+1. In your article list page, create an instance of DrupalState:
 
 ```js title="src/pages/articles/index.js"
 import { DrupalState } from '@pantheon-systems/drupal-kit';
@@ -80,7 +74,7 @@ const store = new DrupalState({
 });
 ```
 
-3. In `getSeverSideProps` use the `store` instance to fetch data from Drupal and
+2. In `getSeverSideProps` use the `store` instance to fetch data from Drupal and
    provide the outgoing response object:
 
 ```js title="src/pages/articles/index.js"


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Removed adjustment to next.config from the Drupal Next surrogate key example as it is no longer necessary.

## Where were the changes made?

Next Drupal Developer docs.

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

Ran docs locally.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->