### PR TITLE
DB-6463: [next-wp] preview test option

### DIFF
--- a/.changeset/tender-mayflies-notice.md
+++ b/.changeset/tender-mayflies-notice.md
@@ -1,0 +1,7 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-wp] Added logic to `api/preview.js` that returns JSON which indicates
+if there are any issues with the preview route or secret if the `test=true`
+queryparam exists on the request URL.

--- a/.changeset/weak-papayas-cheat.md
+++ b/.changeset/weak-papayas-cheat.md
@@ -2,6 +2,6 @@
 'create-pantheon-decoupled-kit': patch
 ---
 
-[next-wp] Added logic to `api/preview.js` that returns JSON which indicates if
+[next-drupal] Added logic to `api/preview.js` that returns JSON which indicates if
 there are any issues with the preview route or secret if the `test=true` query
 param exists on the request URL.

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
@@ -23,7 +23,7 @@ const preview = async (req, res) => {
 	if (test) {
 		// validate the secret
 		if (secret !== process.env.PREVIEW_SECRET) {
-			return res.status(500).json(PREVIEW_SECRET_DOES_NOT_MATCH);
+			return res.status(401).json(PREVIEW_SECRET_DOES_NOT_MATCH);
 		}
 
 		// validate the content
@@ -39,13 +39,13 @@ const preview = async (req, res) => {
 					'Error verifying preview content in pages/api/preview:\n',
 					error,
 				);
-			return res.status(500).json({
+			return res.status(404).json({
 				error: 'Could not verify preview content',
 				message: error.message,
 			});
 		}
 		if (!content) {
-			return res.status(500).json(CONTENT_NOT_FOUND);
+			return res.status(404).json(CONTENT_NOT_FOUND);
 		}
 		return res.status(200).json({
 			message: `Preview is valid for ${slug}`,

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/pages/api/preview.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/pages/api/preview.js
@@ -1,8 +1,45 @@
 import { getPostPreview } from '../../lib/Posts';
 import { getPagePreview } from '../../lib/Pages';
 
+const PREVIEW_SECRET_DOES_NOT_MATCH = {
+	error: 'Preview secret does not match',
+	message:
+		'Check that your PREVIEW_SECRET environment variable matches the preview secret generated when creating the preview site in WordPress.',
+};
+const CONTENT_NOT_FOUND = {
+	error: 'Requested preview path does not exist',
+	message: 'Make sure the content is published',
+};
+
 const preview = async (req, res) => {
-	const { secret, uri, id, content_type } = req.query;
+	const { secret, uri, id, content_type, test } = req.query;
+
+	if (test) {
+		if (secret !== process.env.PREVIEW_SECRET) {
+			console.log(secret, process.env.PREVIEW_SECRET);
+			return res.status(401).json(PREVIEW_SECRET_DOES_NOT_MATCH);
+		}
+
+		const message = `Preview successful for ${uri}`;
+
+		try {
+			if (content_type === 'post') {
+				const { post } = await getPostPreview(id);
+				if (post.post) {
+					return res.status(404).json(CONTENT_NOT_FOUND);
+				}
+			}
+			if (content_type === 'page') {
+				const { page } = await getPagePreview(id);
+				if (!page) {
+					return res.status(404).json(CONTENT_NOT_FOUND);
+				}
+			}
+			return res.status(200).json({ message });
+		} catch (error) {
+			return res.status(404).json(CONTENT_NOT_FOUND);
+		}
+	}
 
 	if (!secret || !uri || !id || !content_type) {
 		return res.redirect('/500');
@@ -17,7 +54,7 @@ const preview = async (req, res) => {
 	}
 
 	if (content_type === 'post') {
-		const post = await getPostPreview(id);
+		const { post } = await getPostPreview(id);
 		if (!post) {
 			return res.redirect('/500');
 		}
@@ -27,7 +64,7 @@ const preview = async (req, res) => {
 		});
 	}
 	if (content_type === 'page') {
-		const page = await getPagePreview(id);
+		const { page } = await getPagePreview(id);
 		if (!page) {
 			return res.redirect('/500');
 		}

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/pages/api/preview.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/pages/api/preview.js
@@ -16,16 +16,13 @@ const preview = async (req, res) => {
 
 	if (test) {
 		if (secret !== process.env.PREVIEW_SECRET) {
-			console.log(secret, process.env.PREVIEW_SECRET);
 			return res.status(401).json(PREVIEW_SECRET_DOES_NOT_MATCH);
 		}
-
-		const message = `Preview successful for ${uri}`;
 
 		try {
 			if (content_type === 'post') {
 				const { post } = await getPostPreview(id);
-				if (post.post) {
+				if (!post) {
 					return res.status(404).json(CONTENT_NOT_FOUND);
 				}
 			}
@@ -35,7 +32,7 @@ const preview = async (req, res) => {
 					return res.status(404).json(CONTENT_NOT_FOUND);
 				}
 			}
-			return res.status(200).json({ message });
+			return res.status(200).json({ message: `Preview successful for ${uri}` });
 		} catch (error) {
 			return res.status(404).json(CONTENT_NOT_FOUND);
 		}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Add logic to the `next-wp` starter's preview route so that the query param test=true returns JSON instead of the usual redirect to the page with the preview data.

## Where were the changes made?
next-wp template

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->