### PR TITLE
DB-6540: `next-wp` health check script

### DIFF
--- a/.changeset/fifty-pants-peel.md
+++ b/.changeset/fifty-pants-peel.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/decoupled-kit-health-check': minor
+---
+
+Added logic to run the health-check against wordpress

--- a/.changeset/nervous-peas-suffer.md
+++ b/.changeset/nervous-peas-suffer.md
@@ -5,3 +5,5 @@
 [next-wp] Added the `@pantheon-systems/decoupled-kit-health-check` package
 as a dev dependency to the `next-wp` template. The health check will run
 before a build to check critical endpoints for availability
+
+[next-wp, next-drupal] Updated the README to include information about the `@pantheon-systems/decoupled-kit-health-check` and 

--- a/.changeset/nervous-peas-suffer.md
+++ b/.changeset/nervous-peas-suffer.md
@@ -1,0 +1,7 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-wp] Added the `@pantheon-systems/decoupled-kit-health-check` package
+as a dev dependency to the `next-wp` template. The health check will run
+before a build to check critical endpoints for availability

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"build:all": "pnpm build:pkgs && pnpm build:starters",
 		"build:cli": "pnpm --filter create-pantheon-decoupled-kit build",
 		"build:cms-kit": "pnpm --filter cms-kit build",
+		"build:dkhc": "pnpm --filter decoupled-kit-health-check build",
 		"build:drupal-kit": "pnpm --filter drupal-kit build",
 		"build:gatsby-wp": "pnpm --filter gatsby-wordpress-starter build",
 		"build:nextjs-kit": "pnpm --filter nextjs-kit build",

--- a/packages/create-pantheon-decoupled-kit/src/generators/next-wp.generator.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/next-wp.generator.ts
@@ -20,6 +20,7 @@ interface NextWPAnswers extends DefaultAnswers {
 interface NextWpData {
 	nextjsKitVersion: string;
 	wordpressKitVersion: string;
+	dkHealthCheckVersion: string;
 	wp: true;
 }
 
@@ -38,6 +39,7 @@ export const nextWp: DecoupledKitGenerator<NextWPAnswers, NextWpData> = {
 	data: {
 		nextjsKitVersion: versions['nextjs-kit'],
 		wordpressKitVersion: versions['wordpress-kit'],
+		dkHealthCheckVersion: versions['decoupled-kit-health-check'],
 		wp: true,
 	},
 	templates: ['next-wp', 'tailwind-shared', 'tailwindless-next'],

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/README.md
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/README.md
@@ -54,6 +54,13 @@ Any fetch calls should be mocked with
 [`msw`](https://mswjs.io/docs/basics/request-matching) in
 [setupFile.js](./__tests__/setupFile.js).
 
+## Decoupled Kit Health Check
+
+The `@pantheon-systems/decoupled-kit-health-check` will run before your `build`
+and ensure the backend is setup for success. Helpful instructions will guide you
+in case anything in the health check fails. To disable the health check, see
+[Disabling the Decoupled Kit Health Check](https://live-decoupled-kit-docs.appa.pantheon.site/docs/frontend-starters/nextjs/nextjs-drupal/troubleshooting#disabling-the-decoupled-kit-health-check).
+
 ### Commands
 
 This section assumes the package manager in use is `npm`. If you are not using

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/README.md
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/README.md
@@ -38,6 +38,13 @@ should have unit tests or snapshot tests where applicable. Snapshot tests are
 using
 [`@testing-library/react`](https://testing-library.com/docs/react-testing-library/intro/).
 
+## Decoupled Kit Health Check
+
+The `@pantheon-systems/decoupled-kit-health-check` will run before your `build`
+and ensure the backend is setup for success. Helpful instructions will guide you
+in case anything in the health check fails. To disable the health check, see
+[Disabling the Decoupled Kit Health Check](https://live-decoupled-kit-docs.appa.pantheon.site/docs/frontend-starters/nextjs/nextjs-wordpress/troubleshooting#disabling-the-decoupled-kit-health-check).
+
 ### Commands
 
 This section assumes the package manager in use is `npm`. If you are not using

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/package.json.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/package.json.hbs
@@ -2,7 +2,7 @@
 	{{> sharedPkgJsonFields}}
 	"scripts": {
 		"dev": "next dev",
-		"build": "next build && cp -r .next/static .next/standalone/.next && cp -r public .next/standalone",
+		"build": "npm run decoupled-kit-health-check && next build && cp -r .next/static .next/standalone/.next && cp -r public .next/standalone",
 		"start": "node .next/standalone/server.js",
 		"build:mono": "next build",
 		"start:mono": "next start",
@@ -14,6 +14,7 @@
 		"test:watch": "vitest",
 		"update-snapshots": "vitest run --update --silent",
 		"coverage": "vitest run --coverage"
+		"decoupled-kit-health-check": "npx --prefer-offline @pantheon-systems/decoupled-kit-health-check wordpress"
 	},
 	"dependencies": {
 		"@pantheon-systems/nextjs-kit": "{{nextjsKitVersion}}",
@@ -29,6 +30,7 @@
 		"sharp": "^0.31.1"
 	},
 	"devDependencies": {
+		"@pantheon-systems/decoupled-kit-health-check": "{{dkHealthCheckVersion}}",
 		{{#if tailwindcss}}
 		{{> tailwindcssDeps devDeps=true}}
 		{{/if}}

--- a/packages/decoupled-kit-health-check/.gitignore
+++ b/packages/decoupled-kit-health-check/.gitignore
@@ -1,4 +1,4 @@
-node_modules
+/node_modules
 .DS_Store
-dist
-coverage
+/dist
+/coverage

--- a/packages/decoupled-kit-health-check/README.md
+++ b/packages/decoupled-kit-health-check/README.md
@@ -4,21 +4,45 @@
 
 The Decoupled Drupal health check will:
 
-1. check for a BACKEND_URL and/or PANTHEON_CMS_ENDPOINT
-2. If both are set, use the BACKEND_URL for checks, otherwise use whatever is
+1. Check for a BACKEND_URL and/or PANTHEON_CMS_ENDPOINT environment variable
+1. If both are set, use the BACKEND_URL for checks, otherwise use whatever is
    set. Throw an error if none are set.
-3. Ping the endpoint for the language settings to determine subsequent calls.
-4. Ping the endpoint for the decoupled router on an article based on 3. Throw an
-   error if the decoupled router can not be reached.
-5. Use the set CLIENT_ID and CLIENT_SECRET to fetch an oauth token. Warnings are
+1. Fetch the language settings to determine subsequent calls.
+1. Fetch the decoupled router on an article based on 3. Throw an error if the
+   decoupled router can not be reached.
+1. Fetch the decoupled footer menu. Throw an error if it can not be fetched.
+1. Use the set CLIENT_ID and CLIENT_SECRET to fetch an oauth token. Warnings are
    logged if these are not set.
-6. Use the access_token if available to fetch preview content. Logs a warning if
+1. Check that the PREVIEW_SECRET is set
+1. Use the access_token if available to fetch preview content. Logs a warning if
    preview is not accessible.
 
+The Decoupled WordPress health check will:
+
+1. check for a WPGRAPHQL_URL and/or PANTHEON_CMS_ENDPOINT environment variable
+1. If both are set, use the WPGRAPHQL_URL for checks, otherwise use whatever is
+   set. Throw an error if none are set.
+1. Try to fetch the Example Menu, throw an error if it can not be reached.
+1. Use the set WP_APPLICATION_USERNAME and WP_APPLICATION_PASSWORD to fetch
+   private posts. Warnings are logged if these are not set or are not valid.
+1. Check that the PREVIEW_SECRET is set.
+1. Use the credentials if available to fetch preview content. Logs a warning if
+   preview is not accessible..
+
 ## Usage
+
+### Next + Drupal
 
 In the directory of your `next-drupal` project:
 
 ```bash
-npx @pantheon-systems/health-check
+npx @pantheon-systems/decoupled-kit-health-check drupal
+```
+
+### Next + WordPress
+
+In the directory of your `next-wordpress` project:
+
+```bash
+npx @pantheon-systems/decoupled-kit-health-check wordpress
 ```

--- a/packages/decoupled-kit-health-check/__mocks__/server/index.ts
+++ b/packages/decoupled-kit-health-check/__mocks__/server/index.ts
@@ -1,6 +1,7 @@
 import { setupServer } from 'msw/node';
 import { drupalRequestHandlers } from './drupal/requestHandlers';
+import { wordpressRequestHandlers } from './wordpress/requestHandlers';
 
-const handlers = [...drupalRequestHandlers];
+const handlers = [...drupalRequestHandlers, ...wordpressRequestHandlers];
 
 export const server = setupServer(...handlers);

--- a/packages/decoupled-kit-health-check/__mocks__/server/wordpress/requestHandlers.ts
+++ b/packages/decoupled-kit-health-check/__mocks__/server/wordpress/requestHandlers.ts
@@ -1,0 +1,225 @@
+import { rest } from 'msw';
+
+const endpoint = 'https://wordpress.test';
+const invalidEndpoint = 'https://invalid.wordpress.test';
+
+const typenameQuery = rest.get(`${endpoint}`, ({ request }) => {
+	const url = new URL(request.url);
+	if (url.searchParams.get('query') === '{__typename}') {
+		return new Response(
+			JSON.stringify({
+				data: {
+					__typename: 'RootQuery',
+				},
+			}),
+		);
+	} else {
+		return new Response(
+			JSON.stringify({ errors: [{ message: 'Not found' }] }),
+			{ status: 404 },
+		);
+	}
+});
+
+const invalidTypenameQuery = rest.get(`${invalidEndpoint}`, () => {
+	return new Response(JSON.stringify({ errors: [{ message: 'Not found' }] }), {
+		status: 404,
+	});
+});
+
+// using `/auth` to separate the requests since
+// technically they are all going to `/wp/graphql`
+// but since we are not using graphql proper to query,
+// we need this workaround.
+const authorizedQuery = rest.get(`${endpoint}/auth`, ({ request }) => {
+	const url = new URL(request.url);
+	const query = /* graphql */ `query LatestPostsQuery {
+			posts(where: { status: PRIVATE }) {
+				edges {
+					node {
+						id
+					}
+				}
+			}
+		}`;
+	const wpUsername = 'a1b2c3-d4e5g6';
+	const wpPassword = 'mysecretsecret';
+	const encodedCredentials = Buffer.from(
+		`${wpUsername}:${wpPassword}`,
+		'binary',
+	).toString('base64');
+	const auth = new RegExp(`${encodedCredentials}$`).test(
+		request.headers.get('Authorization') ?? '',
+	);
+
+	if (url.searchParams.get('query') === query) {
+		if (auth) {
+			return new Response(
+				JSON.stringify({
+					data: {
+						posts: {
+							edges: [
+								{
+									node: {
+										id: 'cG9zdDo1',
+									},
+								},
+							],
+						},
+					},
+				}),
+			);
+		} else {
+			return new Response(
+				JSON.stringify({
+					data: {
+						posts: {
+							edges: [],
+						},
+					},
+				}),
+			);
+		}
+	}
+});
+
+// using `/preview` to separate the requests
+const previewQuery = rest.get(`${endpoint}/preview`, ({ request }) => {
+	const url = new URL(request.url);
+	const query = /* graphql */ `query PostPreviewQuery {
+			post(id: 1, idType: DATABASE_ID, asPreview: true) {
+				title
+				date
+				featuredImage {
+					node {
+						altText
+						sourceUrl
+					}
+				}
+				content
+			}
+		}`;
+	const wpUsername = 'a1b2c3-d4e5g6';
+	const wpPassword = 'mysecretsecret';
+	const encodedCredentials = Buffer.from(
+		`${wpUsername}:${wpPassword}`,
+		'binary',
+	).toString('base64');
+	const auth = new RegExp(`${encodedCredentials}$`).test(
+		request.headers.get('Authorization') ?? '',
+	);
+	if (url.searchParams.get('query') === query) {
+		if (auth) {
+			return new Response(
+				JSON.stringify({
+					data: {
+						post: {
+							title: 'Hello world!',
+							date: '2023-04-10T03:49:12',
+							featuredImage: null,
+							content:
+								'\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing! </p>\n\n\n\n<p></p>\n',
+						},
+					},
+				}),
+			);
+		} else {
+			return new Response(
+				JSON.stringify({
+					errors: [
+						{
+							message: 'Internal server error',
+							extensions: {
+								category: 'internal',
+							},
+							locations: [
+								{
+									line: 2,
+									column: 3,
+								},
+							],
+							path: ['post'],
+						},
+					],
+					data: {
+						post: null,
+					},
+				}),
+			);
+		}
+	}
+});
+
+const menuQuery = rest.get(`${endpoint}/menu`, ({ request }) => {
+	const url = new URL(request.url);
+	const query = /* graphql */ `query FooterMenuQuery {
+			menu(idType: NAME, id: "Example Menu") {
+				menuItems {
+					edges {
+						node {
+							id
+							path
+							label
+						}
+					}
+				}
+			}
+		}`;
+
+	if (url.searchParams.get('query') === query) {
+		console.log('MATCHED');
+		return new Response(
+			JSON.stringify({
+				data: {
+					menu: {
+						menuItems: {
+							edges: [
+								{
+									node: {
+										id: 'cG9zdDo4',
+										path: '/example-post-with-image/',
+										label: 'Example Post with Image',
+									},
+								},
+							],
+						},
+					},
+				},
+			}),
+		);
+	}
+});
+
+const invalidMenuQuery = rest.get(`${invalidEndpoint}/menu`, ({ request }) => {
+	const url = new URL(request.url);
+	const query = /* graphql */ `query FooterMenuQuery {
+			menu(idType: NAME, id: "Example Menu") {
+				menuItems {
+					edges {
+						node {
+							id
+							path
+							label
+						}
+					}
+				}
+			}
+		}`;
+
+	if (url.searchParams.get('query') === query) {
+		console.log('MATCHED');
+		return new Response(
+			JSON.stringify({
+				error: [{ message: 'Not found' }],
+			}),
+		);
+	}
+});
+
+export const wordpressRequestHandlers = [
+	typenameQuery,
+	invalidTypenameQuery,
+	authorizedQuery,
+	previewQuery,
+	menuQuery,
+];

--- a/packages/decoupled-kit-health-check/__tests__/checkAuthentication.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/checkAuthentication.test.ts
@@ -1,6 +1,9 @@
-import { checkAuthentication } from '../src/utils/checkAuthentication';
+import {
+	checkDrupalAuthentication,
+	checkWPAuthentication,
+} from '../src/utils/checkAuthentication';
 
-describe('checkAuthentication()', async () => {
+describe('checkDrupalAuthentication()', async () => {
 	afterEach(() => {
 		delete process.env['CLIENT_ID'];
 		delete process.env['CLIENT_SECRET'];
@@ -10,7 +13,7 @@ describe('checkAuthentication()', async () => {
 		process.env['CLIENT_ID'] = 'a1b2c3-d4e5g6';
 		process.env['CLIENT_SECRET'] = 'mysecretsecret';
 
-		const result = await checkAuthentication({
+		const result = await checkDrupalAuthentication({
 			env: process.env,
 			cmsEndpoint: new URL('https://drupal.test'),
 		});
@@ -21,7 +24,7 @@ describe('checkAuthentication()', async () => {
 	it('should return an empty string if the CLIENT_ID is not not set', async () => {
 		process.env['CLIENT_SECRET'] = 'mysecretsecret';
 
-		const result = await checkAuthentication({
+		const result = await checkDrupalAuthentication({
 			env: process.env,
 			cmsEndpoint: new URL('https://drupal.test'),
 		});
@@ -32,11 +35,55 @@ describe('checkAuthentication()', async () => {
 	it('should return an empty string if the CLIENT_SECRET is not set', async () => {
 		process.env['CLIENT_ID'] = 'a1b2c3-d4e5g6';
 
-		const result = await checkAuthentication({
+		const result = await checkDrupalAuthentication({
 			env: process.env,
 			cmsEndpoint: new URL('https://drupal.test'),
 		});
 
 		expect(result).toEqual({ access_token: '' });
+	});
+});
+
+describe('checkWPAuthentication()', async () => {
+	afterEach(() => {
+		delete process.env['WP_APPLICATION_USERNAME'];
+		delete process.env['WP_APPLICATION_PASSWORD'];
+	});
+
+	it('should return the credentials if the credentials are valid', async () => {
+		process.env['WP_APPLICATION_USERNAME'] = 'a1b2c3-d4e5g6';
+		process.env['WP_APPLICATION_PASSWORD'] = 'mysecretsecret';
+
+		const credentials = `${process.env['WP_APPLICATION_USERNAME']}:${process.env['WP_APPLICATION_PASSWORD']}`;
+		const encodedCredentials = Buffer.from(credentials, 'binary').toString(
+			'base64',
+		);
+		const result = await checkWPAuthentication({
+			env: process.env,
+			cmsEndpoint: new URL('https://wordpress.test/auth'),
+		});
+		expect(result).toEqual({ credentials: encodedCredentials });
+	});
+
+	it('should return an empty string if the WP_APPLICATION_USERNAME is not not set', async () => {
+		process.env['WP_APPLICATION_PASSWORD'] = 'mysecretsecret';
+
+		const result = await checkWPAuthentication({
+			env: process.env,
+			cmsEndpoint: new URL('https://wordpress.test/auth'),
+		});
+
+		expect(result).toEqual({ credentials: '' });
+	});
+
+	it('should return an empty string if the WP_APPLICATION_PASSWORD is not set', async () => {
+		process.env['WP_APPLICATION_USERNAME'] = 'a1b2c3-d4e5g6';
+
+		const result = await checkWPAuthentication({
+			env: process.env,
+			cmsEndpoint: new URL('https://wordpress.test/auth'),
+		});
+
+		expect(result).toEqual({ credentials: '' });
 	});
 });

--- a/packages/decoupled-kit-health-check/__tests__/checkCMSEndpoint.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/checkCMSEndpoint.test.ts
@@ -1,16 +1,32 @@
 import { checkCMSEndpoint } from '../src/utils/checkCMSEndpoint';
 
-describe('checkCMSEndpoint()', async () => {
+describe('checkCMSEndpoint() - rest', async () => {
 	it('should return true if the cmsEndpoint is valid', async () => {
 		const cmsEndpoint = new URL('https://drupal.test');
-		const result = await checkCMSEndpoint(cmsEndpoint);
+		const result = await checkCMSEndpoint({ cmsEndpoint, type: 'rest' });
 
 		expect(result).toEqual(true);
 	});
 
 	it('should return false if the cmsEndpoint is not valid', async () => {
 		const cmsEndpoint = new URL('https://invalid.drupal.test');
-		const result = await checkCMSEndpoint(cmsEndpoint);
+		const result = await checkCMSEndpoint({ cmsEndpoint, type: 'rest' });
+
+		expect(result).toEqual(false);
+	});
+});
+
+describe('checkCMSEndpoint() - graphql', async () => {
+	it('should return true if the cmsEndpoint is valid', async () => {
+		const cmsEndpoint = new URL('https://wordpress.test');
+		const result = await checkCMSEndpoint({ cmsEndpoint, type: 'graphql' });
+
+		expect(result).toEqual(true);
+	});
+
+	it('should return false if the cmsEndpoint is not valid', async () => {
+		const cmsEndpoint = new URL('https://invalid.wordpress.test');
+		const result = await checkCMSEndpoint({ cmsEndpoint, type: 'graphql' });
 
 		expect(result).toEqual(false);
 	});

--- a/packages/decoupled-kit-health-check/__tests__/checkCMSEnvVars.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/checkCMSEnvVars.test.ts
@@ -1,8 +1,9 @@
 import { checkCMSEnvVars } from '../src/utils/checkCMSEnvVars';
 
-const cmsEndpoint = 'https://drupal.test';
-
 describe('checkCMSEnvVars()', () => {
+	const cmsEndpoint = 'https://drupal.test';
+	const keys = ['PANTHEON_CMS_ENDPOINT', 'BACKEND_URL'];
+
 	afterEach(() => {
 		delete process.env['BACKEND_URL'];
 		delete process.env['PANTHEON_CMS_ENDPOINT'];
@@ -10,7 +11,7 @@ describe('checkCMSEnvVars()', () => {
 	it('returns an object { isSet: true, endpoints, } if BACKEND_URL is set', () => {
 		process.env['BACKEND_URL'] = cmsEndpoint;
 
-		const result = checkCMSEnvVars(process.env);
+		const result = checkCMSEnvVars({ env: process.env, keys });
 
 		expect(result.isSet).toEqual(true);
 		expect(result.endpoints['BACKEND_URL']).toEqual(cmsEndpoint);
@@ -19,7 +20,7 @@ describe('checkCMSEnvVars()', () => {
 	it('returns an object { isSet: true, endpoints, } if PANTHEON_CMS_ENDPOINT is set', () => {
 		process.env['PANTHEON_CMS_ENDPOINT'] = cmsEndpoint;
 
-		const result = checkCMSEnvVars(process.env);
+		const result = checkCMSEnvVars({ env: process.env, keys });
 
 		expect(result.isSet).toEqual(true);
 		expect(result.endpoints['PANTHEON_CMS_ENDPOINT']).toEqual(cmsEndpoint);
@@ -29,7 +30,7 @@ describe('checkCMSEnvVars()', () => {
 		process.env['BACKEND_URL'] = cmsEndpoint;
 		process.env['PANTHEON_CMS_ENDPOINT'] = cmsEndpoint;
 
-		const result = checkCMSEnvVars(process.env);
+		const result = checkCMSEnvVars({ env: process.env, keys });
 
 		expect(result.isSet).toEqual(true);
 		expect(result.endpoints).toEqual({
@@ -39,7 +40,7 @@ describe('checkCMSEnvVars()', () => {
 	});
 
 	it('returns an object { isSet: false, endpoints, } if no required env vars are set', () => {
-		const result = checkCMSEnvVars(process.env);
+		const result = checkCMSEnvVars({ env: process.env, keys });
 
 		expect(result.isSet).toEqual(false);
 		expect(result.endpoints).toEqual({});

--- a/packages/decoupled-kit-health-check/__tests__/checkMenuItemEndpoint.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/checkMenuItemEndpoint.test.ts
@@ -1,16 +1,40 @@
 import { checkMenuItemEndpoint } from '../src/utils/checkMenuItemEndpoint';
 
-describe('checkMenuItemEndpoint()', async () => {
+describe('checkMenuItemEndpoint() - rest', async () => {
 	it('should return true if the menu item endpoint is valid', async () => {
-		const result = await checkMenuItemEndpoint(new URL('https://drupal.test'));
+		const result = await checkMenuItemEndpoint({
+			cmsEndpoint: new URL('https://drupal.test'),
+			type: 'rest',
+		});
 
 		expect(result).toEqual(true);
 	});
 
 	it('should return false if the menu item endpoint is invalid', async () => {
-		const result = await checkMenuItemEndpoint(
-			new URL('https://invalid.drupal.test'),
-		);
+		const result = await checkMenuItemEndpoint({
+			cmsEndpoint: new URL('https://invalid.drupal.test'),
+			type: 'rest',
+		});
+
+		expect(result).toEqual(false);
+	});
+});
+
+describe('checkMenuItemEndpoint() - graphql', async () => {
+	it('should return true if the menu item endpoint is valid', async () => {
+		const result = await checkMenuItemEndpoint({
+			cmsEndpoint: new URL('https://wordpress.test/menu'),
+			type: 'graphql',
+		});
+
+		expect(result).toEqual(true);
+	});
+
+	it('should return false if the menu item endpoint is invalid', async () => {
+		const result = await checkMenuItemEndpoint({
+			cmsEndpoint: new URL('https://invalid.wordpress.test/menu'),
+			type: 'graphql',
+		});
 
 		expect(result).toEqual(false);
 	});

--- a/packages/decoupled-kit-health-check/__tests__/checkPreviewEndpoint.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/checkPreviewEndpoint.test.ts
@@ -1,10 +1,12 @@
-import { checkPreviewEndpoint } from '../src/utils/checkPreviewEndpoint';
+import {
+	checkDrupalPreviewEndpoint,
+	checkWPPreviewEndpoint,
+} from '../src/utils/checkPreviewEndpoint';
 
-const cmsEndpoint = new URL('https://drupal.test');
-
-describe('checkPreviewEndpoint()', async () => {
+describe('checkDrupalPreviewEndpoint()', async () => {
+	const cmsEndpoint = new URL('https://drupal.test');
 	it('should return true if preview is successfully fetched', async () => {
-		const result = await checkPreviewEndpoint({
+		const result = await checkDrupalPreviewEndpoint({
 			access_token: 'abc123',
 			cmsEndpoint,
 		});
@@ -13,11 +15,38 @@ describe('checkPreviewEndpoint()', async () => {
 	});
 
 	it('should return false if preview can not be fetched', async () => {
-		const result = await checkPreviewEndpoint({
+		const result = await checkDrupalPreviewEndpoint({
 			access_token: '',
 			cmsEndpoint,
 		});
 
 		expect(result.preview).toEqual(false);
+	});
+});
+
+describe('checkWPPreviewEndpoint()', async () => {
+	const cmsEndpoint = new URL('https://wordpress.test/preview');
+	it('should return true if preview is successfully fetched', async () => {
+		const wpUsername = 'a1b2c3-d4e5g6';
+		const wpPassword = 'mysecretsecret';
+		const encodedCredentials = Buffer.from(
+			`${wpUsername}:${wpPassword}`,
+			'binary',
+		).toString('base64');
+		const result = await checkWPPreviewEndpoint({
+			credentials: encodedCredentials,
+			cmsEndpoint,
+		});
+
+		expect(result).toEqual(true);
+	});
+
+	it('should return false if preview can not be fetched', async () => {
+		const result = await checkWPPreviewEndpoint({
+			credentials: '',
+			cmsEndpoint: new URL('https://wordpress.test/preview'),
+		});
+
+		expect(result).toEqual(false);
 	});
 });

--- a/packages/decoupled-kit-health-check/src/bin.ts
+++ b/packages/decoupled-kit-health-check/src/bin.ts
@@ -1,142 +1,27 @@
 #!/usr/bin/env node
-import dotenv from 'dotenv';
-import {
-	BackendNotSetError,
-	DecoupledMenuError,
-	DecoupledRouterError,
-	InvalidCMSEndpointError,
-} from './errors';
-import { checkAuthentication } from './utils/checkAuthentication';
-import { checkCMSEndpoint } from './utils/checkCMSEndpoint';
-import { checkCMSEnvVars } from './utils/checkCMSEnvVars';
-import { checkDecoupledRouter } from './utils/checkDecoupledRouter';
-import { checkLanguageSettings } from './utils/checkLanguageSettings';
-import { checkMenuItemEndpoint } from './utils/checkMenuItemEndpoint';
-import { checkPreviewEndpoint } from './utils/checkPreviewEndpoint';
-import { checkPreviewSecret } from './utils/checkPreviewSecret';
-import { log } from './utils/logger';
-import { resolveDotenvFile } from './utils/resolveDotenvFile';
+import { nextDrupalHealthCheck } from './next-drupal';
+import { nextWPHealthCheck } from './next-wp';
+import { getFramework } from './utils/getFramework';
 
-const main = async () => {
-	// resolve .env if it exists or not NODE_ENV=production
-	if (process.env.NODE_ENV !== 'production') {
-		dotenv.config({
-			path: resolveDotenvFile(),
-		});
-	} else {
-		console.log('Production environment detected, skipping .env* resolution.');
-	}
+const [cms] = process.argv.slice(2, 3);
 
-	console.log('Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...');
-	const cmsEnvVars = checkCMSEnvVars(process.env);
-
-	if (!cmsEnvVars.isSet) {
-		throw new BackendNotSetError();
-	} else {
-		const setEndpoints = Object.keys(cmsEnvVars.endpoints);
-		log.success(
-			`${setEndpoints.join(' and ')} ${
-				setEndpoints.length > 1 ? 'are' : 'is'
-			} set!`,
-		);
-		if (Object.keys(cmsEnvVars.endpoints).length > 1) {
-			log.warn(
-				`Both PANTHEON_CMS_ENDPOINT and BACKEND_URL are set.\n|____Using BACKEND_URL for remaining checks.`,
-			);
-		}
-	}
-
-	// Use BACKEND_URL only if both are set.
-	const [[envVar, endpoint]] =
-		Object.keys(cmsEnvVars.endpoints).length > 1
-			? Object.entries(cmsEnvVars.endpoints).filter(
-					([key]) => key === 'BACKEND_URL',
-			  )
-			: Object.entries(cmsEnvVars.endpoints);
-	const cmsEndpoint = /^https:\/\//.test(endpoint)
-		? new URL(endpoint)
-		: new URL(`https://${endpoint}`);
-
-	console.log('Validating CMS endpoint...');
-	const isValidEndpoint = await checkCMSEndpoint(cmsEndpoint);
-	if (!isValidEndpoint) {
-		throw new InvalidCMSEndpointError({
-			endpointType: envVar,
-			endpoint: cmsEndpoint.hostname,
-		});
-	} else {
-		log.success(`${envVar} is valid!`);
-	}
-
-	// determines which article to attempt to fetch with
-	// the decoupledRouter and decoupledMenu checks
-	const hasUmami = await checkLanguageSettings(cmsEndpoint);
-	console.log('Validating Decoupled Router endpoint...');
-	const decoupledRouterIsValid = await checkDecoupledRouter({
-		cmsEndpoint,
-		hasUmami,
-	});
-	if (!decoupledRouterIsValid) {
-		throw new DecoupledRouterError({
-			endpointType: envVar,
-			endpoint: cmsEndpoint.hostname,
-		});
-	} else {
-		log.success('Decoupled Router is valid!');
-	}
-
-	console.log('Validating Menu Item endpoint...');
-	const menuItemEndpointIsValid = await checkMenuItemEndpoint(cmsEndpoint);
-	if (!menuItemEndpointIsValid) {
-		throw new DecoupledMenuError({
-			endpointType: envVar,
-			endpoint: cmsEndpoint.hostname,
-		});
-	} else {
-		log.success('Menu Items endpoint is valid!');
-	}
-
-	console.log('Validating authentication...');
-	const { access_token } = await checkAuthentication({
-		env: process.env,
-		cmsEndpoint,
-	});
-	if (!access_token) {
-		log.warn('Auth not valid.');
-		log.suggest('Ensure the CLIENT_ID and CLIENT_SECRET are correct.');
-		console.log(
-			'⏭  Skipping preview endpoint validation -- authorization required.',
-		);
-	} else {
-		log.success('Auth is valid!');
-		console.log('Checking for PREVIEW_SECRET...');
-		const previewSecretIsSet = checkPreviewSecret(process.env);
-		if (!previewSecretIsSet) {
-			log.warn('PREVIEW_SECRET env var is not set.');
-			log.suggest(
-				`To set a new secret, go to 🔗 https://${cmsEndpoint.host}/admin/structure/dp-preview-site and edit the preview site you want to use.`,
-			);
-		} else {
-			log.success('PREVIEW_SECRET is set.');
-		}
-		console.log('Validating preview endpoint...');
-		const previewCheck = await checkPreviewEndpoint({
-			cmsEndpoint,
-			access_token,
-		});
-		if (!previewCheck.preview) {
-			previewCheck.cause
-				? log.warn(previewCheck.cause)
-				: log.warn('Could not fetch preview site.');
-		} else {
-			log.success('Preview is valid!');
-		}
-	}
-
-	console.log('🚀 Ready to build!');
-};
 try {
-	await main();
+	if (/(drupal|d(9|10))/.test(cms)) {
+		await nextDrupalHealthCheck();
+	} else if (/(wordpress|wp)/.test(cms)) {
+		const framework = getFramework();
+		switch (framework) {
+			case 'next':
+				await nextWPHealthCheck();
+				break;
+			case 'gatsby':
+				console.log('running gatsby-wp');
+				break;
+			case 'none':
+			default:
+				console.log('No valid framework detected. Exiting 👋');
+		}
+	}
 } catch (error) {
 	if (error instanceof Error) {
 		console.log(error.message);

--- a/packages/decoupled-kit-health-check/src/bin.ts
+++ b/packages/decoupled-kit-health-check/src/bin.ts
@@ -22,7 +22,9 @@ try {
 				console.log('No valid framework detected. Exiting 👋');
 		}
 	} else {
-		throw new Error('No cms type selected. Expected drupal or wordpress');
+		throw new Error(
+			'No cms selected. Expected "drupal" or "wordpress" as an argument',
+		);
 	}
 } catch (error) {
 	if (error instanceof Error) {

--- a/packages/decoupled-kit-health-check/src/bin.ts
+++ b/packages/decoupled-kit-health-check/src/bin.ts
@@ -21,6 +21,8 @@ try {
 			default:
 				console.log('No valid framework detected. Exiting 👋');
 		}
+	} else {
+		throw new Error('No cms type selected. Expected drupal or wordpress');
 	}
 } catch (error) {
 	if (error instanceof Error) {

--- a/packages/decoupled-kit-health-check/src/errors.ts
+++ b/packages/decoupled-kit-health-check/src/errors.ts
@@ -8,9 +8,9 @@ class HealthCheckError extends Error {
 
 export class BackendNotSetError extends HealthCheckError {
 	constructor(
+		endpointType: string,
 		message = `No backend set: 
-	The PANTHEON_CMS_ENDPOINT or BACKEND_URL environment variable must be set to fetch data.
-{insert helpful message}`,
+	The PANTHEON_CMS_ENDPOINT or ${endpointType} environment variable must be set to fetch data.`,
 	) {
 		super(message);
 	}

--- a/packages/decoupled-kit-health-check/src/next-drupal.ts
+++ b/packages/decoupled-kit-health-check/src/next-drupal.ts
@@ -1,0 +1,142 @@
+import dotenv from 'dotenv';
+import {
+	BackendNotSetError,
+	DecoupledMenuError,
+	DecoupledRouterError,
+	InvalidCMSEndpointError,
+} from './errors';
+import { checkDrupalAuthentication } from './utils/checkAuthentication';
+import { checkCMSEndpoint } from './utils/checkCMSEndpoint';
+import { checkCMSEnvVars } from './utils/checkCMSEnvVars';
+import { checkDecoupledRouter } from './utils/checkDecoupledRouter';
+import { checkLanguageSettings } from './utils/checkLanguageSettings';
+import { checkMenuItemEndpoint } from './utils/checkMenuItemEndpoint';
+import { checkDrupalPreviewEndpoint } from './utils/checkPreviewEndpoint';
+import { checkPreviewSecret } from './utils/checkPreviewSecret';
+import { log } from './utils/logger';
+import { resolveDotenvFile } from './utils/resolveDotenvFile';
+
+export const nextDrupalHealthCheck = async () => {
+	// resolve .env if it exists or not NODE_ENV=production
+	if (process.env.NODE_ENV !== 'production') {
+		dotenv.config({
+			path: resolveDotenvFile(),
+		});
+	} else {
+		console.log('Production environment detected, skipping .env* resolution.');
+	}
+
+	console.log('Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...');
+	const cmsEnvVars = checkCMSEnvVars({
+		env: process.env,
+		keys: ['BACKEND_URL', 'PANTHEON_CMS_ENDPOINT'],
+	});
+
+	if (!cmsEnvVars.isSet) {
+		throw new BackendNotSetError();
+	} else {
+		const setEndpoints = Object.keys(cmsEnvVars.endpoints);
+		log.success(
+			`${setEndpoints.join(' and ')} ${
+				setEndpoints.length > 1 ? 'are' : 'is'
+			} set!`,
+		);
+		if (Object.keys(cmsEnvVars.endpoints).length > 1) {
+			log.warn(
+				`Both PANTHEON_CMS_ENDPOINT and BACKEND_URL are set.\n|____Using BACKEND_URL for remaining checks.`,
+			);
+		}
+	}
+
+	// Use BACKEND_URL only if both are set.
+	const [[envVar, endpoint]] =
+		Object.keys(cmsEnvVars.endpoints).length > 1
+			? Object.entries(cmsEnvVars.endpoints).filter(
+					([key]) => key === 'BACKEND_URL',
+			  )
+			: Object.entries(cmsEnvVars.endpoints);
+	const cmsEndpoint = /^https:\/\//.test(endpoint)
+		? new URL(endpoint)
+		: new URL(`https://${endpoint}`);
+
+	console.log('Validating CMS endpoint...');
+	const isValidEndpoint = await checkCMSEndpoint({ cmsEndpoint, type: 'rest' });
+	if (!isValidEndpoint) {
+		throw new InvalidCMSEndpointError({
+			endpoint: cmsEndpoint.host,
+			endpointType: envVar,
+		});
+	} else {
+		log.success(`${envVar} is valid!`);
+	}
+
+	// determines which article to attempt to fetch with
+	// the decoupledRouter and decoupledMenu checks
+	const hasUmami = await checkLanguageSettings(cmsEndpoint);
+	console.log('Validating Decoupled Router endpoint...');
+	const decoupledRouterIsValid = await checkDecoupledRouter({
+		cmsEndpoint,
+		hasUmami,
+	});
+	if (!decoupledRouterIsValid) {
+		throw new DecoupledRouterError({
+			endpoint: cmsEndpoint.host,
+			endpointType: envVar,
+		});
+	} else {
+		log.success('Decoupled Router is valid!');
+	}
+
+	console.log('Validating Menu Item endpoint...');
+	const menuItemEndpointIsValid = await checkMenuItemEndpoint({
+		cmsEndpoint,
+		type: 'rest',
+	});
+	if (!menuItemEndpointIsValid) {
+		throw new DecoupledMenuError({
+			endpoint: cmsEndpoint.host,
+			endpointType: envVar,
+		});
+	} else {
+		log.success('Menu Items endpoint is valid!');
+	}
+
+	console.log('Validating authentication...');
+	const { access_token } = await checkDrupalAuthentication({
+		env: process.env,
+		cmsEndpoint,
+	});
+	if (!access_token) {
+		log.warn('Auth not valid.');
+		log.suggest('Ensure the CLIENT_ID and CLIENT_SECRET are correct.');
+		console.log(
+			'⏭  Skipping preview endpoint validation -- authorization required.',
+		);
+	} else {
+		log.success('Auth is valid!');
+		console.log('Checking for PREVIEW_SECRET...');
+		const previewSecretIsSet = checkPreviewSecret(process.env);
+		if (!previewSecretIsSet) {
+			log.warn('PREVIEW_SECRET env var is not set.');
+			log.suggest(
+				`To set a new secret, go to 🔗 https://${cmsEndpoint.host}/admin/structure/dp-preview-site and edit the preview site you want to use.`,
+			);
+		} else {
+			log.success('PREVIEW_SECRET is set.');
+		}
+		console.log('Validating preview endpoint...');
+		const previewCheck = await checkDrupalPreviewEndpoint({
+			cmsEndpoint,
+			access_token,
+		});
+		if (!previewCheck.preview) {
+			previewCheck.cause
+				? log.warn(previewCheck.cause)
+				: log.warn('Could not fetch preview site.');
+		} else {
+			log.success('Preview is valid!');
+		}
+	}
+
+	console.log('🚀 Ready to build!');
+};

--- a/packages/decoupled-kit-health-check/src/next-drupal.ts
+++ b/packages/decoupled-kit-health-check/src/next-drupal.ts
@@ -33,7 +33,7 @@ export const nextDrupalHealthCheck = async () => {
 	});
 
 	if (!cmsEnvVars.isSet) {
-		throw new BackendNotSetError();
+		throw new BackendNotSetError('BACKEND_URL');
 	} else {
 		const setEndpoints = Object.keys(cmsEnvVars.endpoints);
 		log.success(

--- a/packages/decoupled-kit-health-check/src/next-wp.ts
+++ b/packages/decoupled-kit-health-check/src/next-wp.ts
@@ -1,0 +1,122 @@
+import dotenv from 'dotenv';
+import {
+	BackendNotSetError,
+	DecoupledMenuError,
+	InvalidCMSEndpointError,
+} from './errors';
+import { checkWPAuthentication } from './utils/checkAuthentication';
+import { checkCMSEndpoint } from './utils/checkCMSEndpoint';
+import { checkCMSEnvVars } from './utils/checkCMSEnvVars';
+import { checkMenuItemEndpoint } from './utils/checkMenuItemEndpoint';
+import { checkWPPreviewEndpoint } from './utils/checkPreviewEndpoint';
+import { checkPreviewSecret } from './utils/checkPreviewSecret';
+import { log } from './utils/logger';
+import { resolveDotenvFile } from './utils/resolveDotenvFile';
+
+export const nextWPHealthCheck = async () => {
+	// resolve .env if it exists or not NODE_ENV=production
+	if (process.env.NODE_ENV !== 'production') {
+		dotenv.config({
+			path: resolveDotenvFile(),
+		});
+	} else {
+		console.log('Production environment detected, skipping .env* resolution.');
+	}
+
+	console.log('Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...');
+	const cmsEnvVars = checkCMSEnvVars({
+		env: process.env,
+		keys: ['WPGRAPHQL_URL', 'PANTHEON_CMS_ENDPOINT'],
+	});
+
+	if (!cmsEnvVars.isSet) {
+		throw new BackendNotSetError();
+	} else {
+		const setEndpoints = Object.keys(cmsEnvVars.endpoints);
+		log.success(
+			`${setEndpoints.join(' and ')} ${
+				setEndpoints.length > 1 ? 'are' : 'is'
+			} set!`,
+		);
+		if (Object.keys(cmsEnvVars.endpoints).length > 1) {
+			log.warn('Both PANTHEON_CMS_ENDPOINT and WPGRAPHQL_URL are set');
+			log.suggest('Using WPGRAPHQL_URL for remaining checks.');
+		}
+	}
+
+	// Use WPGRAPHQL_URL only if both are set.
+	const [[envVar, endpoint]] =
+		Object.keys(cmsEnvVars.endpoints).length > 1
+			? Object.entries(cmsEnvVars.endpoints).filter(
+					([key]) => key === 'WPGRAPHQL_URL',
+			  )
+			: Object.entries(cmsEnvVars.endpoints);
+	const cmsEndpoint = /^https:\/\//.test(endpoint)
+		? new URL(endpoint)
+		: new URL(`https://${endpoint}`);
+	console.log('Validating CMS endpoint...');
+	const isValidEndpoint = await checkCMSEndpoint({
+		cmsEndpoint,
+		type: 'graphql',
+	});
+	if (!isValidEndpoint) {
+		throw new InvalidCMSEndpointError({
+			endpoint: cmsEndpoint.host,
+			endpointType: envVar,
+		});
+	} else {
+		log.success(`${envVar} is valid!`);
+	}
+
+	console.log('Validating Example Menu query...');
+	const menuItemEndpointIsValid = await checkMenuItemEndpoint({
+		cmsEndpoint,
+		type: 'graphql',
+	});
+	if (!menuItemEndpointIsValid) {
+		throw new DecoupledMenuError({
+			endpoint: cmsEndpoint.host,
+			endpointType: envVar,
+		});
+	} else {
+		log.success('Example Menu query is valid!');
+	}
+
+	console.log('Validating authentication...');
+	const { credentials } = await checkWPAuthentication({
+		env: process.env,
+		cmsEndpoint,
+	});
+	if (!credentials) {
+		log.warn('Auth not valid.');
+		log.suggest(
+			'Ensure the WP_APPLICATION_USERNAME and WP_APPLICATION_PASSWORD are correct.',
+		);
+		console.log(
+			'⏭  Skipping preview endpoint validation -- authorization required.',
+		);
+	} else {
+		log.success('Auth is valid!');
+		const previewSecretIsSet = checkPreviewSecret(process.env);
+		if (!previewSecretIsSet) {
+			log.warn('PREVIEW_SECRET env var is not set.');
+			log.suggest(
+				`To set a new secret, go to 🔗 https://${cmsEndpoint.host}/wp/wp-admin/options-general.php?page=preview_sites and edit the preview site you want to use.`,
+			);
+		} else {
+			log.success('PREVIEW_SECRET is set.');
+		}
+		console.log('Validating preview endpoint...');
+		const previewCheck = await checkWPPreviewEndpoint({
+			cmsEndpoint,
+			credentials,
+		});
+		if (!previewCheck) {
+			log.warn('Could not fetch preview site.');
+		} else {
+			log.success('Preview data can be fetched!');
+		}
+	}
+
+	console.log('🚀 Ready to build!');
+};

--- a/packages/decoupled-kit-health-check/src/next-wp.ts
+++ b/packages/decoupled-kit-health-check/src/next-wp.ts
@@ -30,7 +30,7 @@ export const nextWPHealthCheck = async () => {
 	});
 
 	if (!cmsEnvVars.isSet) {
-		throw new BackendNotSetError();
+		throw new BackendNotSetError('WPGRAPHQL_URL');
 	} else {
 		const setEndpoints = Object.keys(cmsEnvVars.endpoints);
 		log.success(

--- a/packages/decoupled-kit-health-check/src/utils/checkCMSEndpoint.ts
+++ b/packages/decoupled-kit-health-check/src/utils/checkCMSEndpoint.ts
@@ -1,11 +1,24 @@
 import { isEndpointValid } from './isEndpointValid';
 
 /**
- * Checks the path `/jsonapi` of the cmsEndpoint
+ * Checks the `/jsonapi` or __typename query depending on the type of endpoint
  * @param cmsEndpoint - the cmsEndpoint
+ * @param type - graphql or rest
  * @returns true if the cmsEndpoint is valid
  */
-export const checkCMSEndpoint = async (cmsEndpoint: URL) => {
-	cmsEndpoint.pathname = '/jsonapi';
-	return await isEndpointValid(cmsEndpoint);
+export const checkCMSEndpoint = async ({
+	cmsEndpoint,
+	type,
+}: {
+	cmsEndpoint: URL;
+	type: 'graphql' | 'rest';
+}) => {
+	if (type === 'rest') {
+		cmsEndpoint.pathname = '/jsonapi';
+		return await isEndpointValid({ cmsEndpoint, type });
+	} else if (type === 'graphql') {
+		cmsEndpoint.searchParams.set('query', '{__typename}');
+		return await isEndpointValid({ cmsEndpoint, type });
+	}
+	throw new Error('type "graphql" or "rest" required.');
 };

--- a/packages/decoupled-kit-health-check/src/utils/checkCMSEnvVars.ts
+++ b/packages/decoupled-kit-health-check/src/utils/checkCMSEnvVars.ts
@@ -5,13 +5,19 @@ type CMS_ENV_VARS = 'BACKEND_URL' | 'PANTHEON_CMS_ENDPOINT';
  * @param env - process.env
  * @returns an object with a boolean if at least one of the required backendVars is set, and the endpoints that are set
  */
-export const checkCMSEnvVars = (env: typeof process.env) => {
+export const checkCMSEnvVars = ({
+	env,
+	keys,
+}: {
+	env: typeof process.env;
+	keys: string[];
+}) => {
 	const backendVars: {
 		[key in CMS_ENV_VARS]?: string;
 	} = {};
 	Object.entries(env)
 		.filter(([key]) => {
-			if (['BACKEND_URL', 'PANTHEON_CMS_ENDPOINT'].includes(key)) {
+			if (keys.includes(key)) {
 				return true;
 			}
 			return false;

--- a/packages/decoupled-kit-health-check/src/utils/checkDecoupledRouter.ts
+++ b/packages/decoupled-kit-health-check/src/utils/checkDecoupledRouter.ts
@@ -20,5 +20,5 @@ export const checkDecoupledRouter = async ({
 		? cmsEndpoint.searchParams.set('path', 'articles/lets-hear-it-for-carrots')
 		: cmsEndpoint.searchParams.set('path', 'articles/example-article');
 
-	return await isEndpointValid(cmsEndpoint);
+	return await isEndpointValid({ cmsEndpoint, type: 'rest' });
 };

--- a/packages/decoupled-kit-health-check/src/utils/checkLanguageSettings.ts
+++ b/packages/decoupled-kit-health-check/src/utils/checkLanguageSettings.ts
@@ -8,5 +8,5 @@ import { isEndpointValid } from './isEndpointValid';
 export const checkLanguageSettings = async (cmsEndpoint: URL) => {
 	const url = new URL(cmsEndpoint);
 	url.pathname = '/jsonapi/configurable_language/configurable_language';
-	return await isEndpointValid(url);
+	return await isEndpointValid({ cmsEndpoint: url, type: 'rest' });
 };

--- a/packages/decoupled-kit-health-check/src/utils/checkMenuItemEndpoint.ts
+++ b/packages/decoupled-kit-health-check/src/utils/checkMenuItemEndpoint.ts
@@ -1,11 +1,37 @@
 import { isEndpointValid } from './isEndpointValid';
 
 /**
- * Checks the path `/jsonapi/menu_items/footer` on the cmsEndpoint
+ * Checks for the default menu on the cmsEndpoint depending on the type
  * @param cmsEndpoint - the cmsEndpoint
+ * @param type - graphql or rest
  * @returns true if the endpoint is valid
  */
-export const checkMenuItemEndpoint = async (cmsEndpoint: URL) => {
-	cmsEndpoint.pathname = '/jsonapi/menu_items/footer';
-	return await isEndpointValid(cmsEndpoint);
+export const checkMenuItemEndpoint = async ({
+	cmsEndpoint,
+	type,
+}: {
+	cmsEndpoint: URL;
+	type: 'graphql' | 'rest';
+}) => {
+	if (type === 'rest') {
+		cmsEndpoint.pathname = '/jsonapi/menu_items/footer';
+		return await isEndpointValid({ cmsEndpoint, type });
+	} else if (type === 'graphql') {
+		const footerMenuQuery = /* graphql */ `query FooterMenuQuery {
+			menu(idType: NAME, id: "Example Menu") {
+				menuItems {
+					edges {
+						node {
+							id
+							path
+							label
+						}
+					}
+				}
+			}
+		}`;
+		cmsEndpoint.searchParams.set('query', footerMenuQuery);
+		return await isEndpointValid({ cmsEndpoint, type });
+	}
+	throw new Error('type "graphql" or "rest" is required.');
 };

--- a/packages/decoupled-kit-health-check/src/utils/checkPreviewEndpoint.ts
+++ b/packages/decoupled-kit-health-check/src/utils/checkPreviewEndpoint.ts
@@ -4,7 +4,7 @@
  * @param access_token - the oauth access token required to fetch private data from the cmsEndpoint
  * @returns an object with a boolean indicating if the preview was valid. If there was an error, a cause will be included with extra information.
  */
-export const checkPreviewEndpoint = async ({
+export const checkDrupalPreviewEndpoint = async ({
 	cmsEndpoint,
 	access_token,
 }: {
@@ -43,4 +43,52 @@ export const checkPreviewEndpoint = async ({
 		}
 	}
 	return { preview: false };
+};
+
+/**
+ *
+ * @param cmsEndpoint - the cmsEndpoint
+ * @param access_token - the oauth access token required to fetch private data from the cmsEndpoint
+ * @returns an object with a boolean indicating if the preview was valid. If there was an error, a cause will be included with extra information.
+ */
+export const checkWPPreviewEndpoint = async ({
+	cmsEndpoint,
+	credentials,
+}: {
+	cmsEndpoint: URL;
+	credentials: string;
+}) => {
+	try {
+		const query = /* graphql */ `query PostPreviewQuery {
+			post(id: 1, idType: DATABASE_ID, asPreview: true) {
+				title
+				date
+				featuredImage {
+					node {
+						altText
+						sourceUrl
+					}
+				}
+				content
+			}
+		}`;
+		cmsEndpoint.searchParams.set('query', query);
+		const res = await fetch(cmsEndpoint, {
+			headers: {
+				Authorization: `Basic ${credentials}`,
+			},
+		});
+		const payload = (await res.json()) as {
+			errors?: unknown[];
+			data?: { post: unknown };
+		};
+		if (payload?.data?.post) {
+			return true;
+		} else {
+			return false;
+		}
+	} catch (error) {
+		console.log(error);
+		return false;
+	}
 };

--- a/packages/decoupled-kit-health-check/src/utils/getFramework.ts
+++ b/packages/decoupled-kit-health-check/src/utils/getFramework.ts
@@ -1,0 +1,16 @@
+import path from 'node:path';
+import fs from 'node:fs';
+
+export const getFramework = () => {
+	const pkgPath = path.resolve(process.cwd(), 'package.json');
+	const pkgJson = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+		[key: string]: { [key: string]: string };
+	};
+	if (pkgJson.dependencies.next) {
+		return 'next';
+	}
+	if (pkgJson.dependencies.gatsby) {
+		return 'gatsby';
+	}
+	return 'none';
+};

--- a/packages/decoupled-kit-health-check/src/utils/isEndpointValid.ts
+++ b/packages/decoupled-kit-health-check/src/utils/isEndpointValid.ts
@@ -1,17 +1,37 @@
 /**
- * Checks that the endpoint returns a 200
+ * Checks that the endpoint returns a 200 or a valid payload
  * @param endpoint - a URL
+ * @param type - graphql or rest
  * @returns true if the endpoint returns a 200, otherwise false
  */
-export const isEndpointValid = async (endpoint: URL) => {
+export const isEndpointValid = async ({
+	cmsEndpoint,
+	type,
+}: {
+	cmsEndpoint: URL;
+	type: 'graphql' | 'rest';
+}) => {
 	try {
-		const res = await fetch(endpoint);
-		if (res.status === 200) {
-			return true;
-		} else {
-			return false;
+		const res = await fetch(cmsEndpoint);
+		if (type === 'rest') {
+			if (res.status === 200) {
+				return true;
+			} else {
+				return false;
+			}
+		} else if (type === 'graphql') {
+			const payload = (await res.json()) as {
+				errors?: unknown[];
+				data?: unknown;
+			};
+			if (payload.errors) {
+				return false;
+			} else if (payload.data) {
+				return true;
+			}
 		}
 	} catch (error) {
 		return false;
 	}
+	throw new Error('type "graphql" or "rest" is required.');
 };

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/troubleshooting.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/troubleshooting.md
@@ -198,3 +198,14 @@ const params =
 
 After making these changes, images should now display correctly within your
 articles.
+
+## Disabling the Decoupled Kit Health Check
+
+After you begin editing content in your Drupal CMS, you may find the
+`@pantheon-systems/decoupled-kit-health-check` unnecessary. If you would like to
+remove it from the build step, follow the steps below:
+
+1. In a text editor, open the `package.json`
+2. Find the `"scripts"` and remove `"decoupled-kit-health-check": "npx --prefer-offline @pantheon-systems/decoupled-kit-health-check drupal"`
+3. Edit the `"build"` script and remove `npm run decoupled-kit-health-check && ` from the beginning of the script
+4. Find the `"devDependencies"` and remove `@pantheon-systems/decoupled-kit-health-check`, Or in a terminal, run `npm rm @pantheon-systems/decoupled-kit-health-check`

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/troubleshooting.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/troubleshooting.md
@@ -46,3 +46,14 @@ See [The docs on the `next/image` component for more information](https://nextjs
 
 1. Ensure the `WPGRAQPHQL_URL` environment variable is set and contains the correct endpoint
 2. Ensure the `WP GraphQL` plugin is activated on WordPress
+
+## Disabling the Decoupled Kit Health Check
+
+After you begin editing content in your WordPress CMS, you may find the
+`@pantheon-systems/decoupled-kit-health-check` unnecessary. If you would like to
+remove it from the build step, follow the steps below:
+
+1. In a text editor, open the `package.json`
+2. Find the `"scripts"` and remove `"decoupled-kit-health-check": "npx --prefer-offline @pantheon-systems/decoupled-kit-health-check wordpress"`
+3. Edit the `"build"` script and remove `npm run decoupled-kit-health-check && ` from the beginning of the script
+4. Find the `"devDependencies"` and remove `@pantheon-systems/decoupled-kit-health-check`, Or in a terminal, run `npm rm @pantheon-systems/decoupled-kit-health-check`


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Add health-check script for next-wp
- Read arg from CLI to determine which script to run (drupal or wp)
- Check package.json to determine which script to run (next or gatsby)
- Update functions to work for drupal (rest) and wp (graphql)
- Update tests accordingly
- Add msw handlers for wordpress
- Add changeset
- Add script to next-wp package.json

Moved actual health check logic for drupal to `next-drupal.ts` and made `bin.ts` more of an entrypoint.

## Where were the changes made?
cli, dk-health-check
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->