### PR TITLE
DB-6705: Fix Drupal decoupled-router validation

### DIFF
--- a/.changeset/grumpy-boxes-unite.md
+++ b/.changeset/grumpy-boxes-unite.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `@pantheon-systems/decoupled-kit-health-check`

--- a/.changeset/mighty-keys-repeat.md
+++ b/.changeset/mighty-keys-repeat.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/decoupled-kit-health-check': patch
+---
+
+[NextDruaplHealthCheck] Fixed potential false negatives when checking for
+decoupled router

--- a/packages/decoupled-kit-health-check/__mocks__/server/drupal/requestHandlers.ts
+++ b/packages/decoupled-kit-health-check/__mocks__/server/drupal/requestHandlers.ts
@@ -1,20 +1,20 @@
-import { rest } from 'msw';
+import { http } from 'msw';
 
 const endpoint = 'https://drupal.test';
 const umamiEndpoint = 'https://umami.drupal.test';
 const invalidEndpoint = 'https://invalid.drupal.test';
 
-const jsonapiIndexHandler = rest.get(
+const jsonapiIndexHandler = http.get(
 	`${endpoint}/jsonapi`,
 	() => new Response(null, { status: 200 }),
 );
 
-const invalidJsonapiIndexHandler = rest.get(
+const invalidJsonapiIndexHandler = http.get(
 	`${invalidEndpoint}/jsonapi`,
 	() => new Response(null, { status: 404 }),
 );
 
-const authHandler = rest.post(`${endpoint}/oauth/token`, ({ request }) => {
+const authHandler = http.post(`${endpoint}/oauth/token`, ({ request }) => {
 	const url = new URL(request.url);
 	if (
 		url.searchParams.get('client_id') &&
@@ -30,42 +30,64 @@ const authHandler = rest.post(`${endpoint}/oauth/token`, ({ request }) => {
 	}
 });
 
-const decoupledRouterHandler = rest.get(
+const decoupledRouterHandler = http.get(
 	`${endpoint}/router/translate-path`,
-	() => new Response(null, { status: 200 }),
+	() =>
+		new Response(
+			JSON.stringify({
+				message:
+					'unable to translate empty path. Please send a ?path query string parameter with your request.',
+			}),
+			{ status: 404 },
+		),
 );
 
-const umamiDecoupledRouterHandler = rest.get(
+const umamiDecoupledRouterHandler = http.get(
 	`${umamiEndpoint}/router/translate-path`,
-	() => new Response(null, { status: 200 }),
+	() =>
+		new Response(
+			JSON.stringify({
+				message:
+					'Unable to translate empty path. Please send a ?path query string parameter with your request.',
+			}),
+			{ status: 404 },
+		),
 );
 
-const invalidDecoupledRouterHandler = rest.get(
+const invalidDecoupledRouterHandler = http.get(
 	`${invalidEndpoint}/router/translate-path`,
-	() => new Response(null, { status: 404 }),
+	() =>
+		new Response(
+			'<html><body><h1>Some html to mock the 404 response without decoupled router</h1></body></html>',
+			{ status: 404 },
+		),
 );
 
-const defaultLanguageSettingsHandler = rest.get(
+const defaultLanguageSettingsHandler = http.get(
 	`${endpoint}/jsonapi/configurable_language/configurable_language`,
 	() => new Response(null, { status: 404 }),
 );
+const invalidLanguageSettingsHandler = http.get(
+	`${invalidEndpoint}/jsonapi/configurable_language/configurable_language`,
+	() => new Response(null, { status: 404 }),
+);
 
-const umamiLanguageSettingsHandler = rest.get(
+const umamiLanguageSettingsHandler = http.get(
 	`${umamiEndpoint}/jsonapi/configurable_language/configurable_language`,
 	() => new Response(null, { status: 200 }),
 );
 
-const menuItemHandler = rest.get(
+const menuItemHandler = http.get(
 	`${endpoint}/jsonapi/menu_items/footer`,
 	() => new Response(null, { status: 200 }),
 );
 
-const invalidMenuItemHandler = rest.get(
+const invalidMenuItemHandler = http.get(
 	`${invalidEndpoint}/jsonapi/menu_items/footer`,
 	() => new Response(null, { status: 404 }),
 );
 
-const previewHandler = rest.get(`${endpoint}/node/1/preview`, ({ request }) => {
+const previewHandler = http.get(`${endpoint}/node/1/preview`, ({ request }) => {
 	if (request.headers.get('Authorization')?.endsWith('Bearer')) {
 		return new Response(null, { status: 401 });
 	} else {
@@ -76,6 +98,7 @@ const previewHandler = rest.get(`${endpoint}/node/1/preview`, ({ request }) => {
 export const drupalRequestHandlers = [
 	jsonapiIndexHandler,
 	invalidJsonapiIndexHandler,
+	invalidLanguageSettingsHandler,
 	authHandler,
 	decoupledRouterHandler,
 	umamiDecoupledRouterHandler,

--- a/packages/decoupled-kit-health-check/__mocks__/server/wordpress/requestHandlers.ts
+++ b/packages/decoupled-kit-health-check/__mocks__/server/wordpress/requestHandlers.ts
@@ -1,9 +1,9 @@
-import { rest } from 'msw';
+import { http } from 'msw';
 
 const endpoint = 'https://wordpress.test/wp/graphql';
 const invalidEndpoint = 'https://invalid.wordpress.test/wp/graphql';
 
-const validResponses = rest.get(`${endpoint}`, ({ request }) => {
+const validResponses = http.get(`${endpoint}`, ({ request }) => {
 	const url = new URL(request.url);
 	const authQuery = /* graphql */ `query LatestPostsQuery {
 				posts(where: { status: PRIVATE }) {
@@ -177,13 +177,13 @@ const validResponses = rest.get(`${endpoint}`, ({ request }) => {
 	}
 });
 
-const invalidResponses = rest.get(`${invalidEndpoint}`, () => {
+const invalidResponses = http.get(`${invalidEndpoint}`, () => {
 	return new Response(JSON.stringify({ errors: [{ message: 'Not found' }] }), {
 		status: 404,
 	});
 });
 
-const noWPGatsbyPlugin = rest.get(
+const noWPGatsbyPlugin = http.get(
 	`https://wordpress.test.no-plugin/wp/graphql`,
 	({ request }) => {
 		const url = new URL(request.url);

--- a/packages/decoupled-kit-health-check/__tests__/NextDrupalHealthCheck.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/NextDrupalHealthCheck.test.ts
@@ -104,4 +104,27 @@ describe('NextDrupalHealthCheck', () => {
 		const result = logSpy.mock.calls.map(([call]) => call);
 		expect(result).toMatchSnapshot();
 	});
+	it('should show a helpful error message if the decoupled router is not available', async ({
+		logSpy,
+	}) => {
+		process.env['PANTHEON_CMS_ENDPOINT'] = 'invalid.drupal.test';
+		const HC = new NextDrupalHealthCheck({ env: process.env });
+		vi.spyOn(HC, 'validateEndpoint').mockImplementationOnce(async () => {
+			console.log('Validating CMS endpoint...');
+			HC.log.success('PANTHEON_CMS_ENDPOINT is valid!');
+			return HC;
+		});
+		vi.spyOn(HC, 'validateMenu').mockImplementationOnce(async () => {
+			console.log('Validating Menu Item endpoint...');
+			HC.log.success('Menu Items endpoint is valid!');
+			return HC;
+		});
+		await HC.validateEndpoint()
+			.then((hc) => hc.validateMenu())
+			.then((hc) => hc.validateRouter())
+			.catch((err) => console.log(err.message));
+
+		const result = logSpy.mock.calls.map(([call]) => call);
+		expect(result).toMatchSnapshot();
+	});
 });

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextDrupalHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextDrupalHealthCheck.test.ts.snap
@@ -9,6 +9,7 @@ exports[`NextDrupalHealthCheck > should pass for a valid BACKEND_URL and invalid
   "|__✅ BACKEND_URL is valid!",
   "Validating Menu Item endpoint...",
   "|__✅ Menu Items endpoint is valid!",
+  "Validating Decoupled Router module...",
   "|__✅ Decoupled Router is valid!",
   "Validating authentication...",
   "|__💡 CLIENT_ID is required for preview but is not set.",
@@ -30,6 +31,7 @@ exports[`NextDrupalHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOINT a
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
   "|__✅ Menu Items endpoint is valid!",
+  "Validating Decoupled Router module...",
   "|__✅ Decoupled Router is valid!",
   "Validating authentication...",
   "|__💡 CLIENT_ID is required for preview but is not set.",
@@ -51,6 +53,7 @@ exports[`NextDrupalHealthCheck > should pass for a valid backend and valid auth 
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
   "|__✅ Menu Items endpoint is valid!",
+  "Validating Decoupled Router module...",
   "|__✅ Decoupled Router is valid!",
   "Validating authentication...",
   "|__✅ Auth is valid!",
@@ -69,6 +72,7 @@ exports[`NextDrupalHealthCheck > should pass for a valid backend and valid auth 
   "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
   "|__✅ Menu Items endpoint is valid!",
+  "Validating Decoupled Router module...",
   "|__✅ Decoupled Router is valid!",
   "Validating authentication...",
   "|__✅ Auth is valid!",
@@ -87,5 +91,21 @@ exports[`NextDrupalHealthCheck > should show a helpful error message if the back
   "Validating CMS endpoint...",
   "|__❌ PANTHEON_CMS_ENDPOINT could not be fetched from.
 Check that invalid.drupal.test is valid and provides a 200 response",
+]
+`;
+
+exports[`NextDrupalHealthCheck > should show a helpful error message if the decoupled router is not available 1`] = `
+[
+  "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
+  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "Validating CMS endpoint...",
+  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "Validating Menu Item endpoint...",
+  "|__✅ Menu Items endpoint is valid!",
+  "Validating Decoupled Router module...",
+  "|__❌ Decoupled Router not detected for PANTHEON_CMS_ENDPOINT.
+Check that invalid.drupal.test is valid and provides a 200 response.
+Also ensure that the Decoupled Router module is enabled.",
 ]
 `;

--- a/packages/decoupled-kit-health-check/package.json
+++ b/packages/decoupled-kit-health-check/package.json
@@ -39,7 +39,7 @@
 		"@types/node": "^18.16.14",
 		"@vitest/coverage-v8": "^0.33.0",
 		"esbuild": "^0.18.11",
-		"msw": "next",
+		"msw": "0.0.0-fetch.rc-17",
 		"rimraf": "^5.0.1",
 		"vitest": "^0.33.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,8 +324,8 @@ importers:
         specifier: ^0.18.11
         version: 0.18.11
       msw:
-        specifier: next
-        version: 0.0.0-fetch.rc-15(typescript@5.1.6)
+        specifier: 0.0.0-fetch.rc-17
+        version: 0.0.0-fetch.rc-17(typescript@5.1.6)
       rimraf:
         specifier: ^5.0.1
         version: 5.0.1
@@ -13077,8 +13077,8 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: false
 
-  /msw@0.0.0-fetch.rc-15(typescript@5.1.6):
-    resolution: {integrity: sha512-apgcCzSmsbJ1rUDpmhrjQAZDzEwOvfZD2VyBZVu6YMD+ovm8ow1buVzRE25IvzrtfIklN/fDbVavTa5lhqX4uQ==}
+  /msw@0.0.0-fetch.rc-17(typescript@5.1.6):
+    resolution: {integrity: sha512-42nt60YOyNKDPNOF4SkMFwnsMKAy5FPjeQv9pXXjtFvx8cr9bJMnWGXD+3RISp8qZpxD1drkMCYmMLlW6N67FQ==}
     engines: {node: '>=18'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Fix false negatives for the decoupled-router module in the NextDrupalHealthCheck
Added a console.log to indicate the decoupled-router check is in progress similar to the other checks.
## Where were the changes made?
dkhc
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested locally with a valid site and invalid site. I modified the script a bit to skip the Menu check for the valid site.
Test was added to mock a site with valid JSONAPI endpoint and decoupled menu endpoint, but an invalid decoupled router.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->