### PR TITLE
DB-6451: Gatsby + WP health check

### DIFF
--- a/.changeset/nervous-cats-flow.md
+++ b/.changeset/nervous-cats-flow.md
@@ -2,5 +2,5 @@
 '@pantheon-systems/decoupled-kit-health-check': patch
 ---
 
-No external facing changes, but the interals for this package have been
+No external facing changes, but the internals for this package have been
 refactored.

--- a/.changeset/strong-planets-add.md
+++ b/.changeset/strong-planets-add.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/decoupled-kit-health-check': minor
+---
+
+Add support for the Gatsby + WordPress starter

--- a/packages/decoupled-kit-health-check/__mocks__/server/wordpress/requestHandlers.ts
+++ b/packages/decoupled-kit-health-check/__mocks__/server/wordpress/requestHandlers.ts
@@ -15,18 +15,18 @@ const validResponses = rest.get(`${endpoint}`, ({ request }) => {
 				}
 			}`;
 	const previewQuery = /* graphql */ `query PostPreviewQuery {
-		post(id: 1, idType: DATABASE_ID, asPreview: true) {
-			title
-			date
-			featuredImage {
-				node {
-					altText
-					sourceUrl
+				post(id: 1, idType: DATABASE_ID, asPreview: true) {
+					title
+					date
+					featuredImage {
+						node {
+							altText
+							sourceUrl
+						}
+					}
+					content
 				}
-			}
-			content
-		}
-	}`;
+			}`;
 	const menuQuery = /* graphql */ `query FooterMenuQuery {
 			menu(idType: NAME, id: "Example Menu") {
 				menuItems {
@@ -39,6 +39,9 @@ const validResponses = rest.get(`${endpoint}`, ({ request }) => {
 					}
 				}
 			}
+		}`;
+	const wpGatsbyQuery = /* graphql */ `query checkWpGatsby {
+			isWpGatsby
 		}`;
 	switch (url.searchParams.get('query')) {
 		case '{__typename}':
@@ -156,6 +159,16 @@ const validResponses = rest.get(`${endpoint}`, ({ request }) => {
 					},
 				}),
 			);
+		case wpGatsbyQuery:
+			return new Response(
+				JSON.stringify({
+					data: {
+						isWpGatsby: true,
+					},
+				}),
+			);
+		case previewQuery:
+
 		default:
 			return new Response(
 				JSON.stringify({ errors: [{ message: 'Not found' }] }),
@@ -170,193 +183,26 @@ const invalidResponses = rest.get(`${invalidEndpoint}`, () => {
 	});
 });
 
-// using `/auth` to separate the requests since
-// technically they are all going to `/wp/graphql`
-// but since we are not using graphql proper to query,
-// we need this workaround.
-// const authorizedQuery = rest.get(`${endpoint}/auth`, ({ request }) => {
-// 	const url = new URL(request.url);
-// 	const query = /* graphql */ `query LatestPostsQuery {
-// 			posts(where: { status: PRIVATE }) {
-// 				edges {
-// 					node {
-// 						id
-// 					}
-// 				}
-// 			}
-// 		}`;
-// 	const wpUsername = 'a1b2c3-d4e5g6';
-// 	const wpPassword = 'mysecretsecret';
-// 	const encodedCredentials = Buffer.from(
-// 		`${wpUsername}:${wpPassword}`,
-// 		'binary',
-// 	).toString('base64');
-// 	const auth = new RegExp(`${encodedCredentials}$`).test(
-// 		request.headers.get('Authorization') ?? '',
-// 	);
+const noWPGatsbyPlugin = rest.get(
+	`https://wordpress.test.no-plugin/wp/graphql`,
+	({ request }) => {
+		const url = new URL(request.url);
+		if (url.searchParams.get('query') !== '{__typename}') {
+			return new Response(
+				JSON.stringify({ errors: [{ message: 'Not found' }] }),
+				{
+					status: 404,
+				},
+			);
+		}
+		return new Response(JSON.stringify({ data: 'success' }), {
+			status: 200,
+		});
+	},
+);
 
-// 	if (url.searchParams.get('query') === query) {
-// 		if (auth) {
-// 			return new Response(
-// 				JSON.stringify({
-// 					data: {
-// 						posts: {
-// 							edges: [
-// 								{
-// 									node: {
-// 										id: 'cG9zdDo1',
-// 									},
-// 								},
-// 							],
-// 						},
-// 					},
-// 				}),
-// 			);
-// 		} else {
-// 			return new Response(
-// 				JSON.stringify({
-// 					data: {
-// 						posts: {
-// 							edges: [],
-// 						},
-// 					},
-// 				}),
-// 			);
-// 		}
-// 	}
-// });
-
-// using `/preview` to separate the requests
-// const previewQuery = rest.get(`${endpoint}/preview`, ({ request }) => {
-// 	const url = new URL(request.url);
-// 	const query = /* graphql */ `query PostPreviewQuery {
-// 			post(id: 1, idType: DATABASE_ID, asPreview: true) {
-// 				title
-// 				date
-// 				featuredImage {
-// 					node {
-// 						altText
-// 						sourceUrl
-// 					}
-// 				}
-// 				content
-// 			}
-// 		}`;
-// 	const wpUsername = 'a1b2c3-d4e5g6';
-// 	const wpPassword = 'mysecretsecret';
-// 	const encodedCredentials = Buffer.from(
-// 		`${wpUsername}:${wpPassword}`,
-// 		'binary',
-// 	).toString('base64');
-// 	const auth = new RegExp(`${encodedCredentials}$`).test(
-// 		request.headers.get('Authorization') ?? '',
-// 	);
-// 	if (url.searchParams.get('query') === query) {
-// 		if (auth) {
-// 			return new Response(
-// 				JSON.stringify({
-// 					data: {
-// 						post: {
-// 							title: 'Hello world!',
-// 							date: '2023-04-10T03:49:12',
-// 							featuredImage: null,
-// 							content:
-// 								'\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing! </p>\n\n\n\n<p></p>\n',
-// 						},
-// 					},
-// 				}),
-// 			);
-// 		} else {
-// 			return new Response(
-// 				JSON.stringify({
-// 					errors: [
-// 						{
-// 							message: 'Internal server error',
-// 							extensions: {
-// 								category: 'internal',
-// 							},
-// 							locations: [
-// 								{
-// 									line: 2,
-// 									column: 3,
-// 								},
-// 							],
-// 							path: ['post'],
-// 						},
-// 					],
-// 					data: {
-// 						post: null,
-// 					},
-// 				}),
-// 			);
-// 		}
-// 	}
-// });
-
-// const menuQuery = rest.get(`${endpoint}/menu`, ({ request }) => {
-// 	const url = new URL(request.url);
-// 	const query = /* graphql */ `query FooterMenuQuery {
-// 			menu(idType: NAME, id: "Example Menu") {
-// 				menuItems {
-// 					edges {
-// 						node {
-// 							id
-// 							path
-// 							label
-// 						}
-// 					}
-// 				}
-// 			}
-// 		}`;
-
-// 	if (url.searchParams.get('query') === query) {
-// 		console.log('MATCHED');
-// 		return new Response(
-// 			JSON.stringify({
-// 				data: {
-// 					menu: {
-// 						menuItems: {
-// 							edges: [
-// 								{
-// 									node: {
-// 										id: 'cG9zdDo4',
-// 										path: '/example-post-with-image/',
-// 										label: 'Example Post with Image',
-// 									},
-// 								},
-// 							],
-// 						},
-// 					},
-// 				},
-// 			}),
-// 		);
-// 	}
-// });
-
-const invalidMenuQuery = rest.get(`${invalidEndpoint}/menu`, ({ request }) => {
-	const url = new URL(request.url);
-	const query = /* graphql */ `query FooterMenuQuery {
-			menu(idType: NAME, id: "Example Menu") {
-				menuItems {
-					edges {
-						node {
-							id
-							path
-							label
-						}
-					}
-				}
-			}
-		}`;
-
-	if (url.searchParams.get('query') === query) {
-		console.log('MATCHED');
-		return new Response(
-			JSON.stringify({
-				error: [{ message: 'Not found' }],
-			}),
-		);
-	}
-});
-
-export const wordpressRequestHandlers = [validResponses, invalidResponses];
+export const wordpressRequestHandlers = [
+	validResponses,
+	invalidResponses,
+	noWPGatsbyPlugin,
+];

--- a/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
-import { NextWordPressHealthCheck } from '../src/classes/NextWordPressHealthCheck';
+import { GatsbyWordPressHealthCheck } from '../src/classes/GatsbyWordPressHealthCheck';
 
-describe('NextWordPressHealthCheck', () => {
+describe('GatsbyWordPressHealthCheck', () => {
 	beforeEach((context) => {
 		vi.restoreAllMocks();
 		context.logSpy = vi.spyOn(console, 'log');
@@ -9,17 +9,16 @@ describe('NextWordPressHealthCheck', () => {
 		delete process.env['PANTHEON_CMS_ENDPOINT'];
 		delete process.env['WP_APPLICATION_USERNAME'];
 		delete process.env['WP_APPLICATION_SECRET'];
-		delete process.env['PREVIEW_SECRET'];
 	});
 	it('should pass for a valid WPGRAPHQL_URL and invalid auth', async ({
 		logSpy,
 	}) => {
 		process.env['WPGRAPHQL_URL'] = 'https://wordpress.test';
-		const HC = new NextWordPressHealthCheck({ env: process.env });
+		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 		await HC.validateEndpoint()
+			.then((hc) => hc.validateWPGatsbyPlugin())
 			.then((hc) => hc.validateMenu())
 			.then((hc) => hc.validateAuth())
-			.then((hc) => hc.validatePreview())
 			.catch(console.error);
 
 		const result = logSpy.mock.calls.map(([call]) => call);
@@ -29,28 +28,11 @@ describe('NextWordPressHealthCheck', () => {
 		logSpy,
 	}) => {
 		process.env['PANTHEON_CMS_ENDPOINT'] = 'wordpress.test';
-		const HC = new NextWordPressHealthCheck({ env: process.env });
+		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 		await HC.validateEndpoint()
+			.then((hc) => hc.validateWPGatsbyPlugin())
 			.then((hc) => hc.validateMenu())
 			.then((hc) => hc.validateAuth())
-			.then((hc) => hc.validatePreview())
-			.catch(console.error);
-
-		const result = logSpy.mock.calls.map(([call]) => call);
-		expect(result).toMatchSnapshot();
-	});
-	it('should pass for a valid backend and valid auth but no preview secret', async ({
-		logSpy,
-	}) => {
-		process.env['PANTHEON_CMS_ENDPOINT'] = 'wordpress.test';
-		process.env['WP_APPLICATION_USERNAME'] = 'a1b2c3-d4e5g6';
-		process.env['WP_APPLICATION_PASSWORD'] = 'mysecretsecret';
-
-		const HC = new NextWordPressHealthCheck({ env: process.env });
-		await HC.validateEndpoint()
-			.then((hc) => hc.validateMenu())
-			.then((hc) => hc.validateAuth())
-			.then((hc) => hc.validatePreview())
 			.catch(console.error);
 
 		const result = logSpy.mock.calls.map(([call]) => call);
@@ -60,13 +42,12 @@ describe('NextWordPressHealthCheck', () => {
 		process.env['PANTHEON_CMS_ENDPOINT'] = 'wordpress.test';
 		process.env['WP_APPLICATION_USERNAME'] = 'a1b2c3-d4e5g6';
 		process.env['WP_APPLICATION_PASSWORD'] = 'mysecretsecret';
-		process.env['PREVIEW_SECRET'] = 'testpreviewsecret!';
 
-		const HC = new NextWordPressHealthCheck({ env: process.env });
+		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 		await HC.validateEndpoint()
+			.then((hc) => hc.validateWPGatsbyPlugin())
 			.then((hc) => hc.validateMenu())
 			.then((hc) => hc.validateAuth())
-			.then((hc) => hc.validatePreview())
 			.catch(console.error);
 
 		const result = logSpy.mock.calls.map(([call]) => call);
@@ -77,11 +58,11 @@ describe('NextWordPressHealthCheck', () => {
 	it.fails(
 		'should show a helpful error message if no required env vars are set',
 		async () => {
-			const HC = new NextWordPressHealthCheck({ env: process.env });
+			const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 			await HC.validateEndpoint()
+				.then((hc) => hc.validateWPGatsbyPlugin())
 				.then((hc) => hc.validateMenu())
 				.then((hc) => hc.validateAuth())
-				.then((hc) => hc.validatePreview())
 				.catch((err) => console.log(err.message));
 		},
 	);
@@ -89,11 +70,25 @@ describe('NextWordPressHealthCheck', () => {
 		logSpy,
 	}) => {
 		process.env['PANTHEON_CMS_ENDPOINT'] = 'invalid.wordpress.test';
-		const HC = new NextWordPressHealthCheck({ env: process.env });
+		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 		await HC.validateEndpoint()
+			.then((hc) => hc.validateWPGatsbyPlugin())
 			.then((hc) => hc.validateMenu())
 			.then((hc) => hc.validateAuth())
-			.then((hc) => hc.validatePreview())
+			.catch((err) => console.log(err.message));
+
+		const result = logSpy.mock.calls.map(([call]) => call);
+		expect(result).toMatchSnapshot();
+	});
+	it('should show a helpful error message if the wp-gatsby plugin is not enabled is invalid', async ({
+		logSpy,
+	}) => {
+		process.env['WPGRAPHQL_URL'] = 'https://wordpress.test.no-plugin';
+		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
+		await HC.validateEndpoint()
+			.then((hc) => hc.validateWPGatsbyPlugin())
+			.then((hc) => hc.validateMenu())
+			.then((hc) => hc.validateAuth())
 			.catch((err) => console.log(err.message));
 
 		const result = logSpy.mock.calls.map(([call]) => call);

--- a/packages/decoupled-kit-health-check/__tests__/NextDrupalHealthCheck.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/NextDrupalHealthCheck.test.ts
@@ -10,7 +10,7 @@ describe('NextDrupalHealthCheck', () => {
 		delete process.env['CLIENT_SECRET'];
 		delete process.env['PREVIEW_SECRET'];
 	});
-	it('should pass for a valid BACKEND_URLR and invalid auth', async ({
+	it('should pass for a valid BACKEND_URL and invalid auth', async ({
 		logSpy,
 	}) => {
 		process.env['BACKEND_URL'] = 'https://drupal.test';

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
@@ -1,0 +1,78 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GatsbyWordPressHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOINT and invalid auth 1`] = `
+[
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
+  "No .env* file found, assuming production environment.",
+  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "Validating CMS endpoint...",
+  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "|__✅ WP Gatsby plugin is active!",
+  "Validating Menu Item endpoint...",
+  "|__✅ Menu Items endpoint is valid!",
+  "Validating authentication...",
+  "|__💡 Auth not valid.",
+  "|__💡 WP_APPLICATION_USERNAME is not set.",
+  "|____ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "|__💡 WP_APPLICATION_PASSWORD is not set.",
+  "|____ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+]
+`;
+
+exports[`GatsbyWordPressHealthCheck > should pass for a valid WPGRAPHQL_URL and invalid auth 1`] = `
+[
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
+  "No .env* file found, assuming production environment.",
+  "|__✅ WPGRAPHQL_URL is set!",
+  "Validating CMS endpoint...",
+  "|__✅ WPGRAPHQL_URL is valid!",
+  "|__✅ WP Gatsby plugin is active!",
+  "Validating Menu Item endpoint...",
+  "|__✅ Menu Items endpoint is valid!",
+  "Validating authentication...",
+  "|__💡 Auth not valid.",
+  "|__💡 WP_APPLICATION_USERNAME is not set.",
+  "|____ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "|__💡 WP_APPLICATION_PASSWORD is not set.",
+  "|____ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+]
+`;
+
+exports[`GatsbyWordPressHealthCheck > should pass for a valid backend and valid auth 1`] = `
+[
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
+  "No .env* file found, assuming production environment.",
+  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "Validating CMS endpoint...",
+  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "|__✅ WP Gatsby plugin is active!",
+  "Validating Menu Item endpoint...",
+  "|__✅ Menu Items endpoint is valid!",
+  "Validating authentication...",
+  "|__✅ Auth is valid!",
+]
+`;
+
+exports[`GatsbyWordPressHealthCheck > should show a helpful error message if the backend is invalid 1`] = `
+[
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
+  "No .env* file found, assuming production environment.",
+  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "Validating CMS endpoint...",
+  "|__❌ PANTHEON_CMS_ENDPOINT could not be fetched from.
+Check that invalid.wordpress.test is valid and provides a 200 response",
+]
+`;
+
+exports[`GatsbyWordPressHealthCheck > should show a helpful error message if the wp-gatsby plugin is not enabled is invalid 1`] = `
+[
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
+  "No .env* file found, assuming production environment.",
+  "|__✅ WPGRAPHQL_URL is set!",
+  "Validating CMS endpoint...",
+  "|__✅ WPGRAPHQL_URL is valid!",
+  "|__❌ WP Gatsby Plugin not active for WPGRAPHQL_URL.
+Enable the WP Gatsby plugin at 🔗 https://wordpress.test.no-plugin/wp/wp-admin/plugins.php, 
+then clear the cache at 🔗 https://wordpress.test.no-plugin/wp/wp-admin/options-general.php?page=pantheon-cache",
+]
+`;

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextDrupalHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextDrupalHealthCheck.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`NextDrupalHealthCheck > should pass for a valid BACKEND_URLR and invalid auth 1`] = `
+exports[`NextDrupalHealthCheck > should pass for a valid BACKEND_URL and invalid auth 1`] = `
 [
   "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "No .env* file found, assuming production environment.",

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextWordPressHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextWordPressHealthCheck.test.ts.snap
@@ -50,11 +50,10 @@ exports[`NextWordPressHealthCheck > should pass for a valid backend and valid au
   "Validating Menu Item endpoint...",
   "|__✅ Menu Items endpoint is valid!",
   "Validating authentication...",
-  "|__💡 WP_APPLICATION_PASSWORD is required for preview but is not set.",
-  "|____ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
-  "|__💡 Auth not valid.",
-  "|____ Ensure the WP_APPLICATION_USERNAME and WP_APPLICATION_PASSWORD are correct.",
-  "⏭  Skipping preview endpoint validation -- authorization required.",
+  "|__✅ Auth is valid!",
+  "Checking for PREVIEW_SECRET...",
+  "|__✅ PREVIEW_SECRET is set.",
+  "|__✅ Preview is valid!",
 ]
 `;
 
@@ -68,11 +67,11 @@ exports[`NextWordPressHealthCheck > should pass for a valid backend and valid au
   "Validating Menu Item endpoint...",
   "|__✅ Menu Items endpoint is valid!",
   "Validating authentication...",
-  "|__💡 WP_APPLICATION_PASSWORD is required for preview but is not set.",
-  "|____ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
-  "|__💡 Auth not valid.",
-  "|____ Ensure the WP_APPLICATION_USERNAME and WP_APPLICATION_PASSWORD are correct.",
-  "⏭  Skipping preview endpoint validation -- authorization required.",
+  "|__✅ Auth is valid!",
+  "Checking for PREVIEW_SECRET...",
+  "|__💡 PREVIEW_SECRET env var is not set.",
+  "|____ To set a new secret, go to 🔗 https://wordpress.test/admin/structure/dp-preview-site and edit the preview site you want to use.",
+  "⏭  Skipping preview endpoint validation -- PREVIEW_SECRET required.",
 ]
 `;
 

--- a/packages/decoupled-kit-health-check/src/bin.ts
+++ b/packages/decoupled-kit-health-check/src/bin.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { GatsbyWordPressHealthCheck } from './classes/GatsbyWordPressHealthCheck';
 import { NextDrupalHealthCheck } from './classes/NextDrupalHealthCheck';
 import { NextWordPressHealthCheck } from './classes/NextWordPressHealthCheck';
 import { getFramework } from './utils/getFramework';
@@ -25,7 +26,13 @@ try {
 				break;
 			}
 			case 'gatsby':
-				console.log('running gatsby-wp');
+				{
+					const HC = new GatsbyWordPressHealthCheck({ env: process.env });
+					await HC.validateEndpoint()
+						.then((hc) => hc.validateWPGatsbyPlugin())
+						.then((hc) => hc.validateMenu())
+						.then((hc) => hc.validateAuth());
+				}
 				break;
 			case 'none':
 			default:

--- a/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
@@ -1,0 +1,227 @@
+import dotenv from 'dotenv';
+import { logger } from '../utils/logger';
+import { resolveDotenvFile } from '../utils/resolveDotenvFile';
+import {
+	BackendNotSetError,
+	DecoupledMenuError,
+	InvalidCMSEndpointError,
+	WPGatsbyPluginError,
+} from './errors';
+import { WordPressHealthCheck } from './HealthCheckBase';
+
+export class GatsbyWordPressHealthCheck extends WordPressHealthCheck {
+	endpoint: string;
+	envVar: string;
+	appUsername: string | undefined;
+	#appPassword: string | undefined;
+	log = logger;
+	/**
+	 * Resolves .env file if it exists and check for
+	 * required environment variables, and sets the endpoint
+	 * @param env - process.env
+	 */
+	constructor({ env }: { env: typeof process.env }) {
+		super();
+		this.appUsername = env['WP_APPLICATION_USERNAME'];
+		this.#appPassword = env['WP_APPLICATION_PASSWORD'];
+
+		console.log('Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...');
+		if (process.env.NODE_ENV !== 'production') {
+			dotenv.config({
+				path: resolveDotenvFile(),
+			});
+		} else {
+			console.log(
+				'Production environment detected, skipping .env* resolution.',
+			);
+		}
+		const keys = ['WPGRAPHQL_URL', 'PANTHEON_CMS_ENDPOINT'];
+		const backendVars: {
+			[key in 'WPGRAPHQL_URL' | 'PANTHEON_CMS_ENDPOINT']?: string;
+		} = {};
+		Object.entries(env)
+			.filter(([key]) => {
+				if (keys.includes(key)) {
+					return true;
+				}
+				return false;
+			})
+			.forEach(([key, value]) => {
+				Object.assign(backendVars, { [key]: value });
+			});
+
+		const isVarSet = Object.keys(backendVars).length > 0;
+		const areMultipleVarsSet = Object.keys(backendVars).length > 1;
+
+		if (!isVarSet) {
+			throw new BackendNotSetError({ envVar: 'WPGRAPHQL_URL' });
+		} else {
+			const setEndpoints = Object.keys(backendVars);
+			this.log.success(
+				`${setEndpoints.join(' and ')} ${
+					areMultipleVarsSet ? 'are' : 'is'
+				} set!`,
+			);
+			if (areMultipleVarsSet) {
+				this.log.warn(
+					`Both PANTHEON_CMS_ENDPOINT and WPGRAPHQL_URL are set.\n|____Using WPGRAPHQL_URL for remaining checks.`,
+				);
+			}
+		}
+
+		const [[envVar, endpoint]] = areMultipleVarsSet
+			? Object.entries(backendVars).filter(([key]) => key === 'WPGRAPHQL_URL')
+			: Object.entries(backendVars);
+
+		let url;
+		url = /^https:\/\//.test(endpoint) ? endpoint : `https://${endpoint}`;
+		// ensure the url ends with /wp/graphql
+		url = /\/wp\/graphql$/.test(url) ? url : `${url}/wp/graphql`;
+
+		this.endpoint = url;
+		this.envVar = envVar;
+	}
+	getURL() {
+		return new URL(this.endpoint);
+	}
+	async checkFor200(url: URL) {
+		try {
+			const res = await fetch(url);
+			const payload = (await res.json()) as {
+				errors?: unknown[];
+				data?: unknown;
+			};
+			if (payload.errors) {
+				return false;
+			} else if (payload.data) {
+				return true;
+			}
+		} catch (error) {
+			void error;
+		}
+		return false;
+	}
+	async validateEndpoint() {
+		console.log('Validating CMS endpoint...');
+		const cmsEndpoint = this.getURL();
+		cmsEndpoint.searchParams.set('query', '{__typename}');
+		const endpointIsValid = await this.checkFor200(cmsEndpoint);
+		if (endpointIsValid) {
+			this.log.success(`${this.envVar} is valid!`);
+			return this;
+		}
+		throw new InvalidCMSEndpointError({
+			endpointType: this.envVar,
+			endpoint: this.getURL().host,
+		});
+	}
+	async validateMenu() {
+		console.log('Validating Menu Item endpoint...');
+		const cmsEndpoint = this.getURL();
+		const footerMenuQuery = /* graphql */ `query FooterMenuQuery {
+			menu(idType: NAME, id: "Example Menu") {
+				menuItems {
+					edges {
+						node {
+							id
+							path
+							label
+						}
+					}
+				}
+			}
+		}`;
+		cmsEndpoint.searchParams.set('query', footerMenuQuery);
+		const menuIsValid = await this.checkFor200(cmsEndpoint);
+		if (menuIsValid) {
+			this.log.success('Menu Items endpoint is valid!');
+			return this;
+		}
+		throw new DecoupledMenuError({
+			endpointType: this.envVar,
+			endpoint: cmsEndpoint.host,
+		});
+	}
+	async validateAuth() {
+		console.log('Validating authentication...');
+		const cmsEndpoint = this.getURL();
+
+		if (!this.appUsername || !this.#appPassword) {
+			this.log.warn('Auth not valid.');
+			if (!this.appUsername) {
+				this.log.warn('WP_APPLICATION_USERNAME is not set.');
+				this.log.suggest(
+					`Get the WP_APPLICATION_USERNAME here: 🔗 https://${cmsEndpoint.host}/wp/wp-admin/users.php`,
+				);
+			}
+			if (!this.#appPassword) {
+				this.log.warn('WP_APPLICATION_PASSWORD is not set.');
+				this.log.suggest(
+					`Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://${cmsEndpoint.host}/wp/wp-admin/users.php`,
+				);
+			}
+			return this;
+		}
+		try {
+			const credentials = `${String(this.appUsername)}:${String(
+				this.#appPassword,
+			)}`;
+			const encodedCredentials = Buffer.from(credentials, 'binary').toString(
+				'base64',
+			);
+			const query = /* graphql */ `query LatestPostsQuery {
+				posts(where: { status: PRIVATE }) {
+					edges {
+						node {
+							id
+						}
+					}
+				}
+			}`;
+			cmsEndpoint.searchParams.set('query', query);
+			const res = await fetch(cmsEndpoint, {
+				headers: { Authorization: `Basic ${encodedCredentials}` },
+			});
+			const payload = (await res.json()) as {
+				data: { posts: { edges: unknown[] } };
+			};
+			if (payload.data.posts.edges.length > 0) {
+				this.log.success('Auth is valid!');
+				return this;
+			}
+		} catch (error) {
+			void error;
+		}
+		this.log.warn('Auth not valid.');
+		this.log.suggest(
+			'Ensure the WP_APPLICATION_USERNAME and WP_APPLICATION_PASSWORD are correct.',
+		);
+		return this;
+	}
+	async validateWPGatsbyPlugin() {
+		const cmsEndpoint = this.getURL();
+		const query = /* graphql */ `query checkWpGatsby {
+			isWpGatsby
+		}`;
+		cmsEndpoint.searchParams.set('query', query);
+		const res = await fetch(cmsEndpoint);
+		const payload = (await res.json()) as {
+			data?: { isWpGatsby: boolean };
+			errors?: unknown[];
+		};
+		if (payload.errors) {
+			throw new WPGatsbyPluginError({
+				envVar: this.envVar,
+				endpoint: cmsEndpoint.host,
+			});
+		} else if (payload?.data?.isWpGatsby) {
+			this.log.success('WP Gatsby plugin is active!');
+			return this;
+		}
+		return this;
+	}
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async validatePreview() {
+		return this;
+	}
+}

--- a/packages/decoupled-kit-health-check/src/classes/errors.ts
+++ b/packages/decoupled-kit-health-check/src/classes/errors.ts
@@ -47,3 +47,14 @@ Also ensure that the JSON:API Menu Items module is enabled.`,
 		super(message);
 	}
 }
+
+export class WPGatsbyPluginError extends HealthCheckError {
+	constructor(
+		{ envVar, endpoint }: { envVar: string; endpoint: string },
+		message = `WP Gatsby Plugin not active for ${envVar}.
+Enable the WP Gatsby plugin at 🔗 https://${endpoint}/wp/wp-admin/plugins.php, 
+then clear the cache at 🔗 https://${endpoint}/wp/wp-admin/options-general.php?page=pantheon-cache`,
+	) {
+		super(message);
+	}
+}


### PR DESCRIPTION

 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Add GatsbyWordPressHealthCheck
- Add tests for GatsbyWPHC
- Fix incorrect snapshot test output for the NextWP and NextDrupal healthchecks
- Add changeset, fix a changeset

## Where were the changes made?
dkhc (decoupled-kit-health-check)

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
tested locally and with new test suite
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->