### PR TITLE
DB-4833: specify platform docs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,9 @@ importers:
       '@docusaurus/preset-classic':
         specifier: 2.4.0
         version: 2.4.0(@algolia/client-search@4.16.0)(@types/react@17.0.58)(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/theme-common':
+        specifier: ^2.4.1
+        version: 2.4.1(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
       '@docusaurus/theme-mermaid':
         specifier: 2.4.0
         version: 2.4.0(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
@@ -1327,6 +1330,7 @@ packages:
 
   /@babel/plugin-proposal-object-rest-spread@7.12.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -1339,6 +1343,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.4):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -1353,6 +1358,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -2535,6 +2541,23 @@ packages:
       - supports-color
     dev: false
 
+  /@babel/plugin-transform-runtime@7.21.4(@babel/core@7.21.8):
+    resolution: {integrity: sha512-1J4dhrw1h1PqnNNpzwxQ2UBymJUF8KuPjAAnlLwZcGhHAIqUigFW7cdK6GHoB64ubY4qXQNYknoUeks4Wz7CUA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-plugin-utils': 7.21.5
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.8)
+      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.21.8)
+      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.8)
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.21.4):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
@@ -3598,6 +3621,106 @@ packages:
       - webpack-cli
     dev: false
 
+  /@docusaurus/core@2.4.1(@docusaurus/types@2.4.1)(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==}
+    engines: {node: '>=16.14'}
+    hasBin: true
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@babel/core': 7.21.8
+      '@babel/generator': 7.21.9
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.8)
+      '@babel/plugin-transform-runtime': 7.21.4(@babel/core@7.21.8)
+      '@babel/preset-env': 7.21.4(@babel/core@7.21.8)
+      '@babel/preset-react': 7.18.6(@babel/core@7.21.8)
+      '@babel/preset-typescript': 7.21.4(@babel/core@7.21.8)
+      '@babel/runtime': 7.21.0
+      '@babel/runtime-corejs3': 7.21.0
+      '@babel/traverse': 7.21.5
+      '@docusaurus/cssnano-preset': 2.4.1
+      '@docusaurus/logger': 2.4.1
+      '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/react-loadable': 5.5.2(react@17.0.0)
+      '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
+      '@docusaurus/utils-common': 2.4.1(@docusaurus/types@2.4.1)
+      '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
+      '@slorber/static-site-generator-webpack-plugin': 4.0.7
+      '@svgr/webpack': 6.5.1
+      autoprefixer: 10.4.14(postcss@8.4.26)
+      babel-loader: 8.3.0(@babel/core@7.21.8)(webpack@5.77.0)
+      babel-plugin-dynamic-import-node: 2.3.3
+      boxen: 6.2.1
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      clean-css: 5.3.2
+      cli-table3: 0.6.3
+      combine-promises: 1.1.0
+      commander: 5.1.0
+      copy-webpack-plugin: 11.0.0(webpack@5.77.0)
+      core-js: 3.29.1
+      css-loader: 6.7.3(webpack@5.77.0)
+      css-minimizer-webpack-plugin: 4.2.2(clean-css@5.3.2)(webpack@5.77.0)
+      cssnano: 5.1.15(postcss@8.4.26)
+      del: 6.1.1
+      detect-port: 1.5.1
+      escape-html: 1.0.3
+      eta: 2.0.1
+      file-loader: 6.2.0(webpack@5.77.0)
+      fs-extra: 10.1.0
+      html-minifier-terser: 6.1.0
+      html-tags: 3.3.0
+      html-webpack-plugin: 5.5.0(webpack@5.77.0)
+      import-fresh: 3.3.0
+      leven: 3.1.0
+      lodash: 4.17.21
+      mini-css-extract-plugin: 2.7.5(webpack@5.77.0)
+      postcss: 8.4.26
+      postcss-loader: 7.1.0(postcss@8.4.26)(webpack@5.77.0)
+      prompts: 2.4.2
+      react: 17.0.0
+      react-dev-utils: 12.0.1(eslint@8.45.0)(typescript@5.0.4)(webpack@5.77.0)
+      react-dom: 17.0.0(react@17.0.0)
+      react-helmet-async: 1.3.0(react-dom@17.0.0)(react@17.0.0)
+      react-loadable: /@docusaurus/react-loadable@5.5.2(react@17.0.0)
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@5.5.2)(webpack@5.77.0)
+      react-router: 5.3.4(react@17.0.0)
+      react-router-config: 5.1.1(react-router@5.3.4)(react@17.0.0)
+      react-router-dom: 5.3.4(react@17.0.0)
+      rtl-detect: 1.0.4
+      semver: 7.5.4
+      serve-handler: 6.1.5
+      shelljs: 0.8.5
+      terser-webpack-plugin: 5.3.7(webpack@5.77.0)
+      tslib: 2.6.0
+      update-notifier: 5.1.0
+      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.77.0)
+      wait-on: 6.0.1
+      webpack: 5.77.0
+      webpack-bundle-analyzer: 4.8.0
+      webpack-dev-server: 4.13.2(webpack@5.77.0)
+      webpack-merge: 5.8.0
+      webpackbar: 5.0.2(webpack@5.77.0)
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
+
   /@docusaurus/cssnano-preset@2.4.0:
     resolution: {integrity: sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==}
     engines: {node: '>=16.14'}
@@ -3608,8 +3731,26 @@ packages:
       tslib: 2.6.0
     dev: false
 
+  /@docusaurus/cssnano-preset@2.4.1:
+    resolution: {integrity: sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==}
+    engines: {node: '>=16.14'}
+    dependencies:
+      cssnano-preset-advanced: 5.3.10(postcss@8.4.26)
+      postcss: 8.4.26
+      postcss-sort-media-queries: 4.3.0(postcss@8.4.26)
+      tslib: 2.6.0
+    dev: false
+
   /@docusaurus/logger@2.4.0:
     resolution: {integrity: sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==}
+    engines: {node: '>=16.14'}
+    dependencies:
+      chalk: 4.1.2
+      tslib: 2.6.0
+    dev: false
+
+  /@docusaurus/logger@2.4.1:
+    resolution: {integrity: sha512-5h5ysIIWYIDHyTVd8BjheZmQZmEgWDR54aQ1BX9pjFfpyzFo5puKXKYrYJXbjEHGyVhEzmB9UXwbxGfaZhOjcg==}
     engines: {node: '>=16.14'}
     dependencies:
       chalk: 4.1.2
@@ -3627,6 +3768,41 @@ packages:
       '@babel/traverse': 7.21.5
       '@docusaurus/logger': 2.4.0
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      '@mdx-js/mdx': 1.6.22
+      escape-html: 1.0.3
+      file-loader: 6.2.0(webpack@5.77.0)
+      fs-extra: 10.1.0
+      image-size: 1.0.2
+      mdast-util-to-string: 2.0.0
+      react: 17.0.0
+      react-dom: 17.0.0(react@17.0.0)
+      remark-emoji: 2.2.0
+      stringify-object: 3.3.0
+      tslib: 2.6.0
+      unified: 9.2.2
+      unist-util-visit: 2.0.3
+      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.77.0)
+      webpack: 5.77.0
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
+    dev: false
+
+  /@docusaurus/mdx-loader@2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.0)(react@17.0.0):
+    resolution: {integrity: sha512-4KhUhEavteIAmbBj7LVFnrVYDiU51H5YWW1zY6SmBSte/YLhDutztLTBE0PQl1Grux1jzUJeaSvAzHpTn6JJDQ==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@babel/parser': 7.21.9
+      '@babel/traverse': 7.21.5
+      '@docusaurus/logger': 2.4.1
+      '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
       '@mdx-js/mdx': 1.6.22
       escape-html: 1.0.3
       file-loader: 6.2.0(webpack@5.77.0)
@@ -3674,6 +3850,29 @@ packages:
       - webpack-cli
     dev: false
 
+  /@docusaurus/module-type-aliases@2.4.1(react-dom@17.0.0)(react@17.0.0):
+    resolution: {integrity: sha512-gLBuIFM8Dp2XOCWffUDSjtxY7jQgKvYujt7Mx5s4FCTfoL5dN1EVbnrn+O2Wvh8b0a77D57qoIDY7ghgmatR1A==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      '@docusaurus/react-loadable': 5.5.2(react@17.0.0)
+      '@docusaurus/types': 2.4.1(react-dom@17.0.0)(react@17.0.0)
+      '@types/history': 4.7.11
+      '@types/react': 18.2.6
+      '@types/react-router-config': 5.0.6
+      '@types/react-router-dom': 5.3.3
+      react: 17.0.0
+      react-dom: 17.0.0(react@17.0.0)
+      react-helmet-async: 1.3.0(react-dom@17.0.0)(react@17.0.0)
+      react-loadable: /@docusaurus/react-loadable@5.5.2(react@17.0.0)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+    dev: false
+
   /@docusaurus/plugin-content-blog@2.4.0(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
     resolution: {integrity: sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==}
     engines: {node: '>=16.14'}
@@ -3688,6 +3887,49 @@ packages:
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
       '@docusaurus/utils-common': 2.4.0(@docusaurus/types@2.4.0)
       '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      cheerio: 1.0.0-rc.12
+      feed: 4.2.2
+      fs-extra: 10.1.0
+      lodash: 4.17.21
+      react: 17.0.0
+      react-dom: 17.0.0(react@17.0.0)
+      reading-time: 1.5.0
+      tslib: 2.6.0
+      unist-util-visit: 2.0.3
+      utility-types: 3.10.0
+      webpack: 5.77.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
+
+  /@docusaurus/plugin-content-blog@2.4.1(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-E2i7Knz5YIbE1XELI6RlTnZnGgS52cUO4BlCiCUCvQHbR+s1xeIWz4C6BtaVnlug0Ccz7nFSksfwDpVlkujg5Q==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/logger': 2.4.1
+      '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/types': 2.4.1(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
+      '@docusaurus/utils-common': 2.4.1(@docusaurus/types@2.4.1)
+      '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 10.1.0
@@ -3760,6 +4002,49 @@ packages:
       - webpack-cli
     dev: false
 
+  /@docusaurus/plugin-content-docs@2.4.1(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-Lo7lSIcpswa2Kv4HEeUcGYqaasMUQNpjTXpV0N8G6jXgZaQurqp7E8NGYeGbDXnb48czmHWbzDL4S3+BbK0VzA==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/logger': 2.4.1
+      '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/module-type-aliases': 2.4.1(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/types': 2.4.1(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
+      '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
+      '@types/react-router-config': 5.0.6
+      combine-promises: 1.1.0
+      fs-extra: 10.1.0
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      react: 17.0.0
+      react-dom: 17.0.0(react@17.0.0)
+      tslib: 2.6.0
+      utility-types: 3.10.0
+      webpack: 5.77.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
+
   /@docusaurus/plugin-content-pages@2.4.0(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
     resolution: {integrity: sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==}
     engines: {node: '>=16.14'}
@@ -3772,6 +4057,41 @@ packages:
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
       '@docusaurus/utils-validation': 2.4.0(@docusaurus/types@2.4.0)
+      fs-extra: 10.1.0
+      react: 17.0.0
+      react-dom: 17.0.0(react@17.0.0)
+      tslib: 2.6.0
+      webpack: 5.77.0
+    transitivePeerDependencies:
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
+
+  /@docusaurus/plugin-content-pages@2.4.1(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-/UjuH/76KLaUlL+o1OvyORynv6FURzjurSjvn2lbWTFc4tpYY2qLYTlKpTCBVPhlLUQsfyFnshEJDLmPneq2oA==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/core': 2.4.1(@docusaurus/types@2.4.1)(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/types': 2.4.1(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
+      '@docusaurus/utils-validation': 2.4.1(@docusaurus/types@2.4.1)
       fs-extra: 10.1.0
       react: 17.0.0
       react-dom: 17.0.0(react@17.0.0)
@@ -4108,6 +4428,50 @@ packages:
       - webpack-cli
     dev: false
 
+  /@docusaurus/theme-common@2.4.1(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-G7Zau1W5rQTaFFB3x3soQoZpkgMbl/SYNG8PfMFIjKa3M3q8n0m/GRf5/H/e5BqOvt8c+ZWIXGCiz+kUCSHovA==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@docusaurus/mdx-loader': 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/module-type-aliases': 2.4.1(react-dom@17.0.0)(react@17.0.0)
+      '@docusaurus/plugin-content-blog': 2.4.1(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/plugin-content-docs': 2.4.1(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/plugin-content-pages': 2.4.1(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4)
+      '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
+      '@docusaurus/utils-common': 2.4.1(@docusaurus/types@2.4.1)
+      '@types/history': 4.7.11
+      '@types/react': 18.2.6
+      '@types/react-router-config': 5.0.6
+      clsx: 1.2.1
+      parse-numeric-range: 1.3.0
+      prism-react-renderer: 1.3.5(react@17.0.0)
+      react: 17.0.0
+      react-dom: 17.0.0(react@17.0.0)
+      tslib: 2.6.0
+      use-sync-external-store: 1.2.0(react@17.0.0)
+      utility-types: 3.10.0
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+    dev: false
+
   /@docusaurus/theme-mermaid@2.4.0(eslint@8.45.0)(react-dom@17.0.0)(react@17.0.0)(typescript@5.0.4):
     resolution: {integrity: sha512-qB4cMDn93iwQ5JzhLgHsME5DgUbISMKgk6nP6tEWqepP3S/WXR1L/uRAH8xXbuRhJgzERHM/f6riyv0cNIQeTg==}
     engines: {node: '>=16.14'}
@@ -4220,6 +4584,29 @@ packages:
       - webpack-cli
     dev: false
 
+  /@docusaurus/types@2.4.1(react-dom@17.0.0)(react@17.0.0):
+    resolution: {integrity: sha512-0R+cbhpMkhbRXX138UOc/2XZFF8hiZa6ooZAEEJFp5scytzCw4tC1gChMFXrpa3d2tYE6AX8IrOEpSonLmfQuQ==}
+    peerDependencies:
+      react: ^16.8.4 || ^17.0.0
+      react-dom: ^16.8.4 || ^17.0.0
+    dependencies:
+      '@types/history': 4.7.11
+      '@types/react': 18.2.6
+      commander: 5.1.0
+      joi: 17.9.1
+      react: 17.0.0
+      react-dom: 17.0.0(react@17.0.0)
+      react-helmet-async: 1.3.0(react-dom@17.0.0)(react@17.0.0)
+      utility-types: 3.10.0
+      webpack: 5.77.0
+      webpack-merge: 5.8.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+    dev: false
+
   /@docusaurus/utils-common@2.4.0(@docusaurus/types@2.4.0):
     resolution: {integrity: sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==}
     engines: {node: '>=16.14'}
@@ -4233,12 +4620,43 @@ packages:
       tslib: 2.6.0
     dev: false
 
+  /@docusaurus/utils-common@2.4.1(@docusaurus/types@2.4.1):
+    resolution: {integrity: sha512-bCVGdZU+z/qVcIiEQdyx0K13OC5mYwxhSuDUR95oFbKVuXYRrTVrwZIqQljuo1fyJvFTKHiL9L9skQOPokuFNQ==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      '@docusaurus/types': '*'
+    peerDependenciesMeta:
+      '@docusaurus/types':
+        optional: true
+    dependencies:
+      '@docusaurus/types': 2.4.1(react-dom@17.0.0)(react@17.0.0)
+      tslib: 2.6.0
+    dev: false
+
   /@docusaurus/utils-validation@2.4.0(@docusaurus/types@2.4.0):
     resolution: {integrity: sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==}
     engines: {node: '>=16.14'}
     dependencies:
       '@docusaurus/logger': 2.4.0
       '@docusaurus/utils': 2.4.0(@docusaurus/types@2.4.0)
+      joi: 17.9.1
+      js-yaml: 4.1.0
+      tslib: 2.6.0
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
+    dev: false
+
+  /@docusaurus/utils-validation@2.4.1(@docusaurus/types@2.4.1):
+    resolution: {integrity: sha512-unII3hlJlDwZ3w8U+pMO3Lx3RhI4YEbY3YNsQj4yzrkZzlpqZOLuAiZK2JyULnD+TKbceKU0WyWkQXtYbLNDFA==}
+    engines: {node: '>=16.14'}
+    dependencies:
+      '@docusaurus/logger': 2.4.1
+      '@docusaurus/utils': 2.4.1(@docusaurus/types@2.4.1)
       joi: 17.9.1
       js-yaml: 4.1.0
       tslib: 2.6.0
@@ -4262,6 +4680,40 @@ packages:
     dependencies:
       '@docusaurus/logger': 2.4.0
       '@docusaurus/types': 2.4.0(react-dom@17.0.0)(react@17.0.0)
+      '@svgr/webpack': 6.5.1
+      escape-string-regexp: 4.0.0
+      file-loader: 6.2.0(webpack@5.77.0)
+      fs-extra: 10.1.0
+      github-slugger: 1.5.0
+      globby: 11.1.0
+      gray-matter: 4.0.3
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      micromatch: 4.0.5
+      resolve-pathname: 3.0.0
+      shelljs: 0.8.5
+      tslib: 2.6.0
+      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.77.0)
+      webpack: 5.77.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
+    dev: false
+
+  /@docusaurus/utils@2.4.1(@docusaurus/types@2.4.1):
+    resolution: {integrity: sha512-1lvEZdAQhKNht9aPXPoh69eeKnV0/62ROhQeFKKxmzd0zkcuE/Oc5Gpnt00y/f5bIsmOsYMY7Pqfm/5rteT5GA==}
+    engines: {node: '>=16.14'}
+    peerDependencies:
+      '@docusaurus/types': '*'
+    peerDependenciesMeta:
+      '@docusaurus/types':
+        optional: true
+    dependencies:
+      '@docusaurus/logger': 2.4.1
+      '@docusaurus/types': 2.4.1(react-dom@17.0.0)(react@17.0.0)
       '@svgr/webpack': 6.5.1
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.77.0)
@@ -7300,6 +7752,21 @@ packages:
       webpack: '>=2'
     dependencies:
       '@babel/core': 7.21.4
+      find-cache-dir: 3.3.2
+      loader-utils: 2.0.4
+      make-dir: 3.1.0
+      schema-utils: 2.7.1
+      webpack: 5.77.0
+    dev: false
+
+  /babel-loader@8.3.0(@babel/core@7.21.8)(webpack@5.77.0):
+    resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
+    engines: {node: '>= 8.9'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    dependencies:
+      '@babel/core': 7.21.8
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -14105,6 +14572,20 @@ packages:
       cosmiconfig: 8.1.3
       klona: 2.0.6
       postcss: 8.4.23
+      semver: 7.5.4
+      webpack: 5.77.0
+    dev: false
+
+  /postcss-loader@7.1.0(postcss@8.4.26)(webpack@5.77.0):
+    resolution: {integrity: sha512-vTD2DJ8vJD0Vr1WzMQkRZWRjcynGh3t7NeoLg+Sb1TeuK7etiZfL/ZwHbaVa3M+Qni7Lj/29voV9IggnIUjlIw==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      postcss: ^7.0.0 || ^8.0.1
+      webpack: ^5.0.0
+    dependencies:
+      cosmiconfig: 8.1.3
+      klona: 2.0.6
+      postcss: 8.4.26
       semver: 7.5.4
       webpack: 5.77.0
     dev: false

--- a/web/docs/Backend Starters/Decoupled Drupal/creating-new-project.mdx
+++ b/web/docs/Backend Starters/Decoupled Drupal/creating-new-project.mdx
@@ -5,6 +5,37 @@ slug: '/backend-starters/decoupled-drupal/creating-a-new-project'
 sidebar_position: 0
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Clone the Repository
+
+To start a new project, clone one of the following repositories:
+
+<Tabs>
+  <TabItem value="drupal10" label="Drupal 10">
+
+```bash
+git clone git@github.com:pantheon-upstreams/decoupled-drupal-10-composer-managed.git
+```
+
+  </TabItem>
+  <TabItem value="drupal9" label="Drupal 9">
+
+```bash
+git clone git@github.com:pantheon-upstreams/decoupled-drupal-composer-managed.git
+```
+
+  </TabItem>
+</Tabs>
+
+:::pantheon
+
+The following guide assumes that you are intending to deploy the Drupal site on
+[Pantheon](https://pantheon.io).
+
+:::
+
 ## Choosing an Approach
 
 ### Use Build Tools if:

--- a/web/docs/Backend Starters/Decoupled WordPress/creating-new-project.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/creating-new-project.md
@@ -5,7 +5,22 @@ slug: '/backend-starters/decoupled-wordpress/creating-a-new-project'
 sidebar_position: 0
 ---
 
-### Installing using Upstream
+## Installing using Upstream
+
+Clone the repo to start using our decoupled WordPress template:
+
+```bash
+git clone git@github.com:pantheon-upstreams/decoupled-wordpress-composer-managed.git
+```
+
+:::pantheon
+
+The following options are available when using the
+[Pantheon Platform](https://pantheon.io):
+
+:::
+
+If you are deploying to pantheon, you may also choose one of the following options:
 
 - Create from Decoupled WordPress Composer Managed upstream:
 
@@ -15,7 +30,7 @@ sidebar_position: 0
 
   - Or Alternatively via Terminus:
 
-    ```
+    ```bash
     terminus site:create my-new-site "Describe Site" --org='My Team Name' c9f5e5c0-248f-4205-b63a-d2729572dd1f
     ```
 

--- a/web/docs/Backend Starters/terminus-decoupled-kit-plugin.md
+++ b/web/docs/Backend Starters/terminus-decoupled-kit-plugin.md
@@ -7,6 +7,8 @@ slug: '/backend-starters/terminus-decoupled-kit'
 
 # Terminus Decoupled Kit Plugin
 
+:::pantheon
+
 The Terminus Decoupled Kit Plugin provides commands useful for creating
 decoupled projects on [Pantheon](https://pantheon.io) using pre-configured
 starter kits.
@@ -19,6 +21,8 @@ The `decoupled-kit:create` command guides you through the following tasks:
   project. This codebase will be automatically configured for local development,
   and can later be deployed to Pantheon using the
   [import repository workflow](https://docs.pantheon.io/guides/decoupled/no-starter-kit/import-repo).
+
+:::
 
 ## Requirements
 

--- a/web/docs/decoupled-kit-overview.mdx
+++ b/web/docs/decoupled-kit-overview.mdx
@@ -8,7 +8,7 @@ import OverviewCardList from '@site/src/components/OverviewCardList';
 
 <OverviewCardList />
 
-:::info Pantheon Front-End Sites
+:::pantheon Pantheon Front-End Sites
 
 Decoupled Kit is an open source project built by Pantheon. These docs focus on
 using Decoupled Kit components locally or anywhere.
@@ -16,6 +16,7 @@ using Decoupled Kit components locally or anywhere.
 For more information on Pantheon Front-End Sites, see
 https://docs.pantheon.io/guides/decoupled/
 
+Sections or documents that are related specifically to Pantheon will include this callout at the top of the section or page.
 :::
 
 Decoupled Kit is a collection of utilities for building a decoupled front-end

--- a/web/docs/pantheon-front-end-sites.md
+++ b/web/docs/pantheon-front-end-sites.md
@@ -3,8 +3,12 @@ slug: /pantheon-front-end-sites
 title: Pantheon Front-End Sites
 sidebar_position: 5
 ---
+:::pantheon
+ This section relates to the [Pantheon platform](https://pantheon.io).
+:::
 
 Pantheon Front-End Sites is the easiest way to run Decoupled Kit Backend and Frontend Starters.
+
 
 The Decoupled Kit is built as open source software by Pantheon and the kits can be used anywhere; however, they are built with first-class support for Pantheon and are ready to be used out of the box with Front-End Sites.
 

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -106,6 +106,21 @@ const config = {
 					editUrl:
 						'https://github.com/pantheon-systems/decoupled-kit-js/edit/canary/web/',
 					path: 'docs',
+					// overwrite admonitions to add custom 'pantheon' keyword
+					admonitions: {
+						tag: ':::',
+						keywords: [
+							'info',
+							'success',
+							'danger',
+							'note',
+							'tip',
+							'warning',
+							'important',
+							'caution',
+							'pantheon',
+						]
+					}
 				},
 				// blog: {
 				//   showReadingTime: true,

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
 		"@codesandbox/sandpack-react": "^2.1.11",
 		"@docusaurus/core": "2.4.0",
 		"@docusaurus/preset-classic": "2.4.0",
+		"@docusaurus/theme-common": "^2.4.1",
 		"@docusaurus/theme-mermaid": "2.4.0",
 		"@mdx-js/react": "^1.6.22",
 		"clsx": "^1.2.1",

--- a/web/src/css/custom.css
+++ b/web/src/css/custom.css
@@ -60,3 +60,36 @@ EFD121
 	background-color: #ffffff;
 	border-radius: 100px;
 }
+
+/* :::pantheon admonition icon styles */
+.cls-1 {
+	fill: #efd11e;
+}
+
+.cls-2 {
+	fill: #231f20;
+}
+
+.cls-3 {
+	background-color: #000000;
+	border-radius: 15px;
+}
+
+html[data-theme='dark'] .cls-3 {
+	background-color: #ffffff;
+}
+
+/* :::pantheon admonition styles */
+.alert--pantheon {
+	--ifm-alert-background-color: var(--ifm-color-primary);
+	--ifm-alert-background-color-highlight: var(--ifm-color-primary-darkest);
+	--ifm-alert-foreground-color: var(--ifm-color-primary-lightest);
+	--ifm-alert-border-color: var(--ifm-color-primary-darkest);
+}
+
+html[data-theme='dark'] .alert--pantheon {
+	--ifm-alert-background-color: var(--ifm-color-primary);
+	--ifm-alert-background-color-highlight: var(--ifm-color-primary-lightest);
+	--ifm-alert-foreground-color: var(--ifm-color-primary-darkest);
+	--ifm-alert-border-color: var(--ifm-color-primary-lightest);
+}

--- a/web/src/theme/Admonition/index.js
+++ b/web/src/theme/Admonition/index.js
@@ -1,0 +1,241 @@
+import React from 'react';
+import clsx from 'clsx';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import Translate from '@docusaurus/Translate';
+import styles from './styles.module.css';
+
+function NoteIcon() {
+	return (
+		<svg viewBox="0 0 14 16">
+			<path
+				fillRule="evenodd"
+				d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"
+			/>
+		</svg>
+	);
+}
+function TipIcon() {
+	return (
+		<svg viewBox="0 0 12 16">
+			<path
+				fillRule="evenodd"
+				d="M6.5 0C3.48 0 1 2.19 1 5c0 .92.55 2.25 1 3 1.34 2.25 1.78 2.78 2 4v1h5v-1c.22-1.22.66-1.75 2-4 .45-.75 1-2.08 1-3 0-2.81-2.48-5-5.5-5zm3.64 7.48c-.25.44-.47.8-.67 1.11-.86 1.41-1.25 2.06-1.45 3.23-.02.05-.02.11-.02.17H5c0-.06 0-.13-.02-.17-.2-1.17-.59-1.83-1.45-3.23-.2-.31-.42-.67-.67-1.11C2.44 6.78 2 5.65 2 5c0-2.2 2.02-4 4.5-4 1.22 0 2.36.42 3.22 1.19C10.55 2.94 11 3.94 11 5c0 .66-.44 1.78-.86 2.48zM4 14h5c-.23 1.14-1.3 2-2.5 2s-2.27-.86-2.5-2z"
+			/>
+		</svg>
+	);
+}
+function DangerIcon() {
+	return (
+		<svg viewBox="0 0 12 16">
+			<path
+				fillRule="evenodd"
+				d="M5.05.31c.81 2.17.41 3.38-.52 4.31C3.55 5.67 1.98 6.45.9 7.98c-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-.3-6.61-.61 2.03.53 3.33 1.94 2.86 1.39-.47 2.3.53 2.27 1.67-.02.78-.31 1.44-1.13 1.81 3.42-.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52.13-2.03 1.13-1.89 2.75.09 1.08-1.02 1.8-1.86 1.33-.67-.41-.66-1.19-.06-1.78C8.18 5.31 8.68 2.45 5.05.32L5.03.3l.02.01z"
+			/>
+		</svg>
+	);
+}
+function InfoIcon() {
+	return (
+		<svg viewBox="0 0 14 16">
+			<path
+				fillRule="evenodd"
+				d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
+			/>
+		</svg>
+	);
+}
+function CautionIcon() {
+	return (
+		<svg viewBox="0 0 16 16">
+			<path
+				fillRule="evenodd"
+				d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+			/>
+		</svg>
+	);
+}
+function PantheonIcon() {
+	return (
+		<svg
+      className="cls-3"
+			id="Layer_1"
+			data-name="Layer 1"
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 359.999 361.674"
+		>
+			<title>_</title>
+			<g>
+				<polygon
+					className="cls-1"
+					points="129.62 33.809 155.73 96.719 122.499 96.719 133.489 124.409 200.833 124.409 129.62 33.809"
+				/>
+				<polygon
+					className="cls-1"
+					points="218.167 262.858 207.051 235.168 191.635 235.168 159.589 157.276 145.779 157.276 177.806 235.168 138.652 235.168 211.046 325.778 184.94 262.858 218.167 262.858"
+				/>
+			</g>
+			<g>
+				<path d="M227.133,152.113c.816,0,2.717-1.044,2.717-10.665s-1.9-10.649-2.717-10.649H180.745l8.8,21.314Z" />
+				<path d="M200.107,177.673l31.166,0c.826,0,2.723-1.044,2.723-10.66s-1.9-10.654-2.723-10.654l-39.97,0Z" />
+				<g>
+					<path d="M227.133,207.478H185.22l8.8,21.31h33.111c.816,0,2.717-1.034,2.717-10.65S227.949,207.478,227.133,207.478Z" />
+					<path d="M231.273,181.918H174.662l8.8,21.315h47.807c.826,0,2.723-1.044,2.723-10.655S232.1,181.918,231.273,181.918Z" />
+				</g>
+				<path d="M227.133,207.478H185.22l8.8,21.31h33.111c.816,0,2.717-1.034,2.717-10.65S227.949,207.478,227.133,207.478Z" />
+				<path d="M231.273,181.918H174.662l8.8,21.315h47.807c.826,0,2.723-1.044,2.723-10.655S232.1,181.918,231.273,181.918Z" />
+				<path d="M149.028,177.833l-9.94-25.735h23.257L173.1,177.865l22.222-.192L175.96,130.8H127.616c-3.724,0-5.77,0-7.446,5.546-2.013,6.62-2.245,19.119-2.245,43.443s.232,36.823,2.245,43.443c1.676,5.547,3.722,5.547,7.446,5.547l42.413.007-21.014-51.127Z" />
+			</g>
+			<path
+				className="cls-2"
+				d="M237.553,223.186H235.8v-1.118h4.926v1.118h-1.75v5.1h-1.425Zm6.74,5.1-1.572-4.764v4.764h-1.248v-6.222h1.9l1.539,4.8,1.539-4.8h1.831v6.222h-1.3v-4.764l-1.523,4.764Z"
+			/>
+		</svg>
+	);
+}
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+const AdmonitionConfigs = {
+	note: {
+		infimaClassName: 'secondary',
+		iconComponent: NoteIcon,
+		label: (
+			<Translate
+				id="theme.admonition.note"
+				description="The default label used for the Note admonition (:::note)"
+			>
+				note
+			</Translate>
+		),
+	},
+	tip: {
+		infimaClassName: 'success',
+		iconComponent: TipIcon,
+		label: (
+			<Translate
+				id="theme.admonition.tip"
+				description="The default label used for the Tip admonition (:::tip)"
+			>
+				tip
+			</Translate>
+		),
+	},
+	danger: {
+		infimaClassName: 'danger',
+		iconComponent: DangerIcon,
+		label: (
+			<Translate
+				id="theme.admonition.danger"
+				description="The default label used for the Danger admonition (:::danger)"
+			>
+				danger
+			</Translate>
+		),
+	},
+	info: {
+		infimaClassName: 'info',
+		iconComponent: InfoIcon,
+		label: (
+			<Translate
+				id="theme.admonition.info"
+				description="The default label used for the Info admonition (:::info)"
+			>
+				info
+			</Translate>
+		),
+	},
+	caution: {
+		infimaClassName: 'warning',
+		iconComponent: CautionIcon,
+		label: (
+			<Translate
+				id="theme.admonition.caution"
+				description="The default label used for the Caution admonition (:::caution)"
+			>
+				caution
+			</Translate>
+		),
+	},
+	pantheon: {
+		infimaClassName: 'pantheon',
+		iconComponent: PantheonIcon,
+		label: (
+			<Translate
+				id="theme.admonition.pantheon"
+				description="The default label used for the Pantheon admonition (:::pantheon)"
+			>
+				pantheon
+			</Translate>
+		),
+	},
+};
+// Legacy aliases, undocumented but kept for retro-compatibility
+const aliases = {
+	secondary: 'note',
+	important: 'info',
+	success: 'tip',
+	warning: 'danger',
+};
+function getAdmonitionConfig(unsafeType) {
+	const type = aliases[unsafeType] ?? unsafeType;
+	const config = AdmonitionConfigs[type];
+	if (config) {
+		return config;
+	}
+	console.warn(
+		`No admonition config found for admonition type "${type}". Using Info as fallback.`,
+	);
+	return AdmonitionConfigs.info;
+}
+// Workaround because it's difficult in MDX v1 to provide a MDX title as props
+// See https://github.com/facebook/docusaurus/pull/7152#issuecomment-1145779682
+function extractMDXAdmonitionTitle(children) {
+	const items = React.Children.toArray(children);
+	const mdxAdmonitionTitle = items.find(
+		(item) =>
+			React.isValidElement(item) &&
+			item.props?.mdxType === 'mdxAdmonitionTitle',
+	);
+	const rest = <>{items.filter((item) => item !== mdxAdmonitionTitle)}</>;
+	return {
+		mdxAdmonitionTitle,
+		rest,
+	};
+}
+function processAdmonitionProps(props) {
+	const { mdxAdmonitionTitle, rest } = extractMDXAdmonitionTitle(
+		props.children,
+	);
+	return {
+		...props,
+		title: props.title ?? mdxAdmonitionTitle,
+		children: rest,
+	};
+}
+export default function Admonition(props) {
+	const {
+		children,
+		type,
+		title,
+		icon: iconProp,
+	} = processAdmonitionProps(props);
+	const typeConfig = getAdmonitionConfig(type);
+	const titleLabel = title ?? typeConfig.label;
+	const { iconComponent: IconComponent } = typeConfig;
+	const icon = iconProp ?? <IconComponent />;
+	return (
+		<div
+			className={clsx(
+				ThemeClassNames.common.admonition,
+				ThemeClassNames.common.admonitionType(props.type),
+				'alert',
+				`alert--${typeConfig.infimaClassName}`,
+				styles.admonition,
+			)}
+		>
+			<div className={styles.admonitionHeading}>
+				<span className={styles.admonitionIcon}>{icon}</span>
+				{titleLabel}
+			</div>
+			<div className={styles.admonitionContent}>{children}</div>
+		</div>
+	);
+}

--- a/web/src/theme/Admonition/styles.module.css
+++ b/web/src/theme/Admonition/styles.module.css
@@ -1,0 +1,32 @@
+.admonition {
+	margin-bottom: 1em;
+}
+
+.admonitionHeading {
+	font: var(--ifm-heading-font-weight) var(--ifm-h5-font-size) /
+		var(--ifm-heading-line-height) var(--ifm-heading-font-family);
+	text-transform: uppercase;
+	margin-bottom: 0.3rem;
+}
+
+.admonitionHeading code {
+	text-transform: none;
+}
+
+.admonitionIcon {
+	display: inline-block;
+	vertical-align: middle;
+	margin-right: 0.4em;
+}
+
+.admonitionIcon svg {
+	display: inline-block;
+	height: 1.6em;
+	width: 1.6em;
+	fill: var(--ifm-alert-foreground-color);
+}
+
+.admonitionContent > :last-child {
+	margin-bottom: 0;
+}
+


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Added a shiny admonition to call out Pantheon specific documentation. I think there is a reality where we need to be able to mention the platform and our docs cannot be 100% agnostic as much as we'd like them to be. This will help call out these docs/sections so that it is clear that they are intended for use in that context.
- revised a few docs to use the new admonition.
- Added git clone instructions for the decoupled upstreams on the 'creating a new drupal/wp project' docs.

## Where were the changes made?
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
docs. Swizzled the Admonitions to add the new one. Added the relevant custom CSS as well.
## How have the changes been tested?
ran docs site locally
## Additional information
This guide was very helpful especially for the CSS part: https://docusaurus.community/knowledge/component-library/existing/Admonitions/

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->