### PR TITLE
DB-6269: Fix missing https in `PANTHEON_CMS_ENDPOINT`

### DIFF
--- a/.changeset/blue-trainers-knock.md
+++ b/.changeset/blue-trainers-knock.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `@pantheon-systems/decoupled-kit-health-check` version

--- a/.changeset/grumpy-lamps-act.md
+++ b/.changeset/grumpy-lamps-act.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/decoupled-kit-health-check': patch
+---
+
+Fix case where PANTHEON_CMS_ENDPOINT is set but does not have include the
+protocol

--- a/packages/decoupled-kit-health-check/src/bin.ts
+++ b/packages/decoupled-kit-health-check/src/bin.ts
@@ -53,7 +53,9 @@ const main = async () => {
 					([key]) => key === 'BACKEND_URL',
 			  )
 			: Object.entries(cmsEnvVars.endpoints);
-	const cmsEndpoint = new URL(endpoint);
+	const cmsEndpoint = /^https:\/\//.test(endpoint)
+		? new URL(endpoint)
+		: new URL(`https://${endpoint}`);
 
 	console.log('Validating CMS endpoint...');
 	const isValidEndpoint = await checkCMSEndpoint(cmsEndpoint);


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Forgot to account for the protocol missing on the `PANTHEON_CMS_ENDPOINT` when connecting a CMS via the dashboard. This should fix it.
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
healthcheck script
## How have the changes been tested?
Locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->