### PR TITLE
DB-6728: Fix next-wp trailing slash in WPGRAPHQL_URL breaks IMAGE_DOMAIN

### DIFF
--- a/.changeset/tall-garlics-suffer.md
+++ b/.changeset/tall-garlics-suffer.md
@@ -1,0 +1,6 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[next-wp] Fixed a bug where a trailing slash on WPGRAPHQL_URL could break the
+IMAGE_DOMAIN used for the `next/image` component.

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/next.config.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/next.config.js
@@ -30,7 +30,7 @@ if (process.env.WPGRAPHQL_URL === undefined) {
 	backendUrl = process.env.WPGRAPHQL_URL;
 	imageDomain =
 		process.env.IMAGE_DOMAIN ||
-		process.env.WPGRAPHQL_URL.replace(/\/wp\/graphql$/, '').replace(
+		process.env.WPGRAPHQL_URL.replace(/\/wp\/graphql/, '').replace(
 			/^https?:\/\//,
 			'',
 		);


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Previously, if a site has the `WPGRAPHQL_URL` set with a trailing slash, the next.config would not properly remove the `/wp/graphql` portion of the URL to set the `IMAGE_DOMAIN`.
This behavior has now been fixed.

## Where were the changes made?
`next-wp` cli templates
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
tested locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->