### PR TITLE
DB-6588: [gatsby-wp] pagination fails gracefully

### DIFF
--- a/.changeset/itchy-shrimps-check.md
+++ b/.changeset/itchy-shrimps-check.md
@@ -1,0 +1,6 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[gatsby-wp] Pagination example fails gracefully. If the mock content can not be
+reached, a message is displayed at the /examples/pagination route.

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/gatsby-node.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/gatsby-node.ts
@@ -87,7 +87,9 @@ export const createPages = async ({
 	// /examples/
 	createExamplesPage({
 		createPage,
-		routing,
+		// set routing to false if there are no pagination posts to
+		// avoid setting an incorrect link
+		routing: paginationPosts.length > 0 ? routing : false,
 		componentPath: path.resolve('./src/templates/examples.tsx'),
 	});
 	// /examples/auth-api

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/lib/createPagesUtils/createPaginationExamplePage.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/lib/createPagesUtils/createPaginationExamplePage.ts
@@ -13,6 +13,19 @@ export const createPaginationExamplePage = ({
 	routing: boolean;
 	componentPath: string;
 }) => {
+	if (!posts.length) {
+		createPage({
+			path: '/examples/pagination',
+			component: componentPath,
+			context: {
+				posts,
+				postsPerPage: 0,
+				routing: false,
+				breakpoints: {},
+			},
+		});
+		return;
+	}
 	const postsPerPage = 5;
 	const postsChunkedIntoArchivePages = chunk(posts, postsPerPage);
 

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/lib/paginationPostsQuery.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/lib/paginationPostsQuery.ts
@@ -6,23 +6,34 @@ const paginationClient = new GraphQLClientFactory(
 ).create();
 
 export const paginationPostsQuery = async () => {
-	const query = gql`
-		query paginationPostsQuery {
-			posts(first: 50) {
-				edges {
-					node {
-						id
-						title
-						excerpt
+	try {
+		const query = gql`
+			query paginationPostsQuery {
+				posts(first: 50) {
+					edges {
+						node {
+							id
+							title
+							excerpt
+						}
 					}
 				}
 			}
+		`;
+
+		const {
+			posts: { edges },
+		} = await paginationClient.request<PostsQuery>(query);
+
+		return edges.map(({ node }) => node);
+	} catch (error) {
+		if (error instanceof Error) {
+			console.error(
+				'Could not fetch pagination example posts:\n\n',
+				error.message,
+				'\n\nIf https://dev-decoupled-wp-mock-data.pantheonsite.io is not available, try building again when it is. You may set up your own mock data with FakerPress: https://wordpress.org/plugins/fakerpress/',
+			);
 		}
-	`;
-
-	const {
-		posts: { edges },
-	} = await paginationClient.request<PostsQuery>(query);
-
-	return edges.map(({ node }) => node);
+		return [];
+	}
 };

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/templates/pagination.module.css
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/templates/pagination.module.css
@@ -38,6 +38,15 @@
 	margin-bottom: var(--2);
 }
 
+.noData {
+	margin-top: var(--12);
+}
+
+.link {
+	text-decoration-line: underline;
+	color: var(--blue);
+}
+
 /* md breakpoint*/
 @media (max-width: 768px) {
 	.container {

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/templates/pagination.module.css.d.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/templates/pagination.module.css.d.ts
@@ -4,3 +4,5 @@ export const content: string;
 export const title: string;
 export const item: string;
 export const itemTitle: string;
+export const noData: string;
+export const link: string;

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/templates/paginationExample.tsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/templates/paginationExample.tsx
@@ -23,8 +23,13 @@ const PaginationPostsExample = ({
 				{currentItems?.length > 0 ? (
 					currentItems.map((item) => {
 						return (
-							<article key={item.title} className={styles.item}>
-								<h2 className={styles.itemTitle}>{item.title}</h2>
+							<article
+								key={item.title}
+								className={`${styles.item} flex flex-col leading-8 mb-10 p-3`}
+							>
+								<h2 className={`${styles.itemTitle} font-bold mb-2`}>
+									{item.title}
+								</h2>
 								<div
 									dangerouslySetInnerHTML={{ __html: sanitize(item.excerpt) }}
 								/>
@@ -42,15 +47,37 @@ const PaginationPostsExample = ({
 		<Layout>
 			<div className={styles.container}>
 				<section className={styles.content}>
-					<h1 className={styles.title}>Pagination example</h1>
-					<Paginator
-						data={posts}
-						itemsPerPage={postsPerPage}
-						location={location}
-						breakpoints={breakpoints}
-						routing={routing}
-						Component={RenderCurrentItems}
-					/>
+					{posts.length > 0 ? (
+						<>
+							<h1 className={`${styles.title} font-extrabold my-10 mx-0`}>
+								Pagination example
+							</h1>
+							<Paginator
+								data={posts}
+								itemsPerPage={postsPerPage}
+								location={location}
+								breakpoints={breakpoints}
+								routing={routing}
+								Component={RenderCurrentItems}
+							/>
+						</>
+					) : (
+						<p className={styles.noData}>
+							This example relies on data from{' '}
+							<code>https://dev-decoupled-wp-mock-data.pantheonsite.io</code>.
+							If you&apos;re seeing this message, it may be unreachable. Try
+							building again when it is reachable or create your own data with
+							the{' '}
+							<a
+								className={styles.link}
+								href="https://wordpress.org/plugins/fakerpress/"
+								rel="noopener"
+							>
+								FakerPress Plugin
+							</a>
+							.
+						</p>
+					)}
 				</section>
 			</div>
 		</Layout>

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/templates/paginationExample.tsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/src/templates/paginationExample.tsx
@@ -23,13 +23,8 @@ const PaginationPostsExample = ({
 				{currentItems?.length > 0 ? (
 					currentItems.map((item) => {
 						return (
-							<article
-								key={item.title}
-								className={`${styles.item} flex flex-col leading-8 mb-10 p-3`}
-							>
-								<h2 className={`${styles.itemTitle} font-bold mb-2`}>
-									{item.title}
-								</h2>
+							<article key={item.title} className={styles.item}>
+								<h2 className={styles.itemTitle}>{item.title}</h2>
 								<div
 									dangerouslySetInnerHTML={{ __html: sanitize(item.excerpt) }}
 								/>
@@ -49,9 +44,7 @@ const PaginationPostsExample = ({
 				<section className={styles.content}>
 					{posts.length > 0 ? (
 						<>
-							<h1 className={`${styles.title} font-extrabold my-10 mx-0`}>
-								Pagination example
-							</h1>
+							<h1 className={styles.title}>Pagination example</h1>
 							<Paginator
 								data={posts}
 								itemsPerPage={postsPerPage}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
gatsby-wp starter fails gracefully if pagination mock data is unavailable
## Where were the changes made?
cli > templates > `gatsby-wp`
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->