### PR TITLE
[docs] fixing typo in wp next documentation

### DIFF
--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/setting-cache-control-header.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/setting-cache-control-header.md
@@ -14,7 +14,7 @@ Next.js application using the `wordpress-kit`.
 ## Setting Cache-Control Headers with WordPress Kit
 
 The `@pantheon-systems/wordpress-kit` npm package exports a function,
-`setEdgeHeaders`, which takes in a response object and a cache-control header
+`setEdgeHeader`, which takes in a response object and a cache-control header
 value. The value is then set to the response object's headers so that when the
 request is sent along it will be cached at the edge.
 
@@ -27,7 +27,7 @@ Cache-Control: public, s-maxage=600
 To override the default, you may pass in your own cache-control header:
 
 ```jsx title=pages/example/index.js
-import { setEdgeHeaders } from '@pantheon-systems/wordpress-kit';
+import { setEdgeHeader } from '@pantheon-systems/wordpress-kit';
 
 export default function MyPage(props) {
 	// Page component here...
@@ -37,11 +37,11 @@ export async function getServerSideProps(context) {
 	// the response object from the server context
 	const { res } = context;
 
-	// setEdgeHeaders accepts an optional string which is a cache-control header
+	// setEdgeHeader accepts an optional string which is a cache-control header
 	const myCacheControlHeader = 'public, max-age=604800, must-revalidate';
 
-	// Call setEdgeHeaders with the res object and your desired cache-control header
-	setEdgeHeaders({ res, cacheControl: myCacheControlHeader });
+	// Call setEdgeHeader with the res object and your desired cache-control header
+	setEdgeHeader({ res, cacheControl: myCacheControlHeader });
 
 	// Fetch data and return props...
 }


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Adjusted some (what I think are) typos in the Next WP docs.

## Where were the changes made?

In the Next WP setting cache control document.
`web/docs/Frontend Starters/Next.js/Next.js + Wordpress/setting-cache-control-header.md`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
n/a
## Additional information
@FoxBuru  and I were trying to troubleshoot some cache header behavior, and were using the [documentation here](https://decoupledkit.pantheon.io/docs/frontend-starters/nextjs/nextjs-wordpress/setting-cache-control-headers) to set `Cache-Control`. We noticed that the docs reference `setEdgeHeaders` but in the code this appears to be `setEdgeHeader`.

It's a small enough deal that I thought we'd just file a neighborly PR.  Apologies in advance if I'm mucking something up, and let me know if you'd rather I go through more procedural channels for stuff like this in the future.
<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->