### PR TITLE
DB-6644: Fix trailing slash fails health check for WP based starters

### DIFF
--- a/.changeset/five-news-train.md
+++ b/.changeset/five-news-train.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `@pantheon-systems/decoupled-kit-health-check` version

--- a/.changeset/nice-candles-unite.md
+++ b/.changeset/nice-candles-unite.md
@@ -1,0 +1,5 @@
+---
+'@pantheon-systems/decoupled-kit-health-check': patch
+---
+
+Fix trailing slash on WPGRAPHQL_URL fails the healthcheck

--- a/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
@@ -8,7 +8,7 @@ describe('GatsbyWordPressHealthCheck', () => {
 		delete process.env['WPGRAPHQL_URL'];
 		delete process.env['PANTHEON_CMS_ENDPOINT'];
 		delete process.env['WP_APPLICATION_USERNAME'];
-		delete process.env['WP_APPLICATION_SECRET'];
+		delete process.env['WP_APPLICATION_PASSWORD'];
 	});
 	it('should pass for a valid WPGRAPHQL_URL and invalid auth', async ({
 		logSpy,
@@ -93,5 +93,12 @@ describe('GatsbyWordPressHealthCheck', () => {
 
 		const result = logSpy.mock.calls.map(([call]) => call);
 		expect(result).toMatchSnapshot();
+	});
+	it('should handle a trailing slash in the URL', async () => {
+		process.env['WPGRAPHQL_URL'] = 'wordpress.test/wp/graphql/';
+		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
+		const url = HC.getURL();
+
+		expect(url.href).toEqual('https://wordpress.test/wp/graphql');
 	});
 });

--- a/packages/decoupled-kit-health-check/__tests__/NextWordPressHealthCheck.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/NextWordPressHealthCheck.test.ts
@@ -99,4 +99,11 @@ describe('NextWordPressHealthCheck', () => {
 		const result = logSpy.mock.calls.map(([call]) => call);
 		expect(result).toMatchSnapshot();
 	});
+	it('should handle a trailing slash in the URL', async () => {
+		process.env['WPGRAPHQL_URL'] = 'wordpress.test/wp/graphql/';
+		const HC = new NextWordPressHealthCheck({ env: process.env });
+		const url = HC.getURL();
+
+		expect(url.href).toEqual('https://wordpress.test/wp/graphql');
+	});
 });

--- a/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
@@ -73,16 +73,15 @@ export class GatsbyWordPressHealthCheck extends WordPressHealthCheck {
 			? Object.entries(backendVars).filter(([key]) => key === 'WPGRAPHQL_URL')
 			: Object.entries(backendVars);
 
-		let url;
-		url = /^https:\/\//.test(endpoint) ? endpoint : `https://${endpoint}`;
-		// ensure the url ends with /wp/graphql
-		url = /\/wp\/graphql$/.test(url) ? url : `${url}/wp/graphql`;
+		const url = /^https:\/\//.test(endpoint) ? endpoint : `https://${endpoint}`;
 
 		this.endpoint = url;
 		this.envVar = envVar;
 	}
 	getURL() {
-		return new URL(this.endpoint);
+		const url = new URL(this.endpoint);
+		url.pathname = '/wp/graphql';
+		return url;
 	}
 	async checkFor200(url: URL) {
 		try {

--- a/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts
@@ -75,16 +75,15 @@ export class NextWordPressHealthCheck extends WordPressHealthCheck {
 			? Object.entries(backendVars).filter(([key]) => key === 'WPGRAPHQL_URL')
 			: Object.entries(backendVars);
 
-		let url;
-		url = /^https:\/\//.test(endpoint) ? endpoint : `https://${endpoint}`;
-		// ensure the url ends with /wp/graphql
-		url = /\/wp\/graphql$/.test(url) ? url : `${url}/wp/graphql`;
+		const url = /^https:\/\//.test(endpoint) ? endpoint : `https://${endpoint}`;
 
 		this.endpoint = url;
 		this.envVar = envVar;
 	}
 	getURL() {
-		return new URL(this.endpoint);
+		const url = new URL(this.endpoint);
+		url.pathname = '/wp/graphql';
+		return url;
 	}
 	async checkFor200(url: URL) {
 		try {


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Handle a potential trailing slash on the `WPGRAPHQL_URL`
## Where were the changes made?
`decoupled-kit-health-check`
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
locally, new tests added for the affected classes
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->