### PR TITLE
Fix cli docs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,5 @@
 [ -n "$CI" ] && exit 0
 . "$(dirname "$0")/_/husky.sh"
 
-pnpm --workspace-concurrency=1 --filter './packages/**' lint-staged
+pnpm --workspace-concurrency=1 --filter './(packages/**|web)' lint-staged
 pnpm --filter './packages/**' test

--- a/packages/create-pantheon-decoupled-kit/tsconfig.typedoc.json
+++ b/packages/create-pantheon-decoupled-kit/tsconfig.typedoc.json
@@ -12,6 +12,7 @@
 	"exclude": [
 		"node_modules",
 		"dist",
+		"scripts",
 		"./src/templates/*",
 		"__tests__",
 		"__mocks__"

--- a/web/docs/Backend Starters/Decoupled Drupal/index.mdx
+++ b/web/docs/Backend Starters/Decoupled Drupal/index.mdx
@@ -2,6 +2,7 @@
 slug: /backend-starters/decoupled-drupal
 title: Decoupled Drupal
 ---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/web/docs/Backend Starters/Decoupled WordPress/index.mdx
+++ b/web/docs/Backend Starters/Decoupled WordPress/index.mdx
@@ -2,6 +2,7 @@
 slug: /backend-starters/decoupled-wordpress
 title: Decoupled WordPress
 ---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/web/docs/Backend Starters/index.mdx
+++ b/web/docs/Backend Starters/index.mdx
@@ -2,6 +2,7 @@
 slug: /backend-starters
 title: Backend Starters
 ---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/index.mdx
+++ b/web/docs/Frontend Starters/Gatsby/Gatsby + WordPress/index.mdx
@@ -2,6 +2,7 @@
 slug: /frontend-starters/gatsby/gatsby-wordpress
 title: Gatsby + WordPress
 ---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/web/docs/Frontend Starters/Gatsby/index.mdx
+++ b/web/docs/Frontend Starters/Gatsby/index.mdx
@@ -2,6 +2,7 @@
 slug: /frontend-starters/gatsby
 title: Gatsby
 ---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/index.mdx
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/index.mdx
@@ -2,6 +2,7 @@
 slug: /frontend-starters/nextjs/nextjs-drupal
 title: Next.js + Drupal
 ---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/index.mdx
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/index.mdx
@@ -2,6 +2,7 @@
 slug: /frontend-starters/nextjs/nextjs-wordpress
 title: Next.js + WordPress
 ---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/web/docs/Frontend Starters/Next.js/index.mdx
+++ b/web/docs/Frontend Starters/Next.js/index.mdx
@@ -2,6 +2,7 @@
 slug: /frontend-starters/nextjs
 title: Next.js
 ---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/web/docs/Frontend Starters/index.mdx
+++ b/web/docs/Frontend Starters/index.mdx
@@ -2,6 +2,7 @@
 slug: /frontend-starters
 title: Frontend Starters
 ---
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />

--- a/web/docs/Packages/cms-kit/_category_.yml
+++ b/web/docs/Packages/cms-kit/_category_.yml
@@ -1,2 +1,2 @@
-label: "cms-kit"
+label: 'cms-kit'
 position: 2

--- a/web/docs/Packages/cms-kit/modules.md
+++ b/web/docs/Packages/cms-kit/modules.md
@@ -29,4 +29,4 @@ The current known unique set of surrogate keys.
 
 #### Defined in
 
-[lib/setSurrogateKeyHeader.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/cms-kit/src/lib/setSurrogateKeyHeader.ts#L17)
+[lib/setSurrogateKeyHeader.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/cms-kit/src/lib/setSurrogateKeyHeader.ts#L17)

--- a/web/docs/Packages/cms-kit/modules.md
+++ b/web/docs/Packages/cms-kit/modules.md
@@ -29,4 +29,4 @@ The current known unique set of surrogate keys.
 
 #### Defined in
 
-[lib/setSurrogateKeyHeader.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/cms-kit/src/lib/setSurrogateKeyHeader.ts#L17)
+[lib/setSurrogateKeyHeader.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/cms-kit/src/lib/setSurrogateKeyHeader.ts#L17)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/_category_.yml
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/_category_.yml
@@ -1,2 +1,2 @@
-label: "create-pantheon-decoupled-kit"
+label: 'create-pantheon-decoupled-kit'
 position: 4

--- a/web/docs/Packages/create-pantheon-decoupled-kit/_category_.yml
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/_category_.yml
@@ -1,0 +1,2 @@
+label: "create-pantheon-decoupled-kit"
+position: 4

--- a/web/docs/Packages/create-pantheon-decoupled-kit/index.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/index.md
@@ -1,0 +1,77 @@
+---
+id: 'index'
+title: 'create-pantheon-decoupled-kit'
+sidebar_label: 'Readme'
+sidebar_position: 0
+custom_edit_url: null
+---
+
+# Create Pantheon Decoupled Kit
+
+Pantheon's command line interface for creating and adding on to new projects.
+
+A CLI heavily inspired by various `create-` apps and generator frameworks
+including [`plop`](https://github.com/plopjs/plop)
+[`create-sitecore-jss`](https://github.com/Sitecore/jss/tree/dev/packages/create-sitecore-jss),
+[`create-astro`](https://github.com/withastro/astro/tree/main/packages/create-astro),
+and [`create-create-app`](https://github.com/uetchy/create-create-app).
+
+## Installation
+
+To install this package locally, run the following commands from the root of the
+monorepo.
+
+```bash
+  # build the package
+  pnpm build:cli
+  # link the local version of the package to global node_modules
+  pnpm link ./packages/create-pantheon-decoupled-kit
+  # run the bin script
+  pnpm create-pantheon-decoupled-kit
+```
+
+## Usage
+
+Use the create command to initiate the cli with no arguments and follow the
+prompts in your terminal
+
+```bash
+  # this will use the latest non-canary version from the npm registry
+  # to use the latest canary, use pantheon-decoupled-kit@canary
+  pnpm create pantheon-decoupled-kit
+```
+
+Or, pass in arguments up front to skip those prompts
+
+```bash
+  pnpm create pantheon-decoupled-kit next-wp --appName my-app --outDir ./my-app-dir --force
+```
+
+### `watch` script
+
+To run the `watch` script, ensure there is a `watch.{ts,js}` file at the root of
+this package. The watch file should export a named `watchOptions` object of type
+`minimist.ParsedArgs`. Positional arguments in the `_` array will correspond to
+Generators to run. Named arguments correspond to answers to the Generator
+prompts. Generators will be run in the order they are given. Any number of
+generators may be run at a given time. See `watch.example.ts` for an example of
+`watchOptions`.
+
+See
+[create-pantheon-decoupled-kit](../../Frontend%20Starters/create-pantheon-decoupled-kit.md)
+for more information.
+
+## API Reference
+
+[Visit our docs site](https://decoupledkit.pantheon.io/docs/packages/create-pantheon-decoupled-kit)
+
+## Contributing
+
+Please see the
+[Contributing guide in our monorepo](https://github.com/pantheon-systems/decoupled-kit-js/blob/canary/CONTRIBUTING.md)
+to contribute to the project.
+
+<!-- TODO: Write details for contributing to this package -->
+
+See https://decoupledkit.pantheon.io/docs/contributing for details on
+contributing to this module.

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DecoupledKitGenerator.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DecoupledKitGenerator.md
@@ -1,0 +1,137 @@
+---
+id: 'DecoupledKitGenerator'
+title: 'Interface: DecoupledKitGenerator<Prompts, Data>'
+sidebar_label: 'DecoupledKitGenerator'
+sidebar_position: 0
+custom_edit_url: null
+---
+
+Generators need prompts to get user data not provided by CLI arguments
+
+## Type parameters
+
+| Name      | Type                                  |
+| :-------- | :------------------------------------ |
+| `Prompts` | [`DefaultAnswers`](DefaultAnswers.md) |
+| `Data`    | `unknown`                             |
+
+## Properties
+
+### actions
+
+• **actions**: [`Action`](../modules.md#action)[]
+
+An array of actions to run with the prompts and templates
+
+#### Defined in
+
+[src/types.ts:76](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L76)
+
+---
+
+### addon
+
+• `Optional` **addon**: `boolean`
+
+Set to true if the generator is considered an addon. This will give priority to
+the templates when de-duping.
+
+#### Defined in
+
+[src/types.ts:85](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L85)
+
+---
+
+### cmsType
+
+• **cmsType**: `"drupal"` \| `"wp"` \| `"wordpress"` \| `"d9"` \| `"d10"` \|
+`"any"`
+
+Identifies a generators compatible CMS(s).
+
+#### Defined in
+
+[src/types.ts:93](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L93)
+
+---
+
+### data
+
+• `Optional` **data**: `Data`
+
+Any extra data that should be passed from the generator to the actions
+
+#### Defined in
+
+[src/types.ts:80](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L80)
+
+---
+
+### description
+
+• **description**: `string`
+
+Description of the generator
+
+#### Defined in
+
+[src/types.ts:59](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L59)
+
+---
+
+### name
+
+• **name**: `string`
+
+Generator's name. This should be kebab case.
+
+#### Defined in
+
+[src/types.ts:55](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L55)
+
+---
+
+### nextSteps
+
+• `Optional` **nextSteps**: `string`[]
+
+Any message(s) to be rendered after actions are successfully completed.
+
+#### Defined in
+
+[src/types.ts:89](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L89)
+
+---
+
+### prompts
+
+• **prompts**: `QuestionCollection`<[`DefaultAnswers`](DefaultAnswers.md)\>[]
+
+An array of inquirer prompts
+
+**`Template`**
+
+the type of the required user input
+
+**`Default`**
+
+```ts
+DefaultAnswers - { outDir: string };
+```
+
+#### Defined in
+
+[src/types.ts:65](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L65)
+
+---
+
+### templates
+
+• **templates**: `string`[]
+
+An array of paths to the generator's templates. This should be empty if the
+generator does not have templates.
+
+#### Defined in
+
+[src/types.ts:72](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L72)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DecoupledKitGenerator.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DecoupledKitGenerator.md
@@ -25,7 +25,7 @@ An array of actions to run with the prompts and templates
 
 #### Defined in
 
-[src/types.ts:76](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L76)
+[src/types.ts:76](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L76)
 
 ---
 
@@ -38,7 +38,7 @@ the templates when de-duping.
 
 #### Defined in
 
-[src/types.ts:85](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L85)
+[src/types.ts:85](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L85)
 
 ---
 
@@ -51,7 +51,7 @@ Identifies a generators compatible CMS(s).
 
 #### Defined in
 
-[src/types.ts:93](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L93)
+[src/types.ts:93](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L93)
 
 ---
 
@@ -63,7 +63,7 @@ Any extra data that should be passed from the generator to the actions
 
 #### Defined in
 
-[src/types.ts:80](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L80)
+[src/types.ts:80](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L80)
 
 ---
 
@@ -75,7 +75,7 @@ Description of the generator
 
 #### Defined in
 
-[src/types.ts:59](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L59)
+[src/types.ts:59](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L59)
 
 ---
 
@@ -87,7 +87,7 @@ Generator's name. This should be kebab case.
 
 #### Defined in
 
-[src/types.ts:55](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L55)
+[src/types.ts:55](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L55)
 
 ---
 
@@ -99,7 +99,7 @@ Any message(s) to be rendered after actions are successfully completed.
 
 #### Defined in
 
-[src/types.ts:89](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L89)
+[src/types.ts:89](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L89)
 
 ---
 
@@ -121,7 +121,7 @@ DefaultAnswers - { outDir: string };
 
 #### Defined in
 
-[src/types.ts:65](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L65)
+[src/types.ts:65](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L65)
 
 ---
 
@@ -134,4 +134,4 @@ generator does not have templates.
 
 #### Defined in
 
-[src/types.ts:72](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L72)
+[src/types.ts:72](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L72)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DefaultAnswers.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DefaultAnswers.md
@@ -1,0 +1,23 @@
+---
+id: 'DefaultAnswers'
+title: 'Interface: DefaultAnswers'
+sidebar_label: 'DefaultAnswers'
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Hierarchy
+
+- `Answers`
+
+  ↳ **`DefaultAnswers`**
+
+## Properties
+
+### outDir
+
+• **outDir**: `string`
+
+#### Defined in
+
+[src/types.ts:156](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L156)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DefaultAnswers.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/DefaultAnswers.md
@@ -20,4 +20,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[src/types.ts:156](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L156)
+[src/types.ts:156](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L156)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/GatsbyWPData.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/GatsbyWPData.md
@@ -81,7 +81,7 @@ BaseGeneratorData.eslintVersion
 
 #### Defined in
 
-[src/types.ts:42](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L42)
+[src/types.ts:42](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L42)
 
 ---
 
@@ -91,7 +91,7 @@ BaseGeneratorData.eslintVersion
 
 #### Defined in
 
-[src/types.ts:41](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L41)
+[src/types.ts:41](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L41)
 
 ---
 

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/GatsbyWPData.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/GatsbyWPData.md
@@ -1,0 +1,134 @@
+---
+id: 'GatsbyWPData'
+title: 'Interface: GatsbyWPData'
+sidebar_label: 'GatsbyWPData'
+sidebar_position: 0
+custom_edit_url: null
+---
+
+Base data that is passed to all generators
+
+**`Example`**
+
+```
+{
+	drupalKitVersion: versions['drupal-kit'],
+	drupal: true
+}
+```
+
+## Hierarchy
+
+- [`BaseGeneratorData`](../modules.md#basegeneratordata)
+
+  ↳ **`GatsbyWPData`**
+
+## Properties
+
+### cmsKitVersion
+
+• **cmsKitVersion**: `undefined` \| `string`
+
+#### Inherited from
+
+BaseGeneratorData.cmsKitVersion
+
+---
+
+### decoupledKitHealthCheckVersion
+
+• **decoupledKitHealthCheckVersion**: `undefined` \| `string`
+
+#### Inherited from
+
+BaseGeneratorData.decoupledKitHealthCheckVersion
+
+---
+
+### drupal
+
+• **drupal**: `undefined` \| `boolean`
+
+#### Inherited from
+
+BaseGeneratorData.drupal
+
+---
+
+### drupalKitVersion
+
+• **drupalKitVersion**: `undefined` \| `string`
+
+#### Inherited from
+
+BaseGeneratorData.drupalKitVersion
+
+---
+
+### eslintVersion
+
+• **eslintVersion**: `undefined` \| `string`
+
+#### Inherited from
+
+BaseGeneratorData.eslintVersion
+
+---
+
+### gatsby
+
+• **gatsby**: `true`
+
+#### Defined in
+
+[src/types.ts:42](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L42)
+
+---
+
+### gatsbyPnpmPlugin
+
+• **gatsbyPnpmPlugin**: `boolean`
+
+#### Defined in
+
+[src/types.ts:41](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L41)
+
+---
+
+### nextjsKitVersion
+
+• **nextjsKitVersion**: `undefined` \| `string`
+
+#### Inherited from
+
+BaseGeneratorData.nextjsKitVersion
+
+---
+
+### otherVersion
+
+• **otherVersion**: `undefined` \| `string`
+
+#### Inherited from
+
+BaseGeneratorData.otherVersion
+
+---
+
+### wordpressKitVersion
+
+• **wordpressKitVersion**: `undefined` \| `string`
+
+#### Inherited from
+
+BaseGeneratorData.wordpressKitVersion
+
+---
+
+### wp
+
+• **wp**: `undefined` \| `boolean`
+
+#### Inherited from
+
+BaseGeneratorData.wp

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/MergedPaths.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/MergedPaths.md
@@ -1,0 +1,11 @@
+---
+id: 'MergedPaths'
+title: 'Interface: MergedPaths'
+sidebar_label: 'MergedPaths'
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Indexable
+
+▪ [key: `string`]: { `addon`: `boolean` ; `base`: `string` }

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateData.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateData.md
@@ -1,0 +1,27 @@
+---
+id: 'TemplateData'
+title: 'Interface: TemplateData'
+sidebar_label: 'TemplateData'
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Properties
+
+### addon
+
+• **addon**: `boolean`
+
+#### Defined in
+
+[src/types.ts:148](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L148)
+
+---
+
+### templateDirs
+
+• **templateDirs**: `string`[]
+
+#### Defined in
+
+[src/types.ts:147](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L147)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateData.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateData.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[src/types.ts:148](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L148)
+[src/types.ts:148](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L148)
 
 ---
 
@@ -24,4 +24,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[src/types.ts:147](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L147)
+[src/types.ts:147](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L147)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateImport.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateImport.md
@@ -1,0 +1,17 @@
+---
+id: 'TemplateImport'
+title: 'Interface: TemplateImport'
+sidebar_label: 'TemplateImport'
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Properties
+
+### default
+
+• **default**: [`TemplateFn`](../modules.md#templatefn)
+
+#### Defined in
+
+[src/types.ts:191](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L191)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateImport.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/TemplateImport.md
@@ -14,4 +14,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[src/types.ts:191](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L191)
+[src/types.ts:191](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L191)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/_category_.yml
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/_category_.yml
@@ -1,0 +1,2 @@
+label: "Interfaces"
+position: 4

--- a/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/_category_.yml
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/interfaces/_category_.yml
@@ -1,2 +1,2 @@
-label: "Interfaces"
+label: 'Interfaces'
 position: 4

--- a/web/docs/Packages/create-pantheon-decoupled-kit/modules.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/modules.md
@@ -40,7 +40,7 @@ does an action, like installing dependencies or formatting generated code
 
 #### Defined in
 
-[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
 
 ---
 
@@ -64,7 +64,7 @@ does an action, like installing dependencies or formatting generated code
 
 #### Defined in
 
-[src/types.ts:113](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L113)
+[src/types.ts:113](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L113)
 
 ---
 
@@ -85,7 +85,7 @@ Base data that is passed to all generators
 
 #### Defined in
 
-[src/types.ts:38](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L38)
+[src/types.ts:38](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L38)
 
 ---
 
@@ -97,7 +97,7 @@ Input from command line arguments, prompts, and generator data
 
 #### Defined in
 
-[src/types.ts:142](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L142)
+[src/types.ts:142](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L142)
 
 ---
 
@@ -131,7 +131,7 @@ A tagged template literal function with data and utils context
 
 #### Defined in
 
-[src/types.ts:185](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L185)
+[src/types.ts:185](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L185)
 
 ## Variables
 
@@ -145,7 +145,7 @@ A tagged template literal function with data and utils context
 
 #### Defined in
 
-[src/utils/constants.ts:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/constants.ts#L5)
+[src/utils/constants.ts:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/utils/constants.ts#L5)
 
 ---
 
@@ -161,7 +161,7 @@ Handlebars HelperDelegate
 
 #### Defined in
 
-[src/utils/handlebars.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L10)
+[src/utils/handlebars.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L10)
 
 ---
 
@@ -171,7 +171,7 @@ Handlebars HelperDelegate
 
 #### Defined in
 
-[src/index.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/index.ts#L15)
+[src/index.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/index.ts#L15)
 
 ---
 
@@ -192,7 +192,7 @@ Handlebars HelperDelegate
 
 #### Defined in
 
-[src/utils/taggedTemplateHelpers.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/taggedTemplateHelpers.ts#L8)
+[src/utils/taggedTemplateHelpers.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/utils/taggedTemplateHelpers.ts#L8)
 
 ## Functions
 
@@ -212,7 +212,7 @@ Handlebars HelperDelegate
 
 #### Defined in
 
-[src/types.ts:113](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L113)
+[src/types.ts:113](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L113)
 
 ---
 
@@ -234,7 +234,7 @@ Adds any dependencies and/or devDependencies from the data field
 
 #### Defined in
 
-[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
 
 ---
 
@@ -264,7 +264,7 @@ Adds any dependencies and/or devDependencies from the data field
 
 #### Defined in
 
-[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
 
 ---
 
@@ -287,7 +287,7 @@ does an action, like installing dependencies or formatting generated code
 
 #### Defined in
 
-[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
 
 ---
 
@@ -318,7 +318,7 @@ MergedPaths
 
 #### Defined in
 
-[src/utils/dedupeTemplates.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/dedupeTemplates.ts#L70)
+[src/utils/dedupeTemplates.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/utils/dedupeTemplates.ts#L70)
 
 ---
 
@@ -346,7 +346,7 @@ resolves to {rootDir}/templates/partials
 
 #### Defined in
 
-[src/utils/handlebars.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L119)
+[src/utils/handlebars.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L119)
 
 ---
 
@@ -366,7 +366,7 @@ resolves to {rootDir}/templates/partials
 
 #### Defined in
 
-[src/utils/helpMenu.ts:3](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/helpMenu.ts#L3)
+[src/utils/helpMenu.ts:3](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/utils/helpMenu.ts#L3)
 
 ---
 
@@ -389,7 +389,7 @@ otherwise
 
 #### Defined in
 
-[src/types.ts:206](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L206)
+[src/types.ts:206](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L206)
 
 ---
 
@@ -411,7 +411,7 @@ true if the variable is a string, false otherwise
 
 #### Defined in
 
-[src/types.ts:198](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L198)
+[src/types.ts:198](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L198)
 
 ---
 
@@ -434,7 +434,7 @@ otherwise
 
 #### Defined in
 
-[src/types.ts:214](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L214)
+[src/types.ts:214](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L214)
 
 ---
 
@@ -471,7 +471,7 @@ prompt name via flag.
 
 #### Defined in
 
-[src/index.ts:51](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/index.ts#L51)
+[src/index.ts:51](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/index.ts#L51)
 
 ---
 
@@ -501,7 +501,7 @@ Parses CLI arguments using `minimist`
 
 #### Defined in
 
-[src/index.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/index.ts#L23)
+[src/index.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/index.ts#L23)
 
 ---
 
@@ -524,7 +524,7 @@ does an action, like installing dependencies or formatting generated code
 
 #### Defined in
 
-[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
 
 ---
 
@@ -547,4 +547,4 @@ does an action, like installing dependencies or formatting generated code
 
 #### Defined in
 
-[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/create-pantheon-decoupled-kit/src/types.ts#L111)

--- a/web/docs/Packages/create-pantheon-decoupled-kit/modules.md
+++ b/web/docs/Packages/create-pantheon-decoupled-kit/modules.md
@@ -1,0 +1,550 @@
+---
+id: 'modules'
+title: 'create-pantheon-decoupled-kit'
+sidebar_label: 'Exports'
+sidebar_position: 0.5
+custom_edit_url: null
+---
+
+## Interfaces
+
+- [DecoupledKitGenerator](interfaces/DecoupledKitGenerator.md)
+- [DefaultAnswers](interfaces/DefaultAnswers.md)
+- [GatsbyWPData](interfaces/GatsbyWPData.md)
+- [MergedPaths](interfaces/MergedPaths.md)
+- [TemplateData](interfaces/TemplateData.md)
+- [TemplateImport](interfaces/TemplateImport.md)
+
+## Type Aliases
+
+### Action
+
+Ƭ **Action**: (`config`: `ActionConfig`) => `Promise`<`string`\> \| `string`
+
+#### Type declaration
+
+▸ (`config`): `Promise`<`string`\> \| `string`
+
+An action that takes in the data, templates, and an instance of handlebars and
+does an action, like installing dependencies or formatting generated code
+
+##### Parameters
+
+| Name     | Type           |
+| :------- | :------------- |
+| `config` | `ActionConfig` |
+
+##### Returns
+
+`Promise`<`string`\> \| `string`
+
+#### Defined in
+
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+
+---
+
+### ActionRunner
+
+Ƭ **ActionRunner**: (`config`: `ActionRunnerConfig`) => `Promise`<`string`\>
+
+#### Type declaration
+
+▸ (`config`): `Promise`<`string`\>
+
+##### Parameters
+
+| Name     | Type                 |
+| :------- | :------------------- |
+| `config` | `ActionRunnerConfig` |
+
+##### Returns
+
+`Promise`<`string`\>
+
+#### Defined in
+
+[src/types.ts:113](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L113)
+
+---
+
+### BaseGeneratorData
+
+Ƭ **BaseGeneratorData**: `Partial`<`PackageVersionData`\> & `DrupalOrWP`
+
+Base data that is passed to all generators
+
+**`Example`**
+
+```
+{
+	drupalKitVersion: versions['drupal-kit'],
+	drupal: true
+}
+```
+
+#### Defined in
+
+[src/types.ts:38](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L38)
+
+---
+
+### Input
+
+Ƭ **Input**: { [Property in keyof InputIndex]: InputIndex[Property] }
+
+Input from command line arguments, prompts, and generator data
+
+#### Defined in
+
+[src/types.ts:142](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L142)
+
+---
+
+### TemplateFn
+
+Ƭ **TemplateFn**: <Data\>(`{ 	data, 	utils, }`: `TemplateFnArgs`<`Data`\>) =>
+`string`
+
+#### Type declaration
+
+▸ <`Data`\>(`{ 	data, 	utils, }`): `string`
+
+A tagged template literal function with data and utils context
+
+##### Type parameters
+
+| Name   | Type                                |
+| :----- | :---------------------------------- |
+| `Data` | extends [`Input`](modules.md#input) |
+
+##### Parameters
+
+| Name | Type |
+| :--- | :--- |
+
+| `{ 	data, 	utils, }` | `TemplateFnArgs`<`Data`\> |
+
+##### Returns
+
+`string`
+
+#### Defined in
+
+[src/types.ts:185](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L185)
+
+## Variables
+
+### TAGGED_TEMPLATE_REGEX
+
+• `Const` **TAGGED_TEMPLATE_REGEX**: `RegExp`
+
+**`Remarks`**
+
+`env\.[a-z.]*` - matches `.env.*.ts` such as `.env.development.local.ts`
+
+#### Defined in
+
+[src/utils/constants.ts:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/constants.ts#L5)
+
+---
+
+### hbsHelpers
+
+• `Const` **hbsHelpers**: `Object`
+
+Handlebars HelperDelegate
+
+#### Index signature
+
+▪ [key: `string`]: `HelperDelegate`
+
+#### Defined in
+
+[src/utils/handlebars.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L10)
+
+---
+
+### rootDir
+
+• `Const` **rootDir**: `string`
+
+#### Defined in
+
+[src/index.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/index.ts#L15)
+
+---
+
+### taggedTemplateHelpers
+
+• `Const` **taggedTemplateHelpers**: `Object`
+
+#### Type declaration
+
+| Name           | Type                                                                                       |
+| :------------- | :----------------------------------------------------------------------------------------- |
+| `backticks`    | (`value`: `string` \| `TemplateStringsArray`) => `string`                                  |
+| `if`           | (`condition`: `unknown`, `value`: `string`) => `string`                                    |
+| `md`           | { `codeFence`: (`__namedParameters`: { `lang`: `Lang` ; `value`: `string` }) => `string` } |
+| `md.codeFence` | (`__namedParameters`: { `lang`: `Lang` ; `value`: `string` }) => `string`                  |
+| `pkgName`      | (`value`: `unknown`) => `string`                                                           |
+| `wpGraphql`    | (`value`: `string`) => `string`                                                            |
+
+#### Defined in
+
+[src/utils/taggedTemplateHelpers.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/taggedTemplateHelpers.ts#L8)
+
+## Functions
+
+### actionRunner
+
+▸ **actionRunner**(`config`): `Promise`<`string`\>
+
+#### Parameters
+
+| Name     | Type                 |
+| :------- | :------------------- |
+| `config` | `ActionRunnerConfig` |
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Defined in
+
+[src/types.ts:113](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L113)
+
+---
+
+### addDependencies
+
+▸ **addDependencies**(`config`): `string` \| `Promise`<`string`\>
+
+Adds any dependencies and/or devDependencies from the data field
+
+#### Parameters
+
+| Name     | Type           |
+| :------- | :------------- |
+| `config` | `ActionConfig` |
+
+#### Returns
+
+`string` \| `Promise`<`string`\>
+
+#### Defined in
+
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+
+---
+
+### addWithDiff
+
+▸ **addWithDiff**(`config`): `string` \| `Promise`<`string`\>
+
+1. dedupe the templates, favoring addons in case 2 paths collide
+2. check if the destination path exists or create it. (path to destination +
+   template name minus .hbs) example: ./test/myTest.js
+3. check the diff against the new file and the rendered template or file to copy
+   if source is not a handlebars template
+4. if the --force option is not defined, ask the user if we should overwrite
+   this file (yes to all, yes, skip, abort) if force is true we write
+   everything.
+5. skip or write the file based on input. If yes to all, set force to true.
+
+#### Parameters
+
+| Name     | Type           |
+| :------- | :------------- |
+| `config` | `ActionConfig` |
+
+#### Returns
+
+`string` \| `Promise`<`string`\>
+
+#### Defined in
+
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+
+---
+
+### convertCSSModules
+
+▸ **convertCSSModules**(`config`): `string` \| `Promise`<`string`\>
+
+An action that takes in the data, templates, and an instance of handlebars and
+does an action, like installing dependencies or formatting generated code
+
+#### Parameters
+
+| Name     | Type           |
+| :------- | :------------- |
+| `config` | `ActionConfig` |
+
+#### Returns
+
+`string` \| `Promise`<`string`\>
+
+#### Defined in
+
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+
+---
+
+### dedupeTemplates
+
+▸ **dedupeTemplates**(`templateData`):
+`Promise`<[`MergedPaths`](interfaces/MergedPaths.md)\>
+
+In case there is a template path that exists in two or more generators, we want
+to favor the addon. This way, we avoid writing to a file multiple times
+
+#### Parameters
+
+| Name           | Type                                           | Description           |
+| :------------- | :--------------------------------------------- | :-------------------- |
+| `templateData` | [`TemplateData`](interfaces/TemplateData.md)[] | An array of Templates |
+
+#### Returns
+
+`Promise`<[`MergedPaths`](interfaces/MergedPaths.md)\>
+
+MergedPaths
+
+**`See`**
+
+- Template
+- [MergedPaths](interfaces/MergedPaths.md)
+
+#### Defined in
+
+[src/utils/dedupeTemplates.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/dedupeTemplates.ts#L70)
+
+---
+
+### getHandlebarsInstance
+
+▸ **getHandlebarsInstance**(`rootDir`): `Promise`<typeof `Handlebars`\>
+
+#### Parameters
+
+| Name      | Type     | Description                           |
+| :-------- | :------- | :------------------------------------ |
+| `rootDir` | `string` | dir to look for the partials dir from |
+
+#### Returns
+
+`Promise`<typeof `Handlebars`\>
+
+an instance of handlebars our with helpers and partials registered
+
+**`Example`**
+
+```ts
+resolves to {rootDir}/templates/partials
+```
+
+#### Defined in
+
+[src/utils/handlebars.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/handlebars.ts#L119)
+
+---
+
+### helpMenu
+
+▸ **helpMenu**(`generators`): `string`
+
+#### Parameters
+
+| Name         | Type                                                                                                                           |
+| :----------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| `generators` | [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md), `unknown`\>[] |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[src/utils/helpMenu.ts:3](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/utils/helpMenu.ts#L3)
+
+---
+
+### isDrupalCms
+
+▸ **isDrupalCms**(`value`): value is "drupal" \| "d9" \| "d10"
+
+#### Parameters
+
+| Name    | Type     | Description |
+| :------ | :------- | :---------- |
+| `value` | `string` | a string    |
+
+#### Returns
+
+value is "drupal" \| "d9" \| "d10"
+
+true if the variable matches a Drupal alias in CMSType['Drupal'], false
+otherwise
+
+#### Defined in
+
+[src/types.ts:206](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L206)
+
+---
+
+### isString
+
+▸ **isString**(`arg`): arg is string
+
+#### Parameters
+
+| Name  | Type      | Description |
+| :---- | :-------- | :---------- |
+| `arg` | `unknown` | a variable  |
+
+#### Returns
+
+arg is string
+
+true if the variable is a string, false otherwise
+
+#### Defined in
+
+[src/types.ts:198](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L198)
+
+---
+
+### isWpCms
+
+▸ **isWpCms**(`value`): value is "wp" \| "wordpress"
+
+#### Parameters
+
+| Name    | Type     | Description |
+| :------ | :------- | :---------- |
+| `value` | `string` | a string    |
+
+#### Returns
+
+value is "wp" \| "wordpress"
+
+true if the variable matches a WordPress alias in CMSType['WordPress'], false
+otherwise
+
+#### Defined in
+
+[src/types.ts:214](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L214)
+
+---
+
+### main
+
+▸ **main**(`args`, `DecoupledKitGenerators`): `Promise`<`void`\>
+
+Initializes the CLI prompts based on parsed arguments
+
+#### Parameters
+
+| Name                     | Type                                                                                                                           | Description                         |
+| :----------------------- | :----------------------------------------------------------------------------------------------------------------------------- | :---------------------------------- |
+| `args`                   | `ParsedArgs`                                                                                                                   | ParsedArgs                          |
+| `DecoupledKitGenerators` | [`DecoupledKitGenerator`](interfaces/DecoupledKitGenerator.md)<[`DefaultAnswers`](interfaces/DefaultAnswers.md), `unknown`\>[] | An array of decoupledKitGenerators. |
+
+#### Returns
+
+`Promise`<`void`\>
+
+Runs the actions for the generators given as positional params or if none are
+found, prompts user to select valid generator from list of
+DecoupledKitGenerators
+
+**`See`**
+
+decoupledKitGenerators.
+
+**`Remarks`**
+
+positional args are assumed to be generator names. Multiple generators can be
+queued up this way. Any number of prompts may be skipped by passing in the
+prompt name via flag.
+
+#### Defined in
+
+[src/index.ts:51](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/index.ts#L51)
+
+---
+
+### parseArgs
+
+▸ **parseArgs**(`cliArgs?`): `ParsedArgs`
+
+Parses CLI arguments using `minimist`
+
+#### Parameters
+
+| Name      | Type       | Description          |
+| :-------- | :--------- | :------------------- |
+| `cliArgs` | `string`[] | an array of strings. |
+
+#### Returns
+
+`ParsedArgs`
+
+**`See`**
+
+[https://www.npmjs.com/package/minimist#var-argv--parseargsargs-opts](https://www.npmjs.com/package/minimist#var-argv--parseargsargs-opts)
+
+**`Default Value`**
+
+`process.argv.slice(2)`
+
+#### Defined in
+
+[src/index.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/index.ts#L23)
+
+---
+
+### runInstall
+
+▸ **runInstall**(`config`): `string` \| `Promise`<`string`\>
+
+An action that takes in the data, templates, and an instance of handlebars and
+does an action, like installing dependencies or formatting generated code
+
+#### Parameters
+
+| Name     | Type           |
+| :------- | :------------- |
+| `config` | `ActionConfig` |
+
+#### Returns
+
+`string` \| `Promise`<`string`\>
+
+#### Defined in
+
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)
+
+---
+
+### runLint
+
+▸ **runLint**(`config`): `string` \| `Promise`<`string`\>
+
+An action that takes in the data, templates, and an instance of handlebars and
+does an action, like installing dependencies or formatting generated code
+
+#### Parameters
+
+| Name     | Type           |
+| :------- | :------------- |
+| `config` | `ActionConfig` |
+
+#### Returns
+
+`string` \| `Promise`<`string`\>
+
+#### Defined in
+
+[src/types.ts:111](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/create-pantheon-decoupled-kit/src/types.ts#L111)

--- a/web/docs/Packages/decoupled-kit-health-check/_category_.yml
+++ b/web/docs/Packages/decoupled-kit-health-check/_category_.yml
@@ -1,2 +1,2 @@
-label: "decoupled-kit-health-check"
+label: 'decoupled-kit-health-check'
 position: 5

--- a/web/docs/Packages/decoupled-kit-health-check/classes/BackendNotSetError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/BackendNotSetError.md
@@ -32,7 +32,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L10)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/errors.ts#L10)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/BackendNotSetError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/BackendNotSetError.md
@@ -32,7 +32,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/errors.ts#L10)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L10)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/DecoupledMenuError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/DecoupledMenuError.md
@@ -33,7 +33,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:41](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L41)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:41](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/errors.ts#L41)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/DecoupledMenuError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/DecoupledMenuError.md
@@ -33,7 +33,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:41](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/errors.ts#L41)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:41](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L41)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/DecoupledRouterError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/DecoupledRouterError.md
@@ -33,7 +33,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/errors.ts#L30)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L30)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/DecoupledRouterError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/DecoupledRouterError.md
@@ -33,7 +33,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L30)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/errors.ts#L30)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/GatsbyWordPressHealthCheck.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/GatsbyWordPressHealthCheck.md
@@ -34,7 +34,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L23)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L23)
 
 ## Properties
 
@@ -44,7 +44,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L16)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L16)
 
 ---
 
@@ -58,7 +58,7 @@ WordPressHealthCheck.appUsername
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L15)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L15)
 
 ---
 
@@ -72,7 +72,7 @@ WordPressHealthCheck.endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L13)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L13)
 
 ---
 
@@ -86,7 +86,7 @@ WordPressHealthCheck.envVar
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L14)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L14)
 
 ---
 
@@ -108,7 +108,7 @@ WordPressHealthCheck.log
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L17)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L17)
 
 ## Methods
 
@@ -132,7 +132,7 @@ WordPressHealthCheck.checkFor200
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:86](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L86)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:86](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L86)
 
 ---
 
@@ -150,7 +150,7 @@ WordPressHealthCheck.getURL
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:81](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L81)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:81](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L81)
 
 ---
 
@@ -169,7 +169,7 @@ WordPressHealthCheck.validateAuth
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:144](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L144)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:144](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L144)
 
 ---
 
@@ -188,7 +188,7 @@ WordPressHealthCheck.validateEndpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:103](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L103)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:103](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L103)
 
 ---
 
@@ -207,7 +207,7 @@ WordPressHealthCheck.validateMenu
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:117](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L117)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:117](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L117)
 
 ---
 
@@ -226,7 +226,7 @@ WordPressHealthCheck.validatePreview
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:223](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L223)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:223](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L223)
 
 ---
 
@@ -241,4 +241,4 @@ WordPressHealthCheck.validatePreview
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:200](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L200)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:200](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L200)

--- a/web/docs/Packages/decoupled-kit-health-check/classes/GatsbyWordPressHealthCheck.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/GatsbyWordPressHealthCheck.md
@@ -34,7 +34,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L23)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L23)
 
 ## Properties
 
@@ -44,7 +44,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L16)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L16)
 
 ---
 
@@ -58,7 +58,7 @@ WordPressHealthCheck.appUsername
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L15)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L15)
 
 ---
 
@@ -72,7 +72,7 @@ WordPressHealthCheck.endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L13)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L13)
 
 ---
 
@@ -86,7 +86,7 @@ WordPressHealthCheck.envVar
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L14)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L14)
 
 ---
 
@@ -108,7 +108,7 @@ WordPressHealthCheck.log
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L17)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L17)
 
 ## Methods
 
@@ -132,7 +132,7 @@ WordPressHealthCheck.checkFor200
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:86](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L86)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:86](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L86)
 
 ---
 
@@ -150,7 +150,7 @@ WordPressHealthCheck.getURL
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:81](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L81)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:81](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L81)
 
 ---
 
@@ -169,7 +169,7 @@ WordPressHealthCheck.validateAuth
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:144](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L144)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:144](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L144)
 
 ---
 
@@ -188,7 +188,7 @@ WordPressHealthCheck.validateEndpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:103](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L103)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:103](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L103)
 
 ---
 
@@ -207,7 +207,7 @@ WordPressHealthCheck.validateMenu
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:117](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L117)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:117](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L117)
 
 ---
 
@@ -226,7 +226,7 @@ WordPressHealthCheck.validatePreview
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:223](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L223)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:223](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L223)
 
 ---
 
@@ -241,4 +241,4 @@ WordPressHealthCheck.validatePreview
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:200](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L200)
+[packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts:200](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts#L200)

--- a/web/docs/Packages/decoupled-kit-health-check/classes/HealthCheckBase.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/HealthCheckBase.md
@@ -20,7 +20,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L9)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L9)
 
 ---
 
@@ -30,7 +30,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L10)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L10)
 
 ---
 
@@ -48,7 +48,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L11)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L11)
 
 ## Methods
 
@@ -70,7 +70,7 @@ Check the url for a 200 response
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L24)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L24)
 
 ---
 
@@ -86,7 +86,7 @@ Uses `this.endpoint` to return a new URL
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:19](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L19)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:19](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L19)
 
 ---
 
@@ -103,7 +103,7 @@ Validate the provided credentials
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:32](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L32)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:32](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L32)
 
 ---
 
@@ -122,7 +122,7 @@ Validate the set endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L15)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L15)
 
 ---
 
@@ -141,7 +141,7 @@ Validate the menu query or endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:28](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L28)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:28](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L28)
 
 ---
 
@@ -160,4 +160,4 @@ fetching preview content. Should be skipped if credentials are not validated in
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:37](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L37)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:37](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L37)

--- a/web/docs/Packages/decoupled-kit-health-check/classes/HealthCheckBase.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/HealthCheckBase.md
@@ -20,7 +20,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L9)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L9)
 
 ---
 
@@ -30,7 +30,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L10)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L10)
 
 ---
 
@@ -48,7 +48,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L11)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L11)
 
 ## Methods
 
@@ -70,7 +70,7 @@ Check the url for a 200 response
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L24)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L24)
 
 ---
 
@@ -86,7 +86,7 @@ Uses `this.endpoint` to return a new URL
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:19](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L19)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:19](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L19)
 
 ---
 
@@ -103,7 +103,7 @@ Validate the provided credentials
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:32](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L32)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:32](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L32)
 
 ---
 
@@ -122,7 +122,7 @@ Validate the set endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L15)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L15)
 
 ---
 
@@ -141,7 +141,7 @@ Validate the menu query or endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:28](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L28)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:28](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L28)
 
 ---
 
@@ -160,4 +160,4 @@ fetching preview content. Should be skipped if credentials are not validated in
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:37](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L37)
+[packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts:37](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/HealthCheckBase.ts#L37)

--- a/web/docs/Packages/decoupled-kit-health-check/classes/InvalidCMSEndpointError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/InvalidCMSEndpointError.md
@@ -33,7 +33,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L20)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/errors.ts#L20)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/InvalidCMSEndpointError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/InvalidCMSEndpointError.md
@@ -33,7 +33,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/errors.ts#L20)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L20)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/NextDrupalHealthCheck.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/NextDrupalHealthCheck.md
@@ -34,7 +34,7 @@ DrupalHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L26)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L26)
 
 ## Properties
 
@@ -44,7 +44,7 @@ DrupalHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L20)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L20)
 
 ---
 
@@ -54,7 +54,7 @@ DrupalHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L16)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L16)
 
 ---
 
@@ -64,7 +64,7 @@ DrupalHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L17)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L17)
 
 ---
 
@@ -78,7 +78,7 @@ DrupalHealthCheck.clientID
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L15)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L15)
 
 ---
 
@@ -92,7 +92,7 @@ DrupalHealthCheck.endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L13)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L13)
 
 ---
 
@@ -106,7 +106,7 @@ DrupalHealthCheck.envVar
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L14)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L14)
 
 ---
 
@@ -120,7 +120,7 @@ DrupalHealthCheck.hasUmami
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:19](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L19)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:19](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L19)
 
 ---
 
@@ -142,7 +142,7 @@ DrupalHealthCheck.log
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L18)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L18)
 
 ## Methods
 
@@ -166,7 +166,7 @@ DrupalHealthCheck.checkFor200
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:87](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L87)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:87](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L87)
 
 ---
 
@@ -184,7 +184,7 @@ DrupalHealthCheck.checkForUmami
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:99](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L99)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:99](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L99)
 
 ---
 
@@ -202,7 +202,7 @@ DrupalHealthCheck.getURL
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:84](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L84)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:84](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L84)
 
 ---
 
@@ -221,7 +221,7 @@ DrupalHealthCheck.validateAuth
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:158](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L158)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:158](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L158)
 
 ---
 
@@ -240,7 +240,7 @@ DrupalHealthCheck.validateEndpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:105](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L105)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:105](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L105)
 
 ---
 
@@ -259,7 +259,7 @@ DrupalHealthCheck.validateMenu
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L119)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L119)
 
 ---
 
@@ -278,7 +278,7 @@ DrupalHealthCheck.validatePreview
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:207](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L207)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:207](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L207)
 
 ---
 
@@ -297,4 +297,4 @@ DrupalHealthCheck.validateRouter
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:133](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L133)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:133](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L133)

--- a/web/docs/Packages/decoupled-kit-health-check/classes/NextDrupalHealthCheck.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/NextDrupalHealthCheck.md
@@ -34,7 +34,7 @@ DrupalHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L26)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L26)
 
 ## Properties
 
@@ -44,7 +44,7 @@ DrupalHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L20)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L20)
 
 ---
 
@@ -54,7 +54,7 @@ DrupalHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L16)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L16)
 
 ---
 
@@ -64,7 +64,7 @@ DrupalHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L17)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L17)
 
 ---
 
@@ -78,7 +78,7 @@ DrupalHealthCheck.clientID
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L15)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L15)
 
 ---
 
@@ -92,7 +92,7 @@ DrupalHealthCheck.endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L13)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L13)
 
 ---
 
@@ -106,7 +106,7 @@ DrupalHealthCheck.envVar
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L14)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L14)
 
 ---
 
@@ -120,7 +120,7 @@ DrupalHealthCheck.hasUmami
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:19](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L19)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:19](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L19)
 
 ---
 
@@ -142,7 +142,7 @@ DrupalHealthCheck.log
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L18)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L18)
 
 ## Methods
 
@@ -166,7 +166,7 @@ DrupalHealthCheck.checkFor200
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:87](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L87)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:87](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L87)
 
 ---
 
@@ -184,7 +184,7 @@ DrupalHealthCheck.checkForUmami
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:99](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L99)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:99](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L99)
 
 ---
 
@@ -202,7 +202,7 @@ DrupalHealthCheck.getURL
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:84](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L84)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:84](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L84)
 
 ---
 
@@ -221,7 +221,7 @@ DrupalHealthCheck.validateAuth
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:158](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L158)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:158](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L158)
 
 ---
 
@@ -240,7 +240,7 @@ DrupalHealthCheck.validateEndpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:105](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L105)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:105](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L105)
 
 ---
 
@@ -259,7 +259,7 @@ DrupalHealthCheck.validateMenu
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L119)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L119)
 
 ---
 
@@ -278,7 +278,7 @@ DrupalHealthCheck.validatePreview
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:207](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L207)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:207](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L207)
 
 ---
 
@@ -297,4 +297,4 @@ DrupalHealthCheck.validateRouter
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:133](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L133)
+[packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts:133](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextDrupalHealthCheck.ts#L133)

--- a/web/docs/Packages/decoupled-kit-health-check/classes/NextWordPressHealthCheck.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/NextWordPressHealthCheck.md
@@ -34,7 +34,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L24)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L24)
 
 ## Properties
 
@@ -44,7 +44,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L15)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L15)
 
 ---
 
@@ -54,7 +54,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L18)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L18)
 
 ---
 
@@ -64,7 +64,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L16)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L16)
 
 ---
 
@@ -78,7 +78,7 @@ WordPressHealthCheck.appUsername
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L14)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L14)
 
 ---
 
@@ -92,7 +92,7 @@ WordPressHealthCheck.endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L12)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L12)
 
 ---
 
@@ -106,7 +106,7 @@ WordPressHealthCheck.envVar
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L13)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L13)
 
 ---
 
@@ -128,7 +128,7 @@ WordPressHealthCheck.log
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L17)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L17)
 
 ## Methods
 
@@ -152,7 +152,7 @@ WordPressHealthCheck.checkFor200
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:88](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L88)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:88](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L88)
 
 ---
 
@@ -170,7 +170,7 @@ WordPressHealthCheck.getURL
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:83](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L83)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:83](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L83)
 
 ---
 
@@ -189,7 +189,7 @@ WordPressHealthCheck.validateAuth
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:146](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L146)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:146](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L146)
 
 ---
 
@@ -208,7 +208,7 @@ WordPressHealthCheck.validateEndpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:105](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L105)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:105](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L105)
 
 ---
 
@@ -227,7 +227,7 @@ WordPressHealthCheck.validateMenu
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L119)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L119)
 
 ---
 
@@ -246,4 +246,4 @@ WordPressHealthCheck.validatePreview
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:204](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L204)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:204](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L204)

--- a/web/docs/Packages/decoupled-kit-health-check/classes/NextWordPressHealthCheck.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/NextWordPressHealthCheck.md
@@ -34,7 +34,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L24)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L24)
 
 ## Properties
 
@@ -44,7 +44,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L15)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:15](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L15)
 
 ---
 
@@ -54,7 +54,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L18)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L18)
 
 ---
 
@@ -64,7 +64,7 @@ WordPressHealthCheck.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L16)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L16)
 
 ---
 
@@ -78,7 +78,7 @@ WordPressHealthCheck.appUsername
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L14)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:14](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L14)
 
 ---
 
@@ -92,7 +92,7 @@ WordPressHealthCheck.endpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L12)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L12)
 
 ---
 
@@ -106,7 +106,7 @@ WordPressHealthCheck.envVar
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L13)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L13)
 
 ---
 
@@ -128,7 +128,7 @@ WordPressHealthCheck.log
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L17)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:17](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L17)
 
 ## Methods
 
@@ -152,7 +152,7 @@ WordPressHealthCheck.checkFor200
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:88](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L88)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:88](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L88)
 
 ---
 
@@ -170,7 +170,7 @@ WordPressHealthCheck.getURL
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:83](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L83)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:83](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L83)
 
 ---
 
@@ -189,7 +189,7 @@ WordPressHealthCheck.validateAuth
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:146](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L146)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:146](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L146)
 
 ---
 
@@ -208,7 +208,7 @@ WordPressHealthCheck.validateEndpoint
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:105](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L105)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:105](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L105)
 
 ---
 
@@ -227,7 +227,7 @@ WordPressHealthCheck.validateMenu
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L119)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:119](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L119)
 
 ---
 
@@ -246,4 +246,4 @@ WordPressHealthCheck.validatePreview
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:204](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L204)
+[packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts:204](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/NextWordPressHealthCheck.ts#L204)

--- a/web/docs/Packages/decoupled-kit-health-check/classes/WPGatsbyPluginError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/WPGatsbyPluginError.md
@@ -33,7 +33,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:52](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/classes/errors.ts#L52)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:52](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L52)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/WPGatsbyPluginError.md
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/WPGatsbyPluginError.md
@@ -33,7 +33,7 @@ HealthCheckError.constructor
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/classes/errors.ts:52](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/classes/errors.ts#L52)
+[packages/decoupled-kit-health-check/src/classes/errors.ts:52](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/classes/errors.ts#L52)
 
 ## Properties
 

--- a/web/docs/Packages/decoupled-kit-health-check/classes/_category_.yml
+++ b/web/docs/Packages/decoupled-kit-health-check/classes/_category_.yml
@@ -1,2 +1,2 @@
-label: "Classes"
+label: 'Classes'
 position: 3

--- a/web/docs/Packages/decoupled-kit-health-check/index.md
+++ b/web/docs/Packages/decoupled-kit-health-check/index.md
@@ -54,3 +54,9 @@ In the directory of your `next-wordpress` or `gatsby-wordpress` project:
 ```bash
 npx @pantheon-systems/decoupled-kit-health-check wordpress
 ```
+
+## Opt Out
+
+To opt out of the health check without changing any configuration in the
+`package.json`, set the `NO_DKHC` environment variable. If this variable is set
+to anything, the health check will be skipped.

--- a/web/docs/Packages/decoupled-kit-health-check/modules.md
+++ b/web/docs/Packages/decoupled-kit-health-check/modules.md
@@ -34,7 +34,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/utils/logger.ts:1](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/utils/logger.ts#L1)
+[packages/decoupled-kit-health-check/src/utils/logger.ts:1](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/utils/logger.ts#L1)
 
 ## Functions
 
@@ -48,7 +48,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/utils/getFramework.ts:4](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/utils/getFramework.ts#L4)
+[packages/decoupled-kit-health-check/src/utils/getFramework.ts:4](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/utils/getFramework.ts#L4)
 
 ---
 
@@ -67,4 +67,4 @@ the path to a .env file or undefined
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/utils/resolveDotenvFile.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/decoupled-kit-health-check/src/utils/resolveDotenvFile.ts#L20)
+[packages/decoupled-kit-health-check/src/utils/resolveDotenvFile.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/utils/resolveDotenvFile.ts#L20)

--- a/web/docs/Packages/decoupled-kit-health-check/modules.md
+++ b/web/docs/Packages/decoupled-kit-health-check/modules.md
@@ -34,7 +34,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/utils/logger.ts:1](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/utils/logger.ts#L1)
+[packages/decoupled-kit-health-check/src/utils/logger.ts:1](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/utils/logger.ts#L1)
 
 ## Functions
 
@@ -48,7 +48,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/utils/getFramework.ts:4](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/utils/getFramework.ts#L4)
+[packages/decoupled-kit-health-check/src/utils/getFramework.ts:4](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/utils/getFramework.ts#L4)
 
 ---
 
@@ -67,4 +67,4 @@ the path to a .env file or undefined
 
 #### Defined in
 
-[packages/decoupled-kit-health-check/src/utils/resolveDotenvFile.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/decoupled-kit-health-check/src/utils/resolveDotenvFile.ts#L20)
+[packages/decoupled-kit-health-check/src/utils/resolveDotenvFile.ts:20](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/decoupled-kit-health-check/src/utils/resolveDotenvFile.ts#L20)

--- a/web/docs/Packages/drupal-kit/_category_.yml
+++ b/web/docs/Packages/drupal-kit/_category_.yml
@@ -1,2 +1,2 @@
-label: "drupal-kit"
+label: 'drupal-kit'
 position: 0

--- a/web/docs/Packages/drupal-kit/classes/DrupalState.md
+++ b/web/docs/Packages/drupal-kit/classes/DrupalState.md
@@ -36,7 +36,7 @@ DrupalState.constructor
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/PantheonDrupalState.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L18)
+[packages/drupal-kit/src/lib/PantheonDrupalState.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L18)
 
 ## Properties
 
@@ -356,7 +356,7 @@ DrupalState.fetchData
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/PantheonDrupalState.ts:46](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L46)
+[packages/drupal-kit/src/lib/PantheonDrupalState.ts:46](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L46)
 
 ---
 
@@ -439,7 +439,7 @@ DrupalState.getObject
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/PantheonDrupalState.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L70)
+[packages/drupal-kit/src/lib/PantheonDrupalState.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L70)
 
 ---
 
@@ -470,4 +470,4 @@ DrupalState.getObjectByPath
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/PantheonDrupalState.ts:75](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L75)
+[packages/drupal-kit/src/lib/PantheonDrupalState.ts:75](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L75)

--- a/web/docs/Packages/drupal-kit/classes/DrupalState.md
+++ b/web/docs/Packages/drupal-kit/classes/DrupalState.md
@@ -36,7 +36,7 @@ DrupalState.constructor
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/PantheonDrupalState.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L18)
+[packages/drupal-kit/src/lib/PantheonDrupalState.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L18)
 
 ## Properties
 
@@ -356,7 +356,7 @@ DrupalState.fetchData
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/PantheonDrupalState.ts:46](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L46)
+[packages/drupal-kit/src/lib/PantheonDrupalState.ts:46](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L46)
 
 ---
 
@@ -439,7 +439,7 @@ DrupalState.getObject
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/PantheonDrupalState.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L70)
+[packages/drupal-kit/src/lib/PantheonDrupalState.ts:70](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L70)
 
 ---
 
@@ -470,4 +470,4 @@ DrupalState.getObjectByPath
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/PantheonDrupalState.ts:75](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L75)
+[packages/drupal-kit/src/lib/PantheonDrupalState.ts:75](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/drupal-kit/src/lib/PantheonDrupalState.ts#L75)

--- a/web/docs/Packages/drupal-kit/classes/_category_.yml
+++ b/web/docs/Packages/drupal-kit/classes/_category_.yml
@@ -1,2 +1,2 @@
-label: "Classes"
+label: 'Classes'
 position: 3

--- a/web/docs/Packages/drupal-kit/modules.md
+++ b/web/docs/Packages/drupal-kit/modules.md
@@ -36,7 +36,7 @@ a promise containing the data for the JSON:API response
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/defaultFetch.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/defaultFetch.ts#L16)
+[packages/drupal-kit/src/lib/defaultFetch.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/drupal-kit/src/lib/defaultFetch.ts#L16)
 
 ---
 
@@ -94,7 +94,7 @@ for more information about the Drupal Search API.
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/getDrupalSearchResults.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/getDrupalSearchResults.ts#L23)
+[packages/drupal-kit/src/lib/getDrupalSearchResults.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/drupal-kit/src/lib/getDrupalSearchResults.ts#L23)
 
 ---
 

--- a/web/docs/Packages/drupal-kit/modules.md
+++ b/web/docs/Packages/drupal-kit/modules.md
@@ -36,7 +36,7 @@ a promise containing the data for the JSON:API response
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/defaultFetch.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/drupal-kit/src/lib/defaultFetch.ts#L16)
+[packages/drupal-kit/src/lib/defaultFetch.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/defaultFetch.ts#L16)
 
 ---
 
@@ -94,7 +94,7 @@ for more information about the Drupal Search API.
 
 #### Defined in
 
-[packages/drupal-kit/src/lib/getDrupalSearchResults.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/drupal-kit/src/lib/getDrupalSearchResults.ts#L23)
+[packages/drupal-kit/src/lib/getDrupalSearchResults.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/drupal-kit/src/lib/getDrupalSearchResults.ts#L23)
 
 ---
 

--- a/web/docs/Packages/nextjs-kit/_category_.yml
+++ b/web/docs/Packages/nextjs-kit/_category_.yml
@@ -1,2 +1,2 @@
-label: "nextjs-kit"
+label: 'nextjs-kit'
 position: 3

--- a/web/docs/Packages/nextjs-kit/interfaces/ContentProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/ContentProps.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L6)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/contentWithImage.tsx#L6)
 
 ---
 
@@ -24,7 +24,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L12)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/contentWithImage.tsx#L12)
 
 ---
 
@@ -34,7 +34,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L7)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/contentWithImage.tsx#L7)
 
 ---
 
@@ -51,7 +51,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L8)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/contentWithImage.tsx#L8)
 
 ---
 
@@ -61,4 +61,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L5)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/contentWithImage.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/ContentProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/ContentProps.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/contentWithImage.tsx#L6)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L6)
 
 ---
 
@@ -24,7 +24,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/contentWithImage.tsx#L12)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L12)
 
 ---
 
@@ -34,7 +34,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/contentWithImage.tsx#L7)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L7)
 
 ---
 
@@ -51,7 +51,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/contentWithImage.tsx#L8)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L8)
 
 ---
 
@@ -61,4 +61,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/contentWithImage.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/contentWithImage.tsx#L5)
+[packages/nextjs-kit/src/components/contentWithImage.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/contentWithImage.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/FooterMenuProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/FooterMenuProps.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/footer.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/footer.tsx#L6)
+[packages/nextjs-kit/src/components/footer.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/footer.tsx#L6)
 
 ---
 
@@ -24,4 +24,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/footer.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/footer.tsx#L5)
+[packages/nextjs-kit/src/components/footer.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/footer.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/FooterMenuProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/FooterMenuProps.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/footer.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/footer.tsx#L6)
+[packages/nextjs-kit/src/components/footer.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/footer.tsx#L6)
 
 ---
 
@@ -24,4 +24,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/footer.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/footer.tsx#L5)
+[packages/nextjs-kit/src/components/footer.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/footer.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/HeaderProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/HeaderProps.md
@@ -14,4 +14,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/header.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/header.tsx#L5)
+[packages/nextjs-kit/src/components/header.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/header.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/HeaderProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/HeaderProps.md
@@ -14,4 +14,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/header.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/header.tsx#L5)
+[packages/nextjs-kit/src/components/header.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/header.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/LinkProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/LinkProps.md
@@ -18,7 +18,7 @@ The href to apply to the link.
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L30)
+[packages/nextjs-kit/src/types.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/types.ts#L30)
 
 ---
 
@@ -30,4 +30,4 @@ The text to display in the link
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L26)
+[packages/nextjs-kit/src/types.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/types.ts#L26)

--- a/web/docs/Packages/nextjs-kit/interfaces/LinkProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/LinkProps.md
@@ -18,7 +18,7 @@ The href to apply to the link.
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/types.ts#L30)
+[packages/nextjs-kit/src/types.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L30)
 
 ---
 
@@ -30,4 +30,4 @@ The text to display in the link
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/types.ts#L26)
+[packages/nextjs-kit/src/types.ts:26](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L26)

--- a/web/docs/Packages/nextjs-kit/interfaces/PaginationProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/PaginationProps.md
@@ -24,7 +24,7 @@ The React component to render for each datum
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L39)
+[packages/nextjs-kit/src/components/paginator.tsx:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/paginator.tsx#L39)
 
 ---
 
@@ -52,7 +52,7 @@ end = 25, then add should be 5 or 10.
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:27](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L27)
+[packages/nextjs-kit/src/components/paginator.tsx:27](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/paginator.tsx#L27)
 
 ---
 
@@ -64,7 +64,7 @@ The type of data to paginate
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L12)
+[packages/nextjs-kit/src/components/paginator.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/paginator.tsx#L12)
 
 ---
 
@@ -76,7 +76,7 @@ Number of items per page
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L16)
+[packages/nextjs-kit/src/components/paginator.tsx:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/paginator.tsx#L16)
 
 ---
 
@@ -89,4 +89,4 @@ If true, uses Next.js shallow routing
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:35](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L35)
+[packages/nextjs-kit/src/components/paginator.tsx:35](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/paginator.tsx#L35)

--- a/web/docs/Packages/nextjs-kit/interfaces/PaginationProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/PaginationProps.md
@@ -24,7 +24,7 @@ The React component to render for each datum
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/paginator.tsx#L39)
+[packages/nextjs-kit/src/components/paginator.tsx:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L39)
 
 ---
 
@@ -52,7 +52,7 @@ end = 25, then add should be 5 or 10.
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:27](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/paginator.tsx#L27)
+[packages/nextjs-kit/src/components/paginator.tsx:27](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L27)
 
 ---
 
@@ -64,7 +64,7 @@ The type of data to paginate
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/paginator.tsx#L12)
+[packages/nextjs-kit/src/components/paginator.tsx:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L12)
 
 ---
 
@@ -76,7 +76,7 @@ Number of items per page
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/paginator.tsx#L16)
+[packages/nextjs-kit/src/components/paginator.tsx:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L16)
 
 ---
 
@@ -89,4 +89,4 @@ If true, uses Next.js shallow routing
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:35](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/paginator.tsx#L35)
+[packages/nextjs-kit/src/components/paginator.tsx:35](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L35)

--- a/web/docs/Packages/nextjs-kit/interfaces/PreviewRibbonProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/PreviewRibbonProps.md
@@ -14,4 +14,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/previewRibbon.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/previewRibbon.tsx#L5)
+[packages/nextjs-kit/src/components/previewRibbon.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/previewRibbon.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/PreviewRibbonProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/PreviewRibbonProps.md
@@ -14,4 +14,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/previewRibbon.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/previewRibbon.tsx#L5)
+[packages/nextjs-kit/src/components/previewRibbon.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/previewRibbon.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/RecipeProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/RecipeProps.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L6)
+[packages/nextjs-kit/src/components/recipe.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/recipe.tsx#L6)
 
 ---
 
@@ -24,7 +24,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L13)
+[packages/nextjs-kit/src/components/recipe.tsx:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/recipe.tsx#L13)
 
 ---
 
@@ -41,7 +41,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L9)
+[packages/nextjs-kit/src/components/recipe.tsx:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/recipe.tsx#L9)
 
 ---
 
@@ -51,7 +51,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L7)
+[packages/nextjs-kit/src/components/recipe.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/recipe.tsx#L7)
 
 ---
 
@@ -61,7 +61,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L8)
+[packages/nextjs-kit/src/components/recipe.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/recipe.tsx#L8)
 
 ---
 
@@ -71,4 +71,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L5)
+[packages/nextjs-kit/src/components/recipe.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/recipe.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/RecipeProps.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/RecipeProps.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/recipe.tsx#L6)
+[packages/nextjs-kit/src/components/recipe.tsx:6](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L6)
 
 ---
 
@@ -24,7 +24,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/recipe.tsx#L13)
+[packages/nextjs-kit/src/components/recipe.tsx:13](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L13)
 
 ---
 
@@ -41,7 +41,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/recipe.tsx#L9)
+[packages/nextjs-kit/src/components/recipe.tsx:9](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L9)
 
 ---
 
@@ -51,7 +51,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/recipe.tsx#L7)
+[packages/nextjs-kit/src/components/recipe.tsx:7](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L7)
 
 ---
 
@@ -61,7 +61,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/recipe.tsx#L8)
+[packages/nextjs-kit/src/components/recipe.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L8)
 
 ---
 
@@ -71,4 +71,4 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/recipe.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/recipe.tsx#L5)
+[packages/nextjs-kit/src/components/recipe.tsx:5](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/recipe.tsx#L5)

--- a/web/docs/Packages/nextjs-kit/interfaces/SortOptions.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/SortOptions.md
@@ -18,7 +18,7 @@ The data to be sorted
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/types.ts#L8)
+[packages/nextjs-kit/src/types.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L8)
 
 ---
 
@@ -30,7 +30,7 @@ The direction to sort the data
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/types.ts#L16)
+[packages/nextjs-kit/src/types.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L16)
 
 ---
 
@@ -42,4 +42,4 @@ The key on which to sort
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/types.ts#L12)
+[packages/nextjs-kit/src/types.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L12)

--- a/web/docs/Packages/nextjs-kit/interfaces/SortOptions.md
+++ b/web/docs/Packages/nextjs-kit/interfaces/SortOptions.md
@@ -18,7 +18,7 @@ The data to be sorted
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L8)
+[packages/nextjs-kit/src/types.ts:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/types.ts#L8)
 
 ---
 
@@ -30,7 +30,7 @@ The direction to sort the data
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L16)
+[packages/nextjs-kit/src/types.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/types.ts#L16)
 
 ---
 
@@ -42,4 +42,4 @@ The key on which to sort
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L12)
+[packages/nextjs-kit/src/types.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/types.ts#L12)

--- a/web/docs/Packages/nextjs-kit/interfaces/_category_.yml
+++ b/web/docs/Packages/nextjs-kit/interfaces/_category_.yml
@@ -1,2 +1,2 @@
-label: "Interfaces"
+label: 'Interfaces'
 position: 4

--- a/web/docs/Packages/nextjs-kit/modules.md
+++ b/web/docs/Packages/nextjs-kit/modules.md
@@ -32,7 +32,7 @@ This should account for Drupal and WordPress menus
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/types.ts#L39)
+[packages/nextjs-kit/src/types.ts:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L39)
 
 ---
 
@@ -42,7 +42,7 @@ This should account for Drupal and WordPress menus
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:33](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/types.ts#L33)
+[packages/nextjs-kit/src/types.ts:33](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L33)
 
 ## Functions
 
@@ -146,7 +146,7 @@ HOC component
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/grid.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/grid.tsx#L8)
+[packages/nextjs-kit/src/components/grid.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/grid.tsx#L8)
 
 ---
 
@@ -232,7 +232,7 @@ for a full example implementation
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:82](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/paginator.tsx#L82)
+[packages/nextjs-kit/src/components/paginator.tsx:82](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L82)
 
 ---
 
@@ -314,7 +314,7 @@ An array of data sorted by the given key and direction
 
 #### Defined in
 
-[packages/nextjs-kit/src/utils/sortChar.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/utils/sortChar.ts#L12)
+[packages/nextjs-kit/src/utils/sortChar.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/utils/sortChar.ts#L12)
 
 ---
 
@@ -339,7 +339,7 @@ An array of data sorted by the given key and direction
 
 #### Defined in
 
-[packages/nextjs-kit/src/utils/sortDate.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/utils/sortDate.ts#L11)
+[packages/nextjs-kit/src/utils/sortDate.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/utils/sortDate.ts#L11)
 
 ---
 
@@ -431,4 +431,4 @@ const MyPage = ({ myArticles }) => {
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/grid.tsx:59](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/nextjs-kit/src/components/grid.tsx#L59)
+[packages/nextjs-kit/src/components/grid.tsx:59](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/grid.tsx#L59)

--- a/web/docs/Packages/nextjs-kit/modules.md
+++ b/web/docs/Packages/nextjs-kit/modules.md
@@ -32,7 +32,7 @@ This should account for Drupal and WordPress menus
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L39)
+[packages/nextjs-kit/src/types.ts:39](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/types.ts#L39)
 
 ---
 
@@ -42,7 +42,7 @@ This should account for Drupal and WordPress menus
 
 #### Defined in
 
-[packages/nextjs-kit/src/types.ts:33](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/types.ts#L33)
+[packages/nextjs-kit/src/types.ts:33](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/types.ts#L33)
 
 ## Functions
 
@@ -146,7 +146,7 @@ HOC component
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/grid.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/grid.tsx#L8)
+[packages/nextjs-kit/src/components/grid.tsx:8](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/grid.tsx#L8)
 
 ---
 
@@ -232,7 +232,7 @@ for a full example implementation
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/paginator.tsx:82](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/paginator.tsx#L82)
+[packages/nextjs-kit/src/components/paginator.tsx:82](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/paginator.tsx#L82)
 
 ---
 
@@ -314,7 +314,7 @@ An array of data sorted by the given key and direction
 
 #### Defined in
 
-[packages/nextjs-kit/src/utils/sortChar.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/utils/sortChar.ts#L12)
+[packages/nextjs-kit/src/utils/sortChar.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/utils/sortChar.ts#L12)
 
 ---
 
@@ -339,7 +339,7 @@ An array of data sorted by the given key and direction
 
 #### Defined in
 
-[packages/nextjs-kit/src/utils/sortDate.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/utils/sortDate.ts#L11)
+[packages/nextjs-kit/src/utils/sortDate.ts:11](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/utils/sortDate.ts#L11)
 
 ---
 
@@ -431,4 +431,4 @@ const MyPage = ({ myArticles }) => {
 
 #### Defined in
 
-[packages/nextjs-kit/src/components/grid.tsx:59](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/nextjs-kit/src/components/grid.tsx#L59)
+[packages/nextjs-kit/src/components/grid.tsx:59](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/nextjs-kit/src/components/grid.tsx#L59)

--- a/web/docs/Packages/wordpress-kit/_category_.yml
+++ b/web/docs/Packages/wordpress-kit/_category_.yml
@@ -1,2 +1,2 @@
-label: "wordpress-kit"
+label: 'wordpress-kit'
 position: 1

--- a/web/docs/Packages/wordpress-kit/classes/GraphqlClientFactory.md
+++ b/web/docs/Packages/wordpress-kit/classes/GraphqlClientFactory.md
@@ -31,7 +31,7 @@ options - A RequestConfig object.
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L18)
+[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L18)
 
 ## Properties
 
@@ -43,7 +43,7 @@ A WordPress GraphQL endpoint
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L12)
+[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L12)
 
 ---
 
@@ -55,7 +55,7 @@ RequestOptions
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L16)
+[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L16)
 
 ## Methods
 
@@ -72,4 +72,4 @@ options
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:34](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L34)
+[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:34](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L34)

--- a/web/docs/Packages/wordpress-kit/classes/GraphqlClientFactory.md
+++ b/web/docs/Packages/wordpress-kit/classes/GraphqlClientFactory.md
@@ -31,7 +31,7 @@ options - A RequestConfig object.
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L18)
+[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:18](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L18)
 
 ## Properties
 
@@ -43,7 +43,7 @@ A WordPress GraphQL endpoint
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L12)
+[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:12](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L12)
 
 ---
 
@@ -55,7 +55,7 @@ RequestOptions
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L16)
+[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:16](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L16)
 
 ## Methods
 
@@ -72,4 +72,4 @@ options
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:34](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L34)
+[packages/wordpress-kit/src/lib/GraphQLClientFactory.ts:34](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/lib/GraphQLClientFactory.ts#L34)

--- a/web/docs/Packages/wordpress-kit/classes/_category_.yml
+++ b/web/docs/Packages/wordpress-kit/classes/_category_.yml
@@ -1,2 +1,2 @@
-label: "Classes"
+label: 'Classes'
 position: 3

--- a/web/docs/Packages/wordpress-kit/modules.md
+++ b/web/docs/Packages/wordpress-kit/modules.md
@@ -27,7 +27,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:220](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L220)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:220](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L220)
 
 ---
 
@@ -60,7 +60,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:4](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L4)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:4](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L4)
 
 ---
 
@@ -78,7 +78,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:227](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L227)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:227](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L227)
 
 ---
 
@@ -97,7 +97,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L30)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L30)
 
 ---
 
@@ -114,7 +114,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:233](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L233)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:233](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L233)
 
 ---
 
@@ -131,7 +131,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:25](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L25)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:25](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L25)
 
 ---
 
@@ -142,7 +142,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:238](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L238)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:238](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L238)
 
 ---
 
@@ -173,7 +173,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:246](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L246)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:246](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L246)
 
 ---
 
@@ -196,7 +196,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:37](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L37)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:37](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L37)
 
 ## Variables
 
@@ -216,7 +216,7 @@ classes.
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/index.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/index.ts#L24)
+[packages/wordpress-kit/src/tailwindcssPlugin/index.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/tailwindcssPlugin/index.ts#L24)
 
 ## Functions
 
@@ -282,7 +282,7 @@ Sets response headers for edge caching.
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/setEdgeHeader.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/setEdgeHeader.ts#L10)
+[packages/wordpress-kit/src/lib/setEdgeHeader.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/lib/setEdgeHeader.ts#L10)
 
 ---
 
@@ -307,7 +307,7 @@ content
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/setOutgoingHeaders.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/setOutgoingHeaders.ts#L23)
+[packages/wordpress-kit/src/lib/setOutgoingHeaders.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/32b3f2995/packages/wordpress-kit/src/lib/setOutgoingHeaders.ts#L23)
 
 ---
 

--- a/web/docs/Packages/wordpress-kit/modules.md
+++ b/web/docs/Packages/wordpress-kit/modules.md
@@ -27,7 +27,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:220](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L220)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:220](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L220)
 
 ---
 
@@ -60,7 +60,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:4](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L4)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:4](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L4)
 
 ---
 
@@ -78,7 +78,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:227](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L227)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:227](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L227)
 
 ---
 
@@ -97,7 +97,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L30)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:30](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L30)
 
 ---
 
@@ -114,7 +114,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:233](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L233)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:233](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L233)
 
 ---
 
@@ -131,7 +131,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:25](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L25)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:25](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L25)
 
 ---
 
@@ -142,7 +142,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:238](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L238)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:238](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L238)
 
 ---
 
@@ -173,7 +173,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:246](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L246)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:246](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L246)
 
 ---
 
@@ -196,7 +196,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:37](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L37)
+[packages/wordpress-kit/src/tailwindcssPlugin/types.ts:37](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/types.ts#L37)
 
 ## Variables
 
@@ -216,7 +216,7 @@ classes.
 
 #### Defined in
 
-[packages/wordpress-kit/src/tailwindcssPlugin/index.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/tailwindcssPlugin/index.ts#L24)
+[packages/wordpress-kit/src/tailwindcssPlugin/index.ts:24](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/tailwindcssPlugin/index.ts#L24)
 
 ## Functions
 
@@ -282,7 +282,7 @@ Sets response headers for edge caching.
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/setEdgeHeader.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/lib/setEdgeHeader.ts#L10)
+[packages/wordpress-kit/src/lib/setEdgeHeader.ts:10](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/setEdgeHeader.ts#L10)
 
 ---
 
@@ -307,7 +307,7 @@ content
 
 #### Defined in
 
-[packages/wordpress-kit/src/lib/setOutgoingHeaders.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/5049fc03/packages/wordpress-kit/src/lib/setOutgoingHeaders.ts#L23)
+[packages/wordpress-kit/src/lib/setOutgoingHeaders.ts:23](https://github.com/pantheon-systems/decoupled-kit-js/blob/c3dc8b3da/packages/wordpress-kit/src/lib/setOutgoingHeaders.ts#L23)
 
 ---
 

--- a/web/docs/decoupled-kit-overview.mdx
+++ b/web/docs/decoupled-kit-overview.mdx
@@ -16,7 +16,9 @@ using Decoupled Kit components locally or anywhere.
 For more information on Pantheon Front-End Sites, see
 https://docs.pantheon.io/guides/decoupled/
 
-Sections or documents that are related specifically to Pantheon will include this callout at the top of the section or page.
+Sections or documents that are related specifically to Pantheon will include
+this callout at the top of the section or page.
+
 :::
 
 Decoupled Kit is a collection of utilities for building a decoupled front-end

--- a/web/lint-staged.config.js
+++ b/web/lint-staged.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	'./**/*.{js,ts,jsx,tsx,md}': [
+		'prettier --write --ignore-path ../.prettierignore',
+	],
+};

--- a/web/lint-staged.config.js
+++ b/web/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	'./**/*.{js,ts,jsx,tsx,md}': [
+	'./**/*.{js,ts,jsx,tsx,md,mdx,yml}': [
 		'prettier --write --ignore-path ../.prettierignore',
 	],
 };

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,8 @@
 		"serve": "docusaurus serve",
 		"write-translations": "docusaurus write-translations",
 		"write-heading-ids": "docusaurus write-heading-ids",
-		"prettier:fix": "prettier \"**/*.{js,ts,jsx,tsx,md}\" --write --ignore-path ../.prettierignore"
+		"prettier:fix": "prettier \"**/*.{js,ts,jsx,tsx,md}\" --write --ignore-path ../.prettierignore",
+		"lint-staged": "lint-staged"
 	},
 	"dependencies": {
 		"@algolia/client-search": "^4.16.0",

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
 		"serve": "docusaurus serve",
 		"write-translations": "docusaurus write-translations",
 		"write-heading-ids": "docusaurus write-heading-ids",
-		"prettier:fix": "prettier \"**/*.{js,ts,jsx,tsx,md}\" --write --ignore-path ../.prettierignore",
+		"prettier:fix": "prettier \"**/*.{js,ts,jsx,tsx,md,mdx,yml}\" --write --ignore-path ../.prettierignore",
 		"lint-staged": "lint-staged"
 	},
 	"dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
 		"docusaurus": "docusaurus",
 		"start": "docusaurus start",
 		"build": "docusaurus build",
-		"generate-typedoc": "docusaurus generate-typedoc",
+		"generate-typedoc": "docusaurus generate-typedoc && pnpm prettier:fix",
 		"swizzle": "docusaurus swizzle",
 		"deploy": "docusaurus deploy",
 		"clear": "docusaurus clear",


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
🔎 CLI docs went missing? found them! 😅
- Ignore `scripts` to ensure CLI api docs are generated
- Add a lint-staged command to the docs workspace
- Add a lint-staged config to the docs workspace so prettier is run
- Add the docs workspace to the husky pre-commit hook that runs lint-
## Where were the changes made?
staged

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->