### PR TITLE
DB-6269: [next-drupal] Run the health check before build

### DIFF
--- a/.changeset/heavy-meals-hang.md
+++ b/.changeset/heavy-meals-hang.md
@@ -1,0 +1,7 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-drupal] Added the `@pantheon-systems/decoupled-kit-health-check` package
+as a dev dependency to the `next-drupal` template. The health check will run
+before a build to check critical endpoints for availability

--- a/packages/create-pantheon-decoupled-kit/__tests__/index.test.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/index.test.ts
@@ -116,6 +116,8 @@ describe('main()', () => {
 			{
 				_: ['next-drupal', 'next-drupal-umami-addon'],
 				appName: 'test',
+				cmsType: 'drupal',
+				dkHealthCheckVersion: versions['decoupled-kit-health-check'],
 				drupal: true,
 				drupalKitVersion: versions['drupal-kit'],
 				outDir: 'test',
@@ -127,7 +129,6 @@ describe('main()', () => {
 				h: false,
 				version: false,
 				v: false,
-				cmsType: 'drupal',
 			},
 			decoupledKitGenerators,
 		);

--- a/packages/create-pantheon-decoupled-kit/src/generators/next-drupal.generator.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/next-drupal.generator.ts
@@ -21,6 +21,7 @@ interface NextDrupalAnswers extends DefaultAnswers {
 interface NextDrupalData {
 	nextjsKitVersion: string;
 	drupalKitVersion: string;
+	dkHealthCheckVersion: string;
 	drupal: true;
 }
 
@@ -41,6 +42,7 @@ export const nextDrupal: DecoupledKitGenerator<
 	data: {
 		nextjsKitVersion: versions['nextjs-kit'],
 		drupalKitVersion: versions['drupal-kit'],
+		dkHealthCheckVersion: versions['decoupled-kit-health-check'],
 		drupal: true,
 	},
 	templates: ['next-drupal', 'tailwind-shared', 'tailwindless-next'],

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/next-drupal/nextDrupalPkgJson.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/next-drupal/nextDrupalPkgJson.hbs
@@ -2,7 +2,7 @@
 	{{> sharedPkgJsonFields}}
 	"scripts": {
 		"dev": "next dev",
-		"build": "next build && cp -r .next/static .next/standalone/.next && cp -r public .next/standalone",
+		"build": "npm run decoupled-kit-health-check && next build && cp -r .next/static .next/standalone/.next && cp -r public .next/standalone",
 		"start": "node .next/standalone/server.js",
 		"build:mono": "next build",
 		"start:mono": "next start",
@@ -12,7 +12,8 @@
 		"prettier:fix": "prettier \"**/*.{js,jsx,,md}\" --write --ignore-path .prettierignore",
 		"test": "vitest run",
 		"update-snapshots": "vitest run --update --silent",
-		"coverage": "vitest run --coverage"
+		"coverage": "vitest run --coverage",
+		"decoupled-kit-health-check": "npx --prefer-offline @pantheon-systems/decoupled-kit-health-check drupal"
 	},
 	"dependencies": {
 		"@pantheon-systems/drupal-kit": "{{drupalKitVersion}}",
@@ -28,6 +29,7 @@
 		"sharp": "^0.31.3"
 	},
 	"devDependencies": {
+		"@pantheon-systems/decoupled-kit-health-check": "{{dkHealthCheckVersion}}",
 		{{#if tailwindcss}}
 		{{> tailwindcssDeps devDeps=true}}
 		{{/if}}


### PR DESCRIPTION


 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Add decoupled-kit-health-check as devDependency to next-drupal
- Run the health-check as the first step of the build command
## Where were the changes made?
next-drupal CLI generator and templates
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tried the command locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->