### PR TITLE
DB-6265: [next-drupal] pagination example fails gracefully

### DIFF
--- a/.changeset/calm-apricots-relate.md
+++ b/.changeset/calm-apricots-relate.md
@@ -1,0 +1,6 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-drupal] Pagination example fails gracefully. If the mock content can not
+be reached, a message is displayed at the /examples/pagination route.

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/examples/pagination/[[...page]].jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/examples/pagination/[[...page]].jsx
@@ -55,14 +55,11 @@ export default function PaginationExampleTemplate({ data, footerMenu }) {
 							/>
 						</>
 					) : (
-						<p className={styles.noData}>
+						<div className={styles.noData}>
 							This example relies on data from{' '}
-							<pre className={styles.pre}>
-								https://dev-ds-demo.pantheonsite.io
-							</pre>
-							. If you&apos;re seeing this message, it may be unreachable. Try
-							building again when it is reachable or create your own data with
-							the{' '}
+							<code>https://dev-ds-demo.pantheonsite.io</code>. If you&apos;re
+							seeing this message, it may be unreachable. Try building again
+							when it is reachable or create your own data with the{' '}
 							<a
 								className={styles.link}
 								href="https://www.drupal.org/project/faker"
@@ -71,7 +68,7 @@ export default function PaginationExampleTemplate({ data, footerMenu }) {
 								Faker Drupal Module
 							</a>
 							.
-						</p>
+						</div>
 					)}
 				</section>
 			</div>

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/examples/pagination/[[...page]].jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/examples/pagination/[[...page]].jsx
@@ -43,14 +43,36 @@ export default function PaginationExampleTemplate({ data, footerMenu }) {
 			</Head>
 			<div className={styles.container}>
 				<section className={styles.content}>
-					<h1>Pagination example</h1>
-					<Paginator
-						data={data}
-						itemsPerPage={itemsPerPage}
-						breakpoints={{ start: 6, end: 12, add: 6 }}
-						routing
-						Component={RenderCurrentItems}
-					/>
+					{data ? (
+						<>
+							<h1>Pagination example</h1>
+							<Paginator
+								data={data}
+								itemsPerPage={itemsPerPage}
+								breakpoints={{ start: 6, end: 12, add: 6 }}
+								routing
+								Component={RenderCurrentItems}
+							/>
+						</>
+					) : (
+						<p className={styles.noData}>
+							This example relies on data from{' '}
+							<pre className={styles.pre}>
+								https://dev-ds-demo.pantheonsite.io
+							</pre>
+							. If you&apos;re seeing this message, it may be unreachable. Try
+							building again when it is reachable or create your own data with
+							the{' '}
+							<a
+								className={styles.link}
+								href="https://www.drupal.org/project/faker"
+								rel="noopener"
+							>
+								Faker Drupal Module
+							</a>
+							.
+						</p>
+					)}
 				</section>
 			</div>
 		</Layout>
@@ -58,64 +80,91 @@ export default function PaginationExampleTemplate({ data, footerMenu }) {
 }
 
 export async function getStaticPaths() {
-	const store = new DrupalState({
-		apiBase: drupalUrl,
-		apiPrefix: 'jsonapi',
-		defaultLocale: 'en',
-		debug: process.env.DEBUG_MODE || false,
-	});
-	const data = await store.getObject({
-		objectName: 'node--ds_example',
-		all: true,
-		params: 'fields[node--ds_example]=title,body,id',
-		anon: true,
-	});
-	const itemsPerPage = 10;
-	const totalPages = Math.ceil(data.length / itemsPerPage);
+	try {
+		const store = new DrupalState({
+			apiBase: drupalUrl,
+			apiPrefix: 'jsonapi',
+			defaultLocale: 'en',
+			debug: process.env.DEBUG_MODE || false,
+		});
+		const data = await store.getObject({
+			objectName: 'node--ds_example',
+			all: true,
+			params: 'fields[node--ds_example]=title,body,id',
+			anon: true,
+		});
+		const itemsPerPage = 10;
+		const totalPages = Math.ceil(data.length / itemsPerPage);
 
-	const arr = Array.from(Array(totalPages).keys());
+		const arr = Array.from(Array(totalPages).keys());
 
-	const paths = arr.map((page) => ({
-		params: { page: [(page + 1).toString()] },
-	}));
-	// allows for  examples/pagination
-	paths.push({ params: { page: [''] } });
+		const paths = arr.map((page) => ({
+			params: { page: [(page + 1).toString()] },
+		}));
+		// allows for  examples/pagination
+		paths.push({ params: { page: [''] } });
 
-	return {
-		paths: paths,
-		fallback: false,
-	};
+		return {
+			paths: paths,
+			fallback: false,
+		};
+	} catch (error) {
+		console.error(
+			'Something went wrong while getting paths for pagination data:',
+		);
+		console.error(error.message);
+	} finally {
+		return { paths: [{ params: { page: [''] } }], fallback: false };
+	}
 }
 
 // Using getStaticProps here with ISR will have a substantial impact on
 // performance due to the large payload.
 export async function getStaticProps(context) {
-	const exampleStore = new DrupalState({
-		apiBase: drupalUrl,
-		apiPrefix: 'jsonapi',
-		defaultLocale: 'en',
-		debug: process.env.DEBUG_MODE || false,
-	});
+	let data;
+	try {
+		const exampleStore = new DrupalState({
+			apiBase: drupalUrl,
+			apiPrefix: 'jsonapi',
+			defaultLocale: 'en',
+			debug: process.env.DEBUG_MODE || false,
+		});
+		// drupal json api params
+		data = await exampleStore.getObject({
+			objectName: 'node--ds_example',
+			params: 'fields[node--ds_example]=title,body,id',
+			all: true,
+			refresh: !BUILD_MODE,
+			anon: true,
+		});
 
-	// drupal json api params
-	const data = await exampleStore.getObject({
-		objectName: 'node--ds_example',
-		params: 'fields[node--ds_example]=title,body,id',
-		all: true,
-		refresh: !BUILD_MODE,
-		anon: true,
-	});
-
-	const store = getCurrentLocaleStore(context.locale, globalDrupalStateStores);
-	const footerMenu = await store.getObject({
-		objectName: 'menu_items--main',
-		anon: true,
-	});
-	return {
-		props: {
-			data,
-			footerMenu,
-		},
-		revalidate: 60,
-	};
+		const store = getCurrentLocaleStore(
+			context.locale,
+			globalDrupalStateStores,
+		);
+		const footerMenu = await store.getObject({
+			objectName: 'menu_items--main',
+			anon: true,
+		});
+	} catch (error) {
+		console.error('Something went wrong while getting pagination data:');
+		console.error(error.message);
+		console.error('Returning null for pagination example data...');
+	} finally {
+		const store = getCurrentLocaleStore(
+			context.locale,
+			globalDrupalStateStores,
+		);
+		const footerMenu = await store.getObject({
+			objectName: 'menu_items--main',
+			anon: true,
+		});
+		return {
+			props: {
+				data: data || null,
+				footerMenu,
+			},
+			revalidate: 60,
+		};
+	}
 }

--- a/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-next/pages/examples/pagination/pagination.module.css
+++ b/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-next/pages/examples/pagination/pagination.module.css
@@ -32,3 +32,16 @@
 .item > div {
 	min-width: var(--sm);
 }
+
+.noData {
+	margin-top: var(--12);
+}
+
+.pre {
+	display: inline;
+}
+
+.link {
+	text-decoration-line: underline;
+	color: var(--blue);
+}

--- a/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-next/pages/examples/pagination/pagination.module.css
+++ b/packages/create-pantheon-decoupled-kit/src/templates/tailwindless-next/pages/examples/pagination/pagination.module.css
@@ -37,10 +37,6 @@
 	margin-top: var(--12);
 }
 
-.pre {
-	display: inline;
-}
-
 .link {
 	text-decoration-line: underline;
 	color: var(--blue);


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Ensure the pagination example does not fail the entire build in case the `dev-ds-demo` backend with the mock data can not be reached
- In case there is no data, show a message indicating why
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
cli > templates > `next-drupal`
## How have the changes been tested?
locally!
## Additional information
I considered doing all 3 starters at once with some template magic but noticed the next-drupal starter is using `getStaticPaths + getStaticProps` instead of `getServerSideProps`. There is a comment indicating why: 
```
// Using getStaticProps here with ISR will have a substantial impact on
// performance due to the large payload.
``` 
but maybe it's time to reconsider?
@backlineint @mitchellmarkoff any thoughts on this? Should we keep on using ISR here even though it's not quite hooked up, or switch to SSR?

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->