### PR TITLE
Make all PackageVersionData keys optional only on BaseGeneratorData

### DIFF
--- a/packages/create-pantheon-decoupled-kit/src/types.ts
+++ b/packages/create-pantheon-decoupled-kit/src/types.ts
@@ -26,7 +26,7 @@ type CamelCase<T extends string> = T extends `${infer First}-${infer Rest}`
 type PackageVersionKeys = `${CamelCase<keyof typeof pkgVersions>}Version`;
 
 type PackageVersionData = {
-	[key in PackageVersionKeys]?: string;
+	[key in PackageVersionKeys]: string;
 };
 
 /**
@@ -39,7 +39,7 @@ type PackageVersionData = {
  * }
  * ```
  */
-export type BaseGeneratorData = PackageVersionData & DrupalOrWP;
+export type BaseGeneratorData = Partial<PackageVersionData> & DrupalOrWP;
 
 export interface GatsbyWPData extends BaseGeneratorData {
 	gatsbyPnpmPlugin: boolean;
@@ -116,8 +116,9 @@ export type ActionRunner = (config: ActionRunnerConfig) => Promise<string>;
 /**
  * Input from command line arguments, prompts, and generator data
  */
-type InputIndex = BaseGeneratorData &
-	GatsbyWPData & {
+type InputIndex = DrupalOrWP &
+	GatsbyWPData &
+	PackageVersionData & {
 		_: string[];
 		appName: string;
 		outDir: string;


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
I'm not sure why this didn't show up in my IDE when I was working on it the first time and I had a feeling this was wrong; The versions should be available to the templates/`Input` type but not required in the `BaseGeneratorData` type.
This shouldn't require a changeset, it will be picked up in the next one or the main release..
## Where were the changes made?
cli types
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
ESLint is no longer throwing errors in the tagged templates for the pkg versions
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->