### PR TITLE
DB-6450: Ensure endpoint ends with `/wp/graphql`

### DIFF
--- a/.changeset/cool-worms-drive.md
+++ b/.changeset/cool-worms-drive.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/decoupled-kit-health-check': patch
+---
+
+Ensure the pathname is set to `/wp/graphql` by default for the wordpress
+health-check

--- a/.changeset/plenty-pillows-drop.md
+++ b/.changeset/plenty-pillows-drop.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `@pantheon-systems/decoupled-kit-health-check` version

--- a/packages/decoupled-kit-health-check/src/next-wp.ts
+++ b/packages/decoupled-kit-health-check/src/next-wp.ts
@@ -51,10 +51,13 @@ export const nextWPHealthCheck = async () => {
 					([key]) => key === 'WPGRAPHQL_URL',
 			  )
 			: Object.entries(cmsEnvVars.endpoints);
-	const getCmsEndpoint = () =>
-		/^https:\/\//.test(endpoint)
-			? new URL(endpoint)
-			: new URL(`https://${endpoint}`);
+	const getCmsEndpoint = () => {
+		let url;
+		url = /^https:\/\//.test(endpoint) ? endpoint : `https://${endpoint}`;
+		// ensure the url ends with /wp/graphql
+		url = /\/wp\/graphql$/.test(url) ? url : `${url}/wp/graphql`;
+		return new URL(url);
+	};
 	console.log('Validating CMS endpoint...');
 	const isValidEndpoint = await checkCMSEndpoint({
 		cmsEndpoint: getCmsEndpoint(),


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Make sure the endpoint ends with `/wp/graphql` when checking WordPress
## Where were the changes made?
dkhc
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested changes locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->