### PR TITLE
DB-6775: Use Pantheon-SKey to obtain surrogate key header

### DIFF
--- a/.changeset/bright-bottles-end.md
+++ b/.changeset/bright-bottles-end.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `@pantheon-systems/wordpress-kit` and `@pantheon-systems/drupal-kit`

--- a/.changeset/nasty-spoons-attack.md
+++ b/.changeset/nasty-spoons-attack.md
@@ -1,0 +1,7 @@
+---
+'@pantheon-systems/wordpress-kit': patch
+'@pantheon-systems/drupal-kit': patch
+---
+
+Use `Pantheon-SKey` instead of `Fastly-Debug` header to obtain the surrogate-key
+header

--- a/packages/drupal-kit/src/lib/defaultFetch.ts
+++ b/packages/drupal-kit/src/lib/defaultFetch.ts
@@ -29,7 +29,7 @@ export const defaultFetch = (
 	// and set appropriate cache-control headers on the active response.
 	if (res && typeof res !== 'boolean') {
 		// Ensure api response contains surrogate key headers.
-		headers.set('Fastly-Debug', '1');
+		headers.set('Pantheon-SKey', '1');
 		res.setHeader('Cache-Control', cacheControl);
 	}
 

--- a/packages/wordpress-kit/__mocks__/server/basicPostsQuery.ts
+++ b/packages/wordpress-kit/__mocks__/server/basicPostsQuery.ts
@@ -4,7 +4,7 @@ import basicPostsQueryData from '../../__tests__/data/basicPostsQuery.json';
 export const basicPostsQuery = graphql.query<typeof basicPostsQueryData>(
 	'BasicPostsQuery',
 	(req, res, ctx) => {
-		if (req.headers.has('Fastly-Debug')) {
+		if (req.headers.has('Pantheon-SKey')) {
 			return res(
 				ctx.data(basicPostsQueryData),
 				ctx.set(

--- a/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts
+++ b/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts
@@ -20,7 +20,7 @@ export class GraphQLClientFactory {
 		this.options = {
 			...options,
 			headers: {
-				'Fastly-Debug': '1',
+				'Pantheon-SKey': '1',
 			},
 			jsonSerializer:
 				options?.method === 'GET'

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
@@ -19,22 +19,29 @@ installed.
 
 ## How It Works
 
+:::pantheon
+
+The following diagram shows the request/response for a Pantheon Front-End Site
+which is fetching data from Drupal also hosted on Pantheon
+
+:::
+
 ```mermaid
 sequenceDiagram
 	participant A as Client
     participant B as Next.js + drupal-kit
     participant C as Drupal
     A->>B: Request a page that fetches from Drupal
-    B->>C: Add Fastly-Debug header to request
+    B->>C: Add Pantheon-SKey header to request
     C->>B: Surrogate-Key header included on response
     B->>A: Set Surrogate-Key header on outgoing response to browser
 ```
 
 The `PantheonDrupalState` class from our `@pantheon-systems/drupal-kit` npm
-package includes an adapted fetch method which adds the `Fastly-Debug` header to
-each request to Drupal. Responses from Drupal will contain the `Surrogate-Key`
-header. With these keys, your frontend can be instructed to purge content from a
-cache when the content in Drupal changes.
+package includes an adapted fetch method which adds the `Pantheon-SKey` header
+to each request to Drupal. Responses from Drupal will contain the
+`Surrogate-Key` header. With these keys, your frontend can be instructed to
+purge content from a cache when the content in Drupal changes.
 
 ## How To Ensure Headers Are Set On Custom Routes
 

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
@@ -22,19 +22,26 @@ installed.
 
 ## How It Works
 
+:::pantheon
+
+The following diagram shows the request/response for a Pantheon Front-End Site
+which is fetching data from WordPress also hosted on Pantheon
+
+:::
+
 ```mermaid
 sequenceDiagram
 	participant A as Client
     participant B as Next.js + wordpress-kit
     participant C as WordPress
     A->>B: Request a page that fetches from WordPress
-    B->>C: Add Fastly-Debug header to request via GET
+    B->>C: Add Pantheon-SKey header to request via GET
     C->>B: Surrogate-Key header included on response
     B->>A: Set Surrogate header on outgoing response to browser
 ```
 
 The `GraphQLClientFactory` class from our `@pantheon-systems/wordpress-kit` npm
-package adds the `Fastly-Debug` header to each request and uses the GET method
+package adds the `Pantheon-SKey` header to each request and uses the GET method
 by default to take advantage of WPGraphQL Smart Cache network caching. Responses
 from WordPress will contain the `Surrogate-Key` header. With these keys, your
 frontend can be instructed to purge content from a cache when the content in
@@ -62,7 +69,7 @@ automatically.
   installed and configured
 - The route fetches data using the `@pantheon-systems/wordpress-kit` Graphql
   client or requests to WordPress are made using the GET method and include the
-  `Fastly-Debug: 1` header
+  `Pantheon-SKey: 1` header
   - in order to see the headers, you must use the `client.rawRequest()` method.
 - The headers must be added to the outgoing response from Next.js in
   `getServerSideProps` (see


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Mostly just `%s/Fastly-Debug/Pantheon-Skey`.

Added the `:::pantheon` admonition to the Mermaid diagrams on those pages too. Is the copy ok here?

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
`wordpress-kit`, `drupal-kit`
## How have the changes been tested?
Tested by locally symlinking new build of the packages to starter kits and running them locally. Editing the content and refreshing shows the new edit.
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->