### PR TITLE
DB-6634: `BACKEND_URL` not required for search

### DIFF
--- a/.changeset/tiny-kangaroos-yawn.md
+++ b/.changeset/tiny-kangaroos-yawn.md
@@ -1,0 +1,5 @@
+---
+"create-pantheon-decoupled-kit": patch
+---
+
+next-drupal-search-api-addon - `BACKEND_URL` not required for successful search queries.

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/pages/search/[[...searchAlias]].jsx
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal-search-api-addon/pages/search/[[...searchAlias]].jsx
@@ -3,6 +3,7 @@ import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 import Layout from '../../components/layout';
 import PageHeader from '../../components/page-header';
+import { DRUPAL_URL } from '../../lib/constants';
 import { isMultiLanguage } from '../../lib/isMultiLanguage.js';
 import {
 	getCurrentLocaleStore,
@@ -104,7 +105,7 @@ export async function getServerSideProps(context) {
 		const searchTerm = searchAlias ? [searchAlias] : null;
 		const searchResults = (
 			await getDrupalSearchResults({
-				apiUrl: process.env.BACKEND_URL,
+				apiUrl: DRUPAL_URL,
 				locale: locale,
 				query: searchTerm,
 				response: res,


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- `BACKEND_URL` is no longer required to be set for search to work.

## Where were the changes made?
- `next-drupal-search-api-addon`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
I created a new front end site with this fix applied and was able to get working search when building against a CMS backend with search enabled on our dashboard. I saw successful searches with no BACKEND_URL configured.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->