### PR TITLE
DB-6765: Opt out health check with an env var

### DIFF
--- a/.changeset/good-fans-invent.md
+++ b/.changeset/good-fans-invent.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `@pantheon-systems/decoupled-kit-health-check` version

--- a/.changeset/yellow-gorillas-jump.md
+++ b/.changeset/yellow-gorillas-jump.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/decoupled-kit-health-check': minor
+---
+
+Added the option to opt out of running the health check by setting the `NO_DKHC`
+environment variable

--- a/packages/decoupled-kit-health-check/README.md
+++ b/packages/decoupled-kit-health-check/README.md
@@ -46,3 +46,9 @@ In the directory of your `next-wordpress` or `gatsby-wordpress` project:
 ```bash
 npx @pantheon-systems/decoupled-kit-health-check wordpress
 ```
+
+## Opt Out
+
+To opt out of the health check without changing any configuration in the
+`package.json`, set the `NO_DKHC` environment variable. If this variable is set
+to anything, the health check will be skipped.

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
@@ -4,18 +4,18 @@ exports[`GatsbyWordPressHealthCheck > should pass for a valid PANTHEON_CMS_ENDPO
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
-  "|__✅ WP Gatsby plugin is active!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "⎩✅ WP Gatsby plugin is active!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating authentication...",
-  "|__💡 Auth not valid.",
-  "|__💡 WP_APPLICATION_USERNAME is not set.",
-  "|____ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
-  "|__💡 WP_APPLICATION_PASSWORD is not set.",
-  "|____ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "⎩💡 Auth not valid.",
+  "⎩💡 WP_APPLICATION_USERNAME is not set.",
+  "⎩ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "⎩💡 WP_APPLICATION_PASSWORD is not set.",
+  "⎩ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
 ]
 `;
 
@@ -23,18 +23,18 @@ exports[`GatsbyWordPressHealthCheck > should pass for a valid WPGRAPHQL_URL and 
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ WPGRAPHQL_URL is set!",
+  "⎩✅ WPGRAPHQL_URL is set!",
   "Validating CMS endpoint...",
-  "|__✅ WPGRAPHQL_URL is valid!",
-  "|__✅ WP Gatsby plugin is active!",
+  "⎩✅ WPGRAPHQL_URL is valid!",
+  "⎩✅ WP Gatsby plugin is active!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating authentication...",
-  "|__💡 Auth not valid.",
-  "|__💡 WP_APPLICATION_USERNAME is not set.",
-  "|____ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
-  "|__💡 WP_APPLICATION_PASSWORD is not set.",
-  "|____ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "⎩💡 Auth not valid.",
+  "⎩💡 WP_APPLICATION_USERNAME is not set.",
+  "⎩ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "⎩💡 WP_APPLICATION_PASSWORD is not set.",
+  "⎩ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
 ]
 `;
 
@@ -42,14 +42,14 @@ exports[`GatsbyWordPressHealthCheck > should pass for a valid backend and valid 
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
-  "|__✅ WP Gatsby plugin is active!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "⎩✅ WP Gatsby plugin is active!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating authentication...",
-  "|__✅ Auth is valid!",
+  "⎩✅ Auth is valid!",
 ]
 `;
 
@@ -57,9 +57,9 @@ exports[`GatsbyWordPressHealthCheck > should show a helpful error message if the
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__❌ PANTHEON_CMS_ENDPOINT could not be fetched from.
+  "⎩❌ PANTHEON_CMS_ENDPOINT could not be fetched from.
 Check that invalid.wordpress.test is valid and provides a 200 response",
 ]
 `;
@@ -68,10 +68,10 @@ exports[`GatsbyWordPressHealthCheck > should show a helpful error message if the
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ WPGRAPHQL_URL is set!",
+  "⎩✅ WPGRAPHQL_URL is set!",
   "Validating CMS endpoint...",
-  "|__✅ WPGRAPHQL_URL is valid!",
-  "|__❌ WP Gatsby Plugin not active for WPGRAPHQL_URL.
+  "⎩✅ WPGRAPHQL_URL is valid!",
+  "⎩❌ WP Gatsby Plugin not active for WPGRAPHQL_URL.
 Enable the WP Gatsby plugin at 🔗 https://wordpress.test.no-plugin/wp/wp-admin/plugins.php, 
 then clear the cache at 🔗 https://wordpress.test.no-plugin/wp/wp-admin/options-general.php?page=pantheon-cache",
 ]

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextDrupalHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextDrupalHealthCheck.test.ts.snap
@@ -4,21 +4,21 @@ exports[`NextDrupalHealthCheck > should pass for a valid BACKEND_URL and invalid
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
-  "|__✅ BACKEND_URL is set!",
+  "⎩✅ BACKEND_URL is set!",
   "Validating CMS endpoint...",
-  "|__✅ BACKEND_URL is valid!",
+  "⎩✅ BACKEND_URL is valid!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating Decoupled Router module...",
-  "|__✅ Decoupled Router is valid!",
+  "⎩✅ Decoupled Router is valid!",
   "Validating authentication...",
-  "|__💡 CLIENT_ID is required for preview but is not set.",
-  "|____ Get the CLIENT_ID here: 🔗 https://drupal.test/admin/config/services/consumer",
-  "|__💡 CLIENT_SECRET is required for preview but is not set.",
-  "|____ Set a new CLIENT_SECRET here by clicking edit: 🔗 https://drupal.test/admin/config/services/consumer",
-  "|__💡 Auth not valid.",
-  "|____ Ensure the CLIENT_ID and CLIENT_SECRET are correct.",
-  "⏭  Skipping preview endpoint validation -- authorization required.",
+  "⎩💡 CLIENT_ID is required for preview but is not set.",
+  "⎩ Get the CLIENT_ID here: 🔗 https://drupal.test/admin/config/services/consumer",
+  "⎩💡 CLIENT_SECRET is required for preview but is not set.",
+  "⎩ Set a new CLIENT_SECRET here by clicking edit: 🔗 https://drupal.test/admin/config/services/consumer",
+  "⎩💡 Auth not valid.",
+  "⎩ Ensure the CLIENT_ID and CLIENT_SECRET are correct.",
+  "⎩⏭  Skipping preview endpoint validation -- authorization required.",
 ]
 `;
 
@@ -26,21 +26,21 @@ exports[`NextDrupalHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOINT a
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating Decoupled Router module...",
-  "|__✅ Decoupled Router is valid!",
+  "⎩✅ Decoupled Router is valid!",
   "Validating authentication...",
-  "|__💡 CLIENT_ID is required for preview but is not set.",
-  "|____ Get the CLIENT_ID here: 🔗 https://drupal.test/admin/config/services/consumer",
-  "|__💡 CLIENT_SECRET is required for preview but is not set.",
-  "|____ Set a new CLIENT_SECRET here by clicking edit: 🔗 https://drupal.test/admin/config/services/consumer",
-  "|__💡 Auth not valid.",
-  "|____ Ensure the CLIENT_ID and CLIENT_SECRET are correct.",
-  "⏭  Skipping preview endpoint validation -- authorization required.",
+  "⎩💡 CLIENT_ID is required for preview but is not set.",
+  "⎩ Get the CLIENT_ID here: 🔗 https://drupal.test/admin/config/services/consumer",
+  "⎩💡 CLIENT_SECRET is required for preview but is not set.",
+  "⎩ Set a new CLIENT_SECRET here by clicking edit: 🔗 https://drupal.test/admin/config/services/consumer",
+  "⎩💡 Auth not valid.",
+  "⎩ Ensure the CLIENT_ID and CLIENT_SECRET are correct.",
+  "⎩⏭  Skipping preview endpoint validation -- authorization required.",
 ]
 `;
 
@@ -48,18 +48,18 @@ exports[`NextDrupalHealthCheck > should pass for a valid backend and valid auth 
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating Decoupled Router module...",
-  "|__✅ Decoupled Router is valid!",
+  "⎩✅ Decoupled Router is valid!",
   "Validating authentication...",
-  "|__✅ Auth is valid!",
+  "⎩✅ Auth is valid!",
   "Checking for PREVIEW_SECRET...",
-  "|__✅ PREVIEW_SECRET is set.",
-  "|__✅ Preview is valid!",
+  "⎩✅ PREVIEW_SECRET is set.",
+  "⎩✅ Preview is valid!",
 ]
 `;
 
@@ -67,18 +67,18 @@ exports[`NextDrupalHealthCheck > should pass for a valid backend and valid auth 
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating Decoupled Router module...",
-  "|__✅ Decoupled Router is valid!",
+  "⎩✅ Decoupled Router is valid!",
   "Validating authentication...",
-  "|__✅ Auth is valid!",
+  "⎩✅ Auth is valid!",
   "Checking for PREVIEW_SECRET...",
-  "|__💡 PREVIEW_SECRET env var is not set.",
-  "|____ To set a new secret, go to 🔗 https://drupal.test/admin/structure/dp-preview-site and edit the preview site you want to use.",
+  "⎩💡 PREVIEW_SECRET env var is not set.",
+  "⎩ To set a new secret, go to 🔗 https://drupal.test/admin/structure/dp-preview-site and edit the preview site you want to use.",
   "⏭  Skipping preview endpoint validation -- PREVIEW_SECRET required.",
 ]
 `;
@@ -87,9 +87,9 @@ exports[`NextDrupalHealthCheck > should show a helpful error message if the back
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__❌ PANTHEON_CMS_ENDPOINT could not be fetched from.
+  "⎩❌ PANTHEON_CMS_ENDPOINT could not be fetched from.
 Check that invalid.drupal.test is valid and provides a 200 response",
 ]
 `;
@@ -98,13 +98,13 @@ exports[`NextDrupalHealthCheck > should show a helpful error message if the deco
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or BACKEND_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating Decoupled Router module...",
-  "|__❌ Decoupled Router not detected for PANTHEON_CMS_ENDPOINT.
+  "⎩❌ Decoupled Router not detected for PANTHEON_CMS_ENDPOINT.
 Check that invalid.drupal.test is valid and provides a 200 response.
 Also ensure that the Decoupled Router module is enabled.",
 ]

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextWordPressHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/NextWordPressHealthCheck.test.ts.snap
@@ -4,19 +4,19 @@ exports[`NextWordPressHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOIN
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating authentication...",
-  "|__💡 WP_APPLICATION_USERNAME is required for preview but is not set.",
-  "|____ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
-  "|__💡 WP_APPLICATION_PASSWORD is required for preview but is not set.",
-  "|____ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
-  "|__💡 Auth not valid.",
-  "|____ Ensure the WP_APPLICATION_USERNAME and WP_APPLICATION_PASSWORD are correct.",
-  "⏭  Skipping preview endpoint validation -- authorization required.",
+  "⎩💡 WP_APPLICATION_USERNAME is required for preview but is not set.",
+  "⎩ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "⎩💡 WP_APPLICATION_PASSWORD is required for preview but is not set.",
+  "⎩ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "⎩💡 Auth not valid.",
+  "⎩ Ensure the WP_APPLICATION_USERNAME and WP_APPLICATION_PASSWORD are correct.",
+  "⎩⏭  Skipping preview endpoint validation -- authorization required.",
 ]
 `;
 
@@ -24,19 +24,19 @@ exports[`NextWordPressHealthCheck > should pass for a valid WPGRAPHQL_URL and in
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ WPGRAPHQL_URL is set!",
+  "⎩✅ WPGRAPHQL_URL is set!",
   "Validating CMS endpoint...",
-  "|__✅ WPGRAPHQL_URL is valid!",
+  "⎩✅ WPGRAPHQL_URL is valid!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating authentication...",
-  "|__💡 WP_APPLICATION_USERNAME is required for preview but is not set.",
-  "|____ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
-  "|__💡 WP_APPLICATION_PASSWORD is required for preview but is not set.",
-  "|____ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
-  "|__💡 Auth not valid.",
-  "|____ Ensure the WP_APPLICATION_USERNAME and WP_APPLICATION_PASSWORD are correct.",
-  "⏭  Skipping preview endpoint validation -- authorization required.",
+  "⎩💡 WP_APPLICATION_USERNAME is required for preview but is not set.",
+  "⎩ Get the WP_APPLICATION_USERNAME here: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "⎩💡 WP_APPLICATION_PASSWORD is required for preview but is not set.",
+  "⎩ Set a new WP_APPLICATION_PASSWORD here by clicking edit: 🔗 https://wordpress.test/wp/wp-admin/users.php",
+  "⎩💡 Auth not valid.",
+  "⎩ Ensure the WP_APPLICATION_USERNAME and WP_APPLICATION_PASSWORD are correct.",
+  "⎩⏭  Skipping preview endpoint validation -- authorization required.",
 ]
 `;
 
@@ -44,16 +44,16 @@ exports[`NextWordPressHealthCheck > should pass for a valid backend and valid au
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating authentication...",
-  "|__✅ Auth is valid!",
+  "⎩✅ Auth is valid!",
   "Checking for PREVIEW_SECRET...",
-  "|__✅ PREVIEW_SECRET is set.",
-  "|__✅ Preview is valid!",
+  "⎩✅ PREVIEW_SECRET is set.",
+  "⎩✅ Preview is valid!",
 ]
 `;
 
@@ -61,17 +61,17 @@ exports[`NextWordPressHealthCheck > should pass for a valid backend and valid au
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is valid!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is valid!",
   "Validating Menu Item endpoint...",
-  "|__✅ Menu Items endpoint is valid!",
+  "⎩✅ Menu Items endpoint is valid!",
   "Validating authentication...",
-  "|__✅ Auth is valid!",
+  "⎩✅ Auth is valid!",
   "Checking for PREVIEW_SECRET...",
-  "|__💡 PREVIEW_SECRET env var is not set.",
-  "|____ To set a new secret, go to 🔗 https://wordpress.test/wp/wp-admin/options-general.php?page=preview_sites and edit the preview site you want to use.",
-  "⏭  Skipping preview endpoint validation -- PREVIEW_SECRET required.",
+  "⎩💡 PREVIEW_SECRET env var is not set.",
+  "⎩ To set a new secret, go to 🔗 https://wordpress.test/wp/wp-admin/options-general.php?page=preview_sites and edit the preview site you want to use.",
+  "⎩⏭  Skipping preview endpoint validation -- PREVIEW_SECRET required.",
 ]
 `;
 
@@ -79,9 +79,9 @@ exports[`NextWordPressHealthCheck > should show a helpful error message if the b
 [
   "No .env* file found, assuming production environment.",
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
-  "|__✅ PANTHEON_CMS_ENDPOINT is set!",
+  "⎩✅ PANTHEON_CMS_ENDPOINT is set!",
   "Validating CMS endpoint...",
-  "|__❌ PANTHEON_CMS_ENDPOINT could not be fetched from.
+  "⎩❌ PANTHEON_CMS_ENDPOINT could not be fetched from.
 Check that invalid.wordpress.test is valid and provides a 200 response",
 ]
 `;

--- a/packages/decoupled-kit-health-check/__tests__/noDKHC.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/noDKHC.test.ts
@@ -1,0 +1,29 @@
+describe('NO_DKHC', () => {
+	beforeEach(() => {
+		delete process.env['NO_DKHC'];
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+	it.fails(
+		'should skip the health check if the NO_DKHC env var is set',
+		async () => {
+			process.env['NO_DKHC'] = '1';
+			const logSpy = vi.spyOn(console, 'log');
+
+			const processSpy = vi
+				.spyOn(process, 'exit')
+				.mockImplementation((code) => {
+					throw code as never;
+				});
+
+			// runs the script
+			await import('../src/bin');
+
+			expect(logSpy).toHaveBeenLastCalledWith(
+				'⏭ Skipping Decoupled Kit Health Check: NO_DKHC is set',
+			);
+			expect(processSpy).toHaveBeenCalledWith(0);
+		},
+	);
+});

--- a/packages/decoupled-kit-health-check/src/bin.ts
+++ b/packages/decoupled-kit-health-check/src/bin.ts
@@ -4,7 +4,12 @@ import { NextDrupalHealthCheck } from './classes/NextDrupalHealthCheck';
 import { NextWordPressHealthCheck } from './classes/NextWordPressHealthCheck';
 import { getFramework } from './utils/getFramework';
 
-const [cms] = process.argv.slice(2, 3);
+if (process.env.NO_DKHC) {
+	console.log('⏭ Skipping Decoupled Kit Health Check: NO_DKHC is set');
+	process.exit(0);
+}
+
+const [cms] = process.argv.slice(2, 3) ?? [];
 
 if (!global.fetch) {
 	const nodeFetch = (await import('node-fetch')).default;
@@ -49,7 +54,7 @@ try {
 			'No cms selected. Expected "drupal" or "wordpress" as an argument',
 		);
 	}
-	console.log('🚀 Ready to build!');
+	console.log('⎩🚀 Ready to build!');
 	process.exit(0);
 } catch (error) {
 	if (error instanceof Error) {

--- a/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts
@@ -207,7 +207,7 @@ export class NextDrupalHealthCheck extends DrupalHealthCheck {
 	async validatePreview() {
 		if (!this.#access_token) {
 			console.log(
-				'⏭  Skipping preview endpoint validation -- authorization required.',
+				'⎩⏭  Skipping preview endpoint validation -- authorization required.',
 			);
 			return this;
 		}

--- a/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts
@@ -204,7 +204,7 @@ export class NextWordPressHealthCheck extends WordPressHealthCheck {
 	async validatePreview() {
 		if (!this.#credentials) {
 			console.log(
-				'⏭  Skipping preview endpoint validation -- authorization required.',
+				'⎩⏭  Skipping preview endpoint validation -- authorization required.',
 			);
 			return this;
 		}
@@ -217,7 +217,7 @@ export class NextWordPressHealthCheck extends WordPressHealthCheck {
 				}/wp/wp-admin/options-general.php?page=preview_sites and edit the preview site you want to use.`,
 			);
 			console.log(
-				'⏭  Skipping preview endpoint validation -- PREVIEW_SECRET required.',
+				'⎩⏭  Skipping preview endpoint validation -- PREVIEW_SECRET required.',
 			);
 			return this;
 		} else {

--- a/packages/decoupled-kit-health-check/src/classes/errors.ts
+++ b/packages/decoupled-kit-health-check/src/classes/errors.ts
@@ -1,6 +1,6 @@
 class HealthCheckError extends Error {
 	constructor(message: string) {
-		super(`|__❌ ${message}`);
+		super(`⎩❌ ${message}`);
 		// no need to show the stack for these errors
 		this.stack = undefined;
 	}

--- a/packages/decoupled-kit-health-check/src/utils/logger.ts
+++ b/packages/decoupled-kit-health-check/src/utils/logger.ts
@@ -1,5 +1,5 @@
 export const logger = {
-	success: (message: string) => console.log(`|__✅ ${message}`),
-	warn: (message: string) => console.log(`|__💡 ${message}`),
-	suggest: (message: string) => console.log(`|____ ${message}`),
+	success: (message: string) => console.log(`⎩✅ ${message}`),
+	warn: (message: string) => console.log(`⎩💡 ${message}`),
+	suggest: (message: string) => console.log(`⎩ ${message}`),
 };

--- a/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/troubleshooting.md
+++ b/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/troubleshooting.md
@@ -58,7 +58,16 @@ plugins: [
 }
 ```
 
-## Disabling the Decoupled Kit Health Check
+## Decoupled Kit Health Check is Failing Valid Builds
+
+### Opt Out With an Environment Variable
+
+To opt out of the health check, set the `NO_DKHC` environment variable. If this
+variable is set to anything, the health check will be skipped.
+
+Unset the variable to continue running the health check before the build step.
+
+### Remove the Health Check
 
 After you begin editing content in your WordPress CMS, you may find the
 `@pantheon-systems/decoupled-kit-health-check` unnecessary. If you would like to

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/troubleshooting.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/troubleshooting.md
@@ -199,7 +199,16 @@ const params =
 After making these changes, images should now display correctly within your
 articles.
 
-## Disabling the Decoupled Kit Health Check
+## Decoupled Kit Health Check is Failing Valid Builds
+
+### Opt Out With an Environment Variable
+
+To opt out of the health check, set the `NO_DKHC` environment variable. If this
+variable is set to anything, the health check will be skipped.
+
+Unset the variable to continue running the health check before the build step.
+
+### Remove the Health Check
 
 After you begin editing content in your Drupal CMS, you may find the
 `@pantheon-systems/decoupled-kit-health-check` unnecessary. If you would like to

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/troubleshooting.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/troubleshooting.md
@@ -35,7 +35,16 @@ Local Development:
    correct endpoint
 2. Ensure the `WP GraphQL` plugin is activated on WordPress
 
-## Disabling the Decoupled Kit Health Check
+## Decoupled Kit Health Check is Failing Valid Builds
+
+### Opt Out With an Environment Variable
+
+To opt out of the health check, set the `NO_DKHC` environment variable. If this
+variable is set to anything, the health check will be skipped.
+
+Unset the variable to continue running the health check before the build step.
+
+### Remove the Health Check
 
 After you begin editing content in your WordPress CMS, you may find the
 `@pantheon-systems/decoupled-kit-health-check` unnecessary. If you would like to


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- health check will be skipped if `NO_DKHC` env var is set
- refined some of the prefix glyphs in the health check messages
- updated readme and docs for removing/opting out of the health check

## Where were the changes made?
`dkhc`, docs

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->