### PR TITLE
DB-6451: [gatsby-wp] Add health-check to gatsby starter

### DIFF
--- a/.changeset/little-feet-drop.md
+++ b/.changeset/little-feet-drop.md
@@ -1,0 +1,6 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[gatsby-wp] Add healthcheck script, bump
+`@pantheon-systems/decoupled-kit-healthcheck` version

--- a/.changeset/nervous-peas-suffer.md
+++ b/.changeset/nervous-peas-suffer.md
@@ -6,4 +6,4 @@
 as a dev dependency to the `next-wp` template. The health check will run
 before a build to check critical endpoints for availability
 
-[next-wp, next-drupal] Updated the README to include information about the `@pantheon-systems/decoupled-kit-health-check` and 
+[next-wp, next-drupal] Updated the README to include information about the `@pantheon-systems/decoupled-kit-health-check`

--- a/.changeset/spicy-schools-love.md
+++ b/.changeset/spicy-schools-love.md
@@ -1,6 +1,0 @@
----
-'create-pantheon-decoupled-kit': minor
----
-
-[gatsby-wp] Starters created using the `gatsby-wp` generator are now in
-TypeScript

--- a/packages/create-pantheon-decoupled-kit/__tests__/index.test.ts
+++ b/packages/create-pantheon-decoupled-kit/__tests__/index.test.ts
@@ -199,6 +199,7 @@ To see this list at any time, use the --help command.`);
 		process.argv = ['node', 'bin.js', 'gatsby-wp'];
 		const data = {
 			_: ['gatsby-wp'],
+			dkHealthCheckVersion: versions['decoupled-kit-health-check'],
 			eslintConfigVersion: versions['eslint'],
 			force: false,
 			gatsby: true,

--- a/packages/create-pantheon-decoupled-kit/src/generators/gatsby-wp.generator.ts
+++ b/packages/create-pantheon-decoupled-kit/src/generators/gatsby-wp.generator.ts
@@ -40,6 +40,7 @@ export const gatsbyWp: DecoupledKitGenerator<GatsbyWPAnswers, GatsbyWPData> = {
 	],
 	data: {
 		gatsbyPnpmPlugin: pnpm,
+		dkHealthCheckVersion: versions['decoupled-kit-health-check'],
 		wordpressKitVersion: versions['wordpress-kit'],
 		otherConfigsVersion: versions['other'],
 		eslintConfigVersion: versions['eslint'],

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/package.json.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/package.json.ts
@@ -5,7 +5,7 @@ import { tailwindcssDeps } from '@partials/pkg-shared/tailwindcssDepsT';
 const json: TemplateFn = ({ data, utils }) => /* JSON */ `{
 	${sharedPkgJsonField(utils.pkgName(data.appName))}
 	"scripts": {
-		"build": "gatsby build",
+		"build": "npm run decoupled-kit-health-check && gatsby build",
 		"develop": "ENABLE_GATSBY_REFRESH_ENDPOINT=true gatsby develop -H 0.0.0.0",
 		"format": "prettier --write '**/*.{js,jsx,ts,tsx,json,md}'",
 		"start": "npm run develop",
@@ -18,7 +18,8 @@ const json: TemplateFn = ({ data, utils }) => /* JSON */ `{
 		"update-snapshots": "vitest run --update --silent",
 		"coverage": "vitest run --coverage",
 		"lint:fix": "eslint --ext .js,.ts,.jsx,.tsx src --fix --ignore-path .gitignore",
-		"lint": "eslint --ext .js,.ts,.jsx,.tsx src --ignore-path .gitignore"
+		"lint": "eslint --ext .js,.ts,.jsx,.tsx src --ignore-path .gitignore",
+		"decoupled-kit-health-check": "npx --prefer-offline @pantheon-systems/decoupled-kit-health-check wordpress"
 	},
 	"dependencies": {
 		"gatsby": "^5.11.0",
@@ -41,13 +42,10 @@ const json: TemplateFn = ({ data, utils }) => /* JSON */ `{
 	"devDependencies": {
 		${utils.if(data.tailwindcss, tailwindcssDeps(true))}
 		${utils.if(data.tailwindcss, tailwindcssDeps(false))}
-		"@pantheon-systems/decoupled-kit-configs": "${String(
-			data.otherConfigsVersion,
-		)}",
-		"@pantheon-systems/eslint-config-decoupled-kit": "${String(
-			data.eslintConfigVersion,
-		)}",
-		"@pantheon-systems/wordpress-kit": "${String(data.wordpressKitVersion)}",
+		"@pantheon-systems/decoupled-kit-configs": "${data.otherConfigsVersion}",
+		"@pantheon-systems/decoupled-kit-health-check": "${data.dkHealthCheckVersion}",
+		"@pantheon-systems/eslint-config-decoupled-kit": "${data.eslintConfigVersion}",
+		"@pantheon-systems/wordpress-kit": "${data.wordpressKitVersion}",
 		"@testing-library/react": "13.4.0",
 		"@types/dompurify": "^3.0.2",
 		"@types/gatsbyjs__reach-router": "^2.0.0",


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Adds the gatsby-wp healthcheck to the gatsby-wp starter and cleans up some changesets.
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
cli gatsby-wp templates
## How have the changes been tested?
locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->