### PR TITLE
Update troubleshooting in docs and readme re: dkhc

### DIFF
--- a/.changeset/eleven-coins-dance.md
+++ b/.changeset/eleven-coins-dance.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[gatsby-wp] Update README

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/README.md
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/README.md
@@ -66,6 +66,14 @@ Tests are written with [`vitest`](https://vitest.dev/). Snapshot tests are using
 [`@testing-library/react`](https://testing-library.com/docs/react-testing-library/intro/).
 Some example tests are provided.
 
+## Decoupled Kit Health Check
+
+The `@pantheon-systems/decoupled-kit-health-check` will run before your `build`
+and ensure the backend is setup for success. Helpful instructions will guide you
+in case anything in the health check fails. To disable the health check, see
+[Disabling the Decoupled Kit Health Check](https://live-decoupled-kit-docs.appa.pantheon.site/docs/frontend-starters/gatsby/gatsby-wordpress/troubleshooting#disabling-the-decoupled-kit-health-check).
+
+
 ### Commands
 
 This section assumes the package manager in use is `npm`. If you are not using

--- a/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/README.md
+++ b/packages/create-pantheon-decoupled-kit/src/templates/gatsby-wp/README.md
@@ -71,7 +71,7 @@ Some example tests are provided.
 The `@pantheon-systems/decoupled-kit-health-check` will run before your `build`
 and ensure the backend is setup for success. Helpful instructions will guide you
 in case anything in the health check fails. To disable the health check, see
-[Disabling the Decoupled Kit Health Check](https://live-decoupled-kit-docs.appa.pantheon.site/docs/frontend-starters/gatsby/gatsby-wordpress/troubleshooting#disabling-the-decoupled-kit-health-check).
+[Disabling the Decoupled Kit Health Check](https://decoupledkit.pantheon.io/docs/frontend-starters/gatsby/gatsby-wordpress/troubleshooting#disabling-the-decoupled-kit-health-check).
 
 
 ### Commands

--- a/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/troubleshooting.md
+++ b/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/troubleshooting.md
@@ -41,3 +41,14 @@ plugins: [
 	]
 }
 ```
+
+## Disabling the Decoupled Kit Health Check
+
+After you begin editing content in your WordPress CMS, you may find the
+`@pantheon-systems/decoupled-kit-health-check` unnecessary. If you would like to
+remove it from the build step, follow the steps below:
+
+1. In a text editor, open the `package.json`
+2. Find the `"scripts"` and remove `"decoupled-kit-health-check": "npx --prefer-offline @pantheon-systems/decoupled-kit-health-check wordpress"`
+3. Edit the `"build"` script and remove `npm run decoupled-kit-health-check && ` from the beginning of the script
+4. Find the `"devDependencies"` and remove `@pantheon-systems/decoupled-kit-health-check`, Or in a terminal, run `npm rm @pantheon-systems/decoupled-kit-health-check`


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Update readme and troubleshooting for gatsby-wordpress regarding how to disable the decoupled-kit-health-check
## Where were the changes made?
cli > templates > gatsby-wp & docs
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->