### PR TITLE
CI: Attempt to fix changeset action

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - canary
 
+permissions:
+  pull-requests: write
+  contents: read
+
 # Releases a canary tagged version of the packages
 jobs:
   canary_release:
@@ -28,10 +32,6 @@ jobs:
           cache: 'pnpm'
       - name: install dependencies
         run: pnpm install
-      - name: setup git user
-        run: |
-          git config --global user.email "decoupled-service-user@pantheon.io"
-          git config --global user.name "pantheon-decoupled-service-user"
       - name: create and publish versions
         uses: changesets/action@v1
         with:
@@ -39,7 +39,6 @@ jobs:
           publish: pnpm ci:publish
           commit: 'canary-release'
           title: 'Canary Release'
-          setupGitUser: false
 
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - '*'
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   release:
     name: version and publish
@@ -29,10 +33,6 @@ jobs:
           cache: 'pnpm'
       - name: install dependencies
         run: pnpm install
-      - name: setup git user
-        run: |
-          git config --global user.email "decoupled-service-user@pantheon.io"
-          git config --global user.name "pantheon-decoupled-service-user"
       - name: create and publish versions
         uses: changesets/action@v1
         with:
@@ -40,7 +40,6 @@ jobs:
           commit: 'Update versions'
           title: 'Update versions'
           publish: pnpm ci:publish
-          setupGitUser: false
 
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Last try: Reverts previous two attempts and adds explicit permissions to the workflow. I am least confident about this one since the `GITHUB_TOKEN` we are using has the proper permissions (confirmed by IT). Let's try it anyway!

I think these are the correct permissions required but not 100%

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->