### PR TITLE
[dkhc] Ensure env vars are loaded in non-prod envs

### DIFF
--- a/.changeset/calm-rings-shake.md
+++ b/.changeset/calm-rings-shake.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `@pantheon-systems/decoupled-kit-health-check` version

--- a/.changeset/young-bats-collect.md
+++ b/.changeset/young-bats-collect.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/decoupled-kit-health-check': patch
+---
+
+Ensure .env vars are loaded if NODE_ENV is not production

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`GatsbyWordPressHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOINT and invalid auth 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
@@ -21,8 +21,8 @@ exports[`GatsbyWordPressHealthCheck > should pass for a valid PANTHEON_CMS_ENDPO
 
 exports[`GatsbyWordPressHealthCheck > should pass for a valid WPGRAPHQL_URL and invalid auth 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ WPGRAPHQL_URL is set!",
   "Validating CMS endpoint...",
   "|__✅ WPGRAPHQL_URL is valid!",
@@ -40,8 +40,8 @@ exports[`GatsbyWordPressHealthCheck > should pass for a valid WPGRAPHQL_URL and 
 
 exports[`GatsbyWordPressHealthCheck > should pass for a valid backend and valid auth 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
@@ -55,8 +55,8 @@ exports[`GatsbyWordPressHealthCheck > should pass for a valid backend and valid 
 
 exports[`GatsbyWordPressHealthCheck > should show a helpful error message if the backend is invalid 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__❌ PANTHEON_CMS_ENDPOINT could not be fetched from.
@@ -66,8 +66,8 @@ Check that invalid.wordpress.test is valid and provides a 200 response",
 
 exports[`GatsbyWordPressHealthCheck > should show a helpful error message if the wp-gatsby plugin is not enabled is invalid 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ WPGRAPHQL_URL is set!",
   "Validating CMS endpoint...",
   "|__✅ WPGRAPHQL_URL is valid!",

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextDrupalHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextDrupalHealthCheck.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`NextDrupalHealthCheck > should pass for a valid BACKEND_URL and invalid auth 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "|__✅ BACKEND_URL is set!",
   "Validating CMS endpoint...",
   "|__✅ BACKEND_URL is valid!",
@@ -23,8 +23,8 @@ exports[`NextDrupalHealthCheck > should pass for a valid BACKEND_URL and invalid
 
 exports[`NextDrupalHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOINT and invalid auth 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
@@ -44,8 +44,8 @@ exports[`NextDrupalHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOINT a
 
 exports[`NextDrupalHealthCheck > should pass for a valid backend and valid auth 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
@@ -62,8 +62,8 @@ exports[`NextDrupalHealthCheck > should pass for a valid backend and valid auth 
 
 exports[`NextDrupalHealthCheck > should pass for a valid backend and valid auth but no preview secret 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
@@ -81,8 +81,8 @@ exports[`NextDrupalHealthCheck > should pass for a valid backend and valid auth 
 
 exports[`NextDrupalHealthCheck > should show a helpful error message if the backend is invalid 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__❌ PANTHEON_CMS_ENDPOINT could not be fetched from.

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextWordPressHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextWordPressHealthCheck.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`NextWordPressHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOINT and invalid auth 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
@@ -22,8 +22,8 @@ exports[`NextWordPressHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOIN
 
 exports[`NextWordPressHealthCheck > should pass for a valid WPGRAPHQL_URL and invalid auth 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ WPGRAPHQL_URL is set!",
   "Validating CMS endpoint...",
   "|__✅ WPGRAPHQL_URL is valid!",
@@ -42,8 +42,8 @@ exports[`NextWordPressHealthCheck > should pass for a valid WPGRAPHQL_URL and in
 
 exports[`NextWordPressHealthCheck > should pass for a valid backend and valid auth 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
@@ -59,8 +59,8 @@ exports[`NextWordPressHealthCheck > should pass for a valid backend and valid au
 
 exports[`NextWordPressHealthCheck > should pass for a valid backend and valid auth but no preview secret 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
@@ -77,8 +77,8 @@ exports[`NextWordPressHealthCheck > should pass for a valid backend and valid au
 
 exports[`NextWordPressHealthCheck > should show a helpful error message if the backend is invalid 1`] = `
 [
-  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "|__✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
   "|__❌ PANTHEON_CMS_ENDPOINT could not be fetched from.

--- a/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
@@ -22,10 +22,6 @@ export class GatsbyWordPressHealthCheck extends WordPressHealthCheck {
 	 */
 	constructor({ env }: { env: typeof process.env }) {
 		super();
-		this.appUsername = env['WP_APPLICATION_USERNAME'];
-		this.#appPassword = env['WP_APPLICATION_PASSWORD'];
-
-		console.log('Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...');
 		if (process.env.NODE_ENV !== 'production') {
 			dotenv.config({
 				path: resolveDotenvFile(),
@@ -35,6 +31,10 @@ export class GatsbyWordPressHealthCheck extends WordPressHealthCheck {
 				'Production environment detected, skipping .env* resolution.',
 			);
 		}
+		this.appUsername = env['WP_APPLICATION_USERNAME'];
+		this.#appPassword = env['WP_APPLICATION_PASSWORD'];
+
+		console.log('Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...');
 		const keys = ['WPGRAPHQL_URL', 'PANTHEON_CMS_ENDPOINT'];
 		const backendVars: {
 			[key in 'WPGRAPHQL_URL' | 'PANTHEON_CMS_ENDPOINT']?: string;

--- a/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts
@@ -25,11 +25,6 @@ export class NextDrupalHealthCheck extends DrupalHealthCheck {
 	 */
 	constructor({ env }: { env: typeof process.env }) {
 		super();
-		this.clientID = env['CLIENT_ID'];
-		this.#clientSecret = env['CLIENT_SECRET'];
-		this.#previewSecret = env['PREVIEW_SECRET'];
-
-		console.log('Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...');
 		if (process.env.NODE_ENV !== 'production') {
 			dotenv.config({
 				path: resolveDotenvFile(),
@@ -39,6 +34,11 @@ export class NextDrupalHealthCheck extends DrupalHealthCheck {
 				'Production environment detected, skipping .env* resolution.',
 			);
 		}
+		this.clientID = env['CLIENT_ID'];
+		this.#clientSecret = env['CLIENT_SECRET'];
+		this.#previewSecret = env['PREVIEW_SECRET'];
+
+		console.log('Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...');
 		const keys = ['BACKEND_URL', 'PANTHEON_CMS_ENDPOINT'];
 		const backendVars: {
 			[key in 'BACKEND_URL' | 'PANTHEON_CMS_ENDPOINT']?: string;

--- a/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts
@@ -23,11 +23,6 @@ export class NextWordPressHealthCheck extends WordPressHealthCheck {
 	 */
 	constructor({ env }: { env: typeof process.env }) {
 		super();
-		this.appUsername = env['WP_APPLICATION_USERNAME'];
-		this.#appPassword = env['WP_APPLICATION_PASSWORD'];
-		this.#previewSecret = env['PREVIEW_SECRET'];
-
-		console.log('Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...');
 		if (process.env.NODE_ENV !== 'production') {
 			dotenv.config({
 				path: resolveDotenvFile(),
@@ -37,6 +32,11 @@ export class NextWordPressHealthCheck extends WordPressHealthCheck {
 				'Production environment detected, skipping .env* resolution.',
 			);
 		}
+		this.appUsername = env['WP_APPLICATION_USERNAME'];
+		this.#appPassword = env['WP_APPLICATION_PASSWORD'];
+		this.#previewSecret = env['PREVIEW_SECRET'];
+
+		console.log('Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...');
 		const keys = ['WPGRAPHQL_URL', 'PANTHEON_CMS_ENDPOINT'];
 		const backendVars: {
 			[key in 'WPGRAPHQL_URL' | 'PANTHEON_CMS_ENDPOINT']?: string;


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Ensures that .env.development.local or .env is read if `NODE_ENV !== 'production'`
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
dkhc
## How have the changes been tested?
locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->