### PR TITLE
DB-4444: [next-drupal] preview route test option

### DIFF
--- a/.changeset/weak-papayas-cheat.md
+++ b/.changeset/weak-papayas-cheat.md
@@ -1,0 +1,7 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-wp] Added logic to `api/preview.js` that returns JSON which indicates if
+there are any issues with the preview route or secret if the `test=true` query
+param exists on the request URL.

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
@@ -1,34 +1,74 @@
 import { globalDrupalStateStores } from '../../lib/stores';
 
+const PREVIEW_SECRET_DOES_NOT_MATCH = {
+	error: 'Preview secret does not match',
+	message:
+		'Check that your PREVIEW_SECRET environment variable matches the preview secret generated when creating the preview site in Drupal.',
+};
+const CONTENT_NOT_FOUND = {
+	error: 'Requested preview path does not exist',
+	message: 'Make sure the content is published',
+};
+
 const preview = async (req, res) => {
-	const { secret, slug, objectName } = req.query;
+	const { secret, slug, objectName, test, locale } = req.query;
+	// returns the store that matches the locale found in the accept-language header
+	// or the only store if using a monolingual backend
+	const [store] = globalDrupalStateStores.filter(({ defaultLocale }) => {
+		const regex = new RegExp(`/${defaultLocale}/`);
+		const detectedLocale = locale ? `/${locale}/` : decodeURIComponent(req.url);
+		return defaultLocale ? regex.test(detectedLocale) : true;
+	});
+
+	if (test) {
+		// validate the secret
+		if (secret !== process.env.PREVIEW_SECRET) {
+			return res.status(500).json(PREVIEW_SECRET_DOES_NOT_MATCH);
+		}
+
+		// validate the content
+		let content;
+		try {
+			content = await store.getObjectByPath({
+				objectName,
+				path: slug,
+			});
+		} catch (error) {
+			process.env.DEBUG_MODE &&
+				console.error(
+					'Error verifying preview content in pages/api/preview:\n',
+					error,
+				);
+			return res.status(500).json({
+				error: 'Could not verify preview content',
+				message: error.message,
+			});
+		}
+		if (!content) {
+			return res.status(500).json(CONTENT_NOT_FOUND);
+		}
+		return res.status(200).json({
+			message: `Preview is valid for ${slug}`,
+		});
+	}
 	// Check the secret and next parameters
 	// This secret should only be known to this API route and the CMS
 	if (secret !== process.env.PREVIEW_SECRET) {
 		return res.redirect(
 			`/preview-error/?error=${encodeURIComponent(
-				'Preview secret does not match',
-			)}&message=${encodeURIComponent(
-				'Check that your PREVIEW_SECRET environment variable matches the preview secret generated when creating the preview site in Drupal.',
-			)}`,
+				PREVIEW_SECRET_DOES_NOT_MATCH.error,
+			)}&message=${encodeURIComponent(PREVIEW_SECRET_DOES_NOT_MATCH.message)}`,
 		);
 	}
 
 	if (!slug) {
 		return res.redirect(
 			`/preview-error/?error=${encodeURIComponent(
-				'Requested preview path does not exist',
-			)}&message=${encodeURIComponent('Make sure the content is published')}`,
+				CONTENT_NOT_FOUND.error,
+			)}&message=${encodeURIComponent(CONTENT_NOT_FOUND.message)}`,
 		);
 	}
 
-	// returns the store that matches the locale found in the requested url
-	// or the only store if using a monolingual backend
-	const [store] = globalDrupalStateStores.filter(({ defaultLocale }) => {
-		const regex = new RegExp(`/${defaultLocale}/`);
-		const decodedUrl = decodeURIComponent(req.url);
-		return defaultLocale ? regex.test(decodedUrl) : true;
-	});
 	// verify the content exists
 	let content;
 	try {
@@ -53,8 +93,8 @@ const preview = async (req, res) => {
 	if (!content) {
 		return res.redirect(
 			`/preview-error/?error=${encodeURIComponent(
-				'Requested preview content does not exist',
-			)}&message=${encodeURIComponent('Make sure the content is published')}`,
+				CONTENT_NOT_FOUND.error,
+			)}&message=${encodeURIComponent(CONTENT_NOT_FOUND.message)}`,
 		);
 	}
 


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Add logic to the `next-drupal` starter's preview route so that the query param `test=true` returns JSON instead of the usual redirect to the page with the preview data.

## Where were the changes made?
`next-drupal` templates in the CLI
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested locally by hand crafting the URL

## Additional information

When trying to hit the preview route with my hand crafted URL, I was not able to include the language as a segment of the path, which is what the route currently uses to get the locale. The locale is needed to use the correct DrupalState store. I ended up passing the locale in as another query param. This should be fine as it will be ignored if the lang is included on the path segment, but I wonder if there is a better way, or if we should embrace the query param and send it from the Drupal side as well.

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->