### PR TITLE
DB-6235: Use logo based on system theme (dark/light)

### DIFF
--- a/.changeset/brown-countries-prove.md
+++ b/.changeset/brown-countries-prove.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Fix logo alignment in READMEs

--- a/packages/create-pantheon-decoupled-kit/src/templates/partials/shared/readme/sharedReadme.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/partials/shared/readme/sharedReadme.ts
@@ -9,8 +9,11 @@ type CmsType = 'drupal' | 'wordpress';
  */
 export const readmeHeader = (
 	starterName: StarterName,
-) => /* md */ `<div style="display:flex;flex-direction:column">
-	<img src="https://raw.githubusercontent.com/pantheon-systems/decoupled-kit-js/canary/web/static/img/B_Fist-Tagline.png" height="120" style="background:#ffffff;border-radius:8px;margin:auto;display:flex;" alt="Pantheon.io logo featuring a fist capturing lighting. Pantheon™, The Platform for Extraordinary Websites.">
+) => /* md */ `<div align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/pantheon-systems/decoupled-kit-js/canary/web/static/img/B_Fist-Tagline.png">
+  <img height="120" alt="Pantheon.io logo featuring a fist capturing lighting. Pantheon™, The Platform for Extraordinary Websites." src="https://raw.githubusercontent.com/pantheon-systems/decoupled-kit-js/canary/web/static/img/W_Fist-Tagline.png">
+</picture>
 	<a href="https://decoupledkit.pantheon.io/docs#${starterName
 		.split(' ')
 		.join('-')


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
GitHub only supports a few HTML elements, so the style tag for the image wasn't working as intended.
This change should center the logo and use the proper color based on the user's system theme (light/dark)


## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information
https://github.blog/changelog/2022-05-19-specify-theme-context-for-images-in-markdown-beta/

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->