### PR TITLE
DB-6721: Use published eslint-config for docs site

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 			"@pantheon-systems/cms-kit": "workspace:*",
 			"@pantheon-systems/workspace-configs": "workspace:*",
 			"@pantheon-systems/eslint-config": "workspace:*",
+			"@pantheon-systems/eslint-config-decoupled-kit": "workspace:*",
 			"trim@<0.0.3": ">=0.0.3",
 			"yaml@<2.2.2": ">=2.2.2",
 			"vite@>=4.3.0 <4.3.9": ">=4.3.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ overrides:
   '@pantheon-systems/cms-kit': workspace:*
   '@pantheon-systems/workspace-configs': workspace:*
   '@pantheon-systems/eslint-config': workspace:*
+  '@pantheon-systems/eslint-config-decoupled-kit': workspace:*
   trim@<0.0.3: '>=0.0.3'
   yaml@<2.2.2: '>=2.2.2'
   vite@>=4.3.0 <4.3.9: '>=4.3.9'
@@ -500,9 +501,9 @@ importers:
         specifier: ^17.0.0
         version: 17.0.0(react@17.0.0)
     devDependencies:
-      '@pantheon-systems/eslint-config':
+      '@pantheon-systems/eslint-config-decoupled-kit':
         specifier: workspace:*
-        version: link:../configs/eslint
+        version: link:../packages/configs/eslint
       '@types/react':
         specifier: 17.0.58
         version: 17.0.58

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -1,7 +1,10 @@
 {
-	"extends": ["@pantheon-systems/eslint-config/react"],
-  "parserOptions": {
-    "ecmaVersion": "latest",
-    "sourceType": "module"
-  }
+	"extends": ["@pantheon-systems/eslint-config-decoupled-kit/react"],
+	"parserOptions": {
+		"ecmaVersion": "latest",
+		"sourceType": "module"
+	},
+	"rules": {
+		"react/prop-types": [false]
+	}
 }

--- a/web/package.json
+++ b/web/package.json
@@ -51,7 +51,7 @@
 		]
 	},
 	"devDependencies": {
-		"@pantheon-systems/eslint-config": "*",
+		"@pantheon-systems/eslint-config-decoupled-kit": "*",
 		"@types/react": "17.0.58",
 		"docusaurus-plugin-typedoc": "^0.20.1",
 		"dotenv": "^16.0.3",


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Use the published eslint config to fix failing build

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information
Most recent build of the docs site failed due to the workspace eslint config missing from the npm registry. This change should allow the site to build again.

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->