### PR TITLE
DB-6542: Fix gatsby-config, use new template for .env.development.local

### DIFF
--- a/.changeset/healthy-brooms-camp.md
+++ b/.changeset/healthy-brooms-camp.md
@@ -1,0 +1,6 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[gatsby-wp] Use new tagged template for .env.development.local and fix typo in
+gatsby-config

--- a/packages/create-pantheon-decoupled-kit/esbuild.js
+++ b/packages/create-pantheon-decoupled-kit/esbuild.js
@@ -8,7 +8,9 @@ const buildOptions = {
 	entryPoints: [
 		'./src/bin.ts',
 		// compile tagged templates to js
-		...(await glob('./src/templates/**/*.{css,jsx,tsx,ts,js,json}.ts')),
+		...(await glob('./src/templates/**/*.{css,jsx,tsx,ts,js,json,env.*}.ts', {
+			dot: true,
+		})),
 	],
 	bundle: true,
 	platform: 'node',

--- a/packages/create-pantheon-decoupled-kit/lint-staged.config.cjs
+++ b/packages/create-pantheon-decoupled-kit/lint-staged.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
 	// lint tagged templates
-	'./src/templates/**/*.{module.css,ts,tsx,json}.ts': [
+	'./src/templates/**/*.{module.css,ts,tsx,json,env.*}.ts': [
 		`eslint --fix --config ./.eslintrc --no-eslintrc  --ignore-path .gitignore`,
 		`prettier --write --ignore-path ../../.prettierignore`,
 	],

--- a/packages/create-pantheon-decoupled-kit/package.json
+++ b/packages/create-pantheon-decoupled-kit/package.json
@@ -39,7 +39,7 @@
 		"watch": "pnpm tsx watch --clear-screen=false ./scripts/watchTemplates.ts",
 		"eslint": "pnpm eslint:templates && pnpm eslint:non-templates",
 		"eslint:fix": "pnpm eslint:templates:fix && pnpm eslint:non-templates:fix",
-		"eslint:templates": "eslint \"./src/templates/**/*.{module.css,ts,tsx,json}.ts\" --config ./.eslintrc --no-eslintrc --ignore-path .gitignore",
+		"eslint:templates": "eslint \"./src/templates/**/*.{module.css,ts,tsx,json,env.*}.ts\" --config ./.eslintrc --no-eslintrc --ignore-path .gitignore",
 		"eslint:non-templates": "eslint \"./src/*.ts\" \"./src/actions/**\" \"./src/generators/**\"  \"./src/utils/**\" --config ./.eslintrc --no-eslintrc --ignore-path .gitignore",
 		"eslint:templates:fix": "pnpm eslint:templates --fix",
 		"eslint:non-templates:fix": "pnpm eslint:non-templates --fix",

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/.env.development.local.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/.env.development.local.hbs
@@ -1,1 +1,0 @@
-WPGRAPHQL_URL={{wpGraphql cmsEndpoint}}

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/.env.development.local.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/.env.development.local.ts
@@ -1,0 +1,7 @@
+import { type TemplateFn } from '@cli/types';
+
+const env: TemplateFn = ({ data, utils }) =>
+	`WPGRAPHQL_URL=${utils.wpGraphql(data.cmsEndpoint)}
+`;
+
+export default env;

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/gatsby-config.ts.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/gatsby-config.ts.ts
@@ -42,7 +42,7 @@ const cmsEndpoint = process.env.PANTHEON_CMS_ENDPOINT || '';
 process.env.PANTHEON_CMS_ENDPOINT =
 	cmsEndpoint && cmsEndpoint.startsWith('https://')
 		? process.env.PANTHEON_CMS_ENDPOINT
-		: ${utils.backticks('https://${cmsEndpoint}}/wp/graphql')};
+		: ${utils.backticks('https://${cmsEndpoint}/wp/graphql')};
 
 // Use URL from .env if it exists, otherwise fall back on the
 // Pantheon CMS endpoint

--- a/packages/create-pantheon-decoupled-kit/src/types.ts
+++ b/packages/create-pantheon-decoupled-kit/src/types.ts
@@ -103,6 +103,7 @@ type InputIndex = BaseGeneratorData &
 		appName: string;
 		outDir: string;
 		templateRootDir: string;
+		cmsEndpoint: string;
 		noInstall: boolean;
 		noLint: boolean;
 		force: boolean;
@@ -114,7 +115,7 @@ type InputIndex = BaseGeneratorData &
  * Input from command line arguments, prompts, and generator data
  */
 export type Input = {
-	[Property in keyof InputIndex]?: InputIndex[Property];
+	[Property in keyof InputIndex]: InputIndex[Property];
 };
 
 export interface TemplateData {

--- a/packages/create-pantheon-decoupled-kit/src/utils/constants.ts
+++ b/packages/create-pantheon-decoupled-kit/src/utils/constants.ts
@@ -1,1 +1,6 @@
-export const TAGGED_TEMPLATE_REGEX = /(\.(css|jsx|tsx|ts|js|json)\.(js|ts))/;
+/**
+ * @remarks
+ * `env\.[a-z.]*` - matches `.env.*.ts` such as `.env.development.local.ts`
+ */
+export const TAGGED_TEMPLATE_REGEX =
+	/(\.(css|jsx|tsx|ts|js|json|env\.[a-z.]*)\.(js|ts))/;


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Fix a typo in the gatsby config
- Use .ts template for .env.development.local
- Added `cmsEndpoint` to the Input type and made them non-optional

## Where were the changes made?
cli
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
gatsby-wp templates
## How have the changes been tested?
locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->