### PR TITLE
Add a redirect to the previous front page to current

### DIFF
--- a/web/src/pages/docs/decoupled-kit-overview.jsx
+++ b/web/src/pages/docs/decoupled-kit-overview.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Redirect } from '@docusaurus/router';
+
+const DecoupledKitOverview = () => {
+	return <Redirect to="/docs" />;
+};
+
+export default DecoupledKitOverview;


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Should fix the 404 from our old homepage (https://decoupledkit.pantheon.io/docs/decoupled-kit-overview)
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->
docs
## How have the changes been tested?
locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->