### PR TITLE
DB-5856: [docs] Audit uses of back-end and front-end for consistency

### DIFF
--- a/web/docs/Backend Starters/Decoupled Drupal/add-ons.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/add-ons.md
@@ -10,7 +10,7 @@ sidebar_position: 8
 This module automatically configures a Solr search API server for use on
 Pantheon environments and creates an example search index that can be accessed
 via a JSON:API. It can also be used with the Next Drupal Search API add-on to
-simplify the process of configuring search for your decoupled front-end.
+simplify the process of configuring search for your decoupled frontend.
 
 ### Before You Begin
 
@@ -62,7 +62,7 @@ following configuration:
 
 The module also adds a JSON:API endpoint for the index to return results.
 Additionally, it automatically indexes content, making it an out-of-the-box
-option to start using the search data in front-end sites.
+option to start using the search data in frontend sites.
 
 ### Contributing
 

--- a/web/docs/Backend Starters/Decoupled Drupal/caching-considerations.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/caching-considerations.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 With the appropriate configuration, Drupal can be configured to cache JSON:API
 endpoints until the underlying content changes. These same routes can also be
-cached on a CDN. This can improve performance for front-end sites that rely on
+cached on a CDN. This can improve performance for frontend sites that rely on
 these API endpoints, and also reduce the load on your CMS in cases where a large
 amount of API requests will be made in a short period of time, like a full site
 build process.

--- a/web/docs/Backend Starters/Decoupled Drupal/configuring-build-hooks.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/configuring-build-hooks.md
@@ -8,7 +8,7 @@ sidebar_position: 4
 ## What Are Build Hooks?
 
 The [Build Hooks](https://www.drupal.org/project/build_hooks) module has the
-capability to trigger builds in one or more front-end sites when any content
+capability to trigger builds in one or more frontend sites when any content
 changes occur, such as creating, updating, or deleting.
 
 ## Installing the Build Hooks Module

--- a/web/docs/Backend Starters/Decoupled Drupal/configuring-existing-project.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/configuring-existing-project.md
@@ -6,10 +6,10 @@ sidebar_position: 1
 ---
 
 While we offer a [backend starter project](./creating-a-new-project) to simplify
-the process of configuring a Drupal site for use with our front-end starter
-kits, you may instead prefer to use an existing Drupal project. Follow the steps
-below to configure an existing Drupal project to work with one of our front-end
-starter kits.
+the process of configuring a Drupal site for use with our frontend starter kits,
+you may instead prefer to use an existing Drupal project. Follow the steps below
+to configure an existing Drupal project to work with one of our frontend starter
+kits.
 
 ## Before You Begin
 
@@ -17,7 +17,7 @@ These instructions assume that you have already installed Drupal using your
 preferred method.
 
 The amount of necessary configuration will vary depending on the features you
-intend to use within your front-end starter kit. As a result, the instructions
+intend to use within your frontend starter kit. As a result, the instructions
 below are broken down into three related sections.
 
 ## 1. Configuring Basic Builds
@@ -68,10 +68,10 @@ Our starter kits assume that there is at least one published article and page in
 your Drupal backend. If your site does not have any article or page content, you
 should create some before proceeding.
 
-### Set the Necessary Front-End Environment Variables
+### Set the Necessary Frontend Environment Variables
 
 At this point, your Drupal site should be configured to allow data to be sourced
-anonymously by the front-end starter kit. Within your front-end project you will
+anonymously by the frontend starter kit. Within your frontend project you will
 also need to set the necessary environment variables to source data from your
 Drupal backend. For anonymous data sourcing you will need to set at least the
 `BACKEND_URL` and `IMAGE_DOMAIN` variables.
@@ -143,13 +143,13 @@ composer require drupal/simple_oauth
   generate public and private keys to be used with the module. For the
   directory, specify `sites/default/files/private` or the path of your choice.
 - Under the Consumer entities settings (Configuration > Web services >
-  Consumers), create a consumer for use with your front-end site.
+  Consumers), create a consumer for use with your frontend site.
   - Provide a label for the consumer.
   - Specify a Client ID and note this for later use.
   - Associate a user with the consumer.
   - Specify a Secret and note this for later use.
 
-### Set the Necessary Front-End Environment Variables
+### Set the Necessary Frontend Environment Variables
 
 For authenticated data sourcing you will need to set the `CLIENT_ID` and
 `CLIENT_SECRET` variables.
@@ -158,7 +158,7 @@ For authenticated data sourcing you will need to set the `CLIENT_ID` and
 
 ## 3. Configuring Preview
 
-If you would like to preview content managed in Drupal on your front-end site,
+If you would like to preview content managed in Drupal on your frontend site,
 follow the additional steps below.
 
 ### Add and Enable Dependencies
@@ -184,7 +184,7 @@ also has the following permissions:
 See the instructions for
 [creating a new preview site configuration](../../backend-starters/decoupled-drupal/configuring-preview-site#creating-a-new-preview-site-configuration).
 
-### Set the Necessary Front-End Environment Variables
+### Set the Necessary Frontend Environment Variables
 
 For preview you will need to set the `PREVIEW_SECRET` variable.
 

--- a/web/docs/Backend Starters/Decoupled Drupal/configuring-existing-project.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/configuring-existing-project.md
@@ -5,11 +5,11 @@ slug: '/backend-starters/decoupled-drupal/configuring-an-existing-project'
 sidebar_position: 1
 ---
 
-While we offer a [back-end starter project](./creating-a-new-project) to
-simplify the process of configuring a Drupal site for use with our front-end
-starter kits, you may instead prefer to use an existing Drupal project. Follow
-the steps below to configure an existing Drupal project to work with one of our
-front-end starter kits.
+While we offer a [backend starter project](./creating-a-new-project) to simplify
+the process of configuring a Drupal site for use with our front-end starter
+kits, you may instead prefer to use an existing Drupal project. Follow the steps
+below to configure an existing Drupal project to work with one of our front-end
+starter kits.
 
 ## Before You Begin
 
@@ -65,15 +65,15 @@ or automatically using the
 ### Create Supporting Content
 
 Our starter kits assume that there is at least one published article and page in
-your Drupal back-end. If your site does not have any article or page content,
-you should create some before proceeding.
+your Drupal backend. If your site does not have any article or page content, you
+should create some before proceeding.
 
 ### Set the Necessary Front-End Environment Variables
 
 At this point, your Drupal site should be configured to allow data to be sourced
 anonymously by the front-end starter kit. Within your front-end project you will
 also need to set the necessary environment variables to source data from your
-Drupal back-end. For anonymous data sourcing you will need to set at least the
+Drupal backend. For anonymous data sourcing you will need to set at least the
 `BACKEND_URL` and `IMAGE_DOMAIN` variables.
 
 - [Instructions for the Next.js and Drupal starter kit](../../frontend-starters/nextjs/nextjs-drupal/setting-environment-variables)

--- a/web/docs/Backend Starters/Decoupled Drupal/creating-a-new-project.mdx
+++ b/web/docs/Backend Starters/Decoupled Drupal/creating-a-new-project.mdx
@@ -227,7 +227,7 @@ site to Drupal 10, clone the backend site repo and do the following:
    terminus drush <BACKEND_SITE>.<ENV> updatedb
    ```
 
-   Via the Drupal web UI: Visit `/update.php` on your Drupal back-end site, e.g.
+   Via the Drupal web UI: Visit `/update.php` on your Drupal backend site, e.g.
 
    ```
    https://dev-my-decoupled-backend.pantheonsite.io/update.php

--- a/web/docs/Backend Starters/Decoupled Drupal/local-development.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/local-development.md
@@ -12,7 +12,7 @@ The example local environment configurations outlined below are based on
 [Lando installation instructions](https://docs.lando.dev/getting-started/installation.html).
 
 Depending on your role, you may only need a local backend environment, or you
-may instead prefer a local environment that can run both the back-end and
+may instead prefer a local environment that can run both the backend and
 front-end. The following sections outline the steps to set up a local
 environment for each of these use cases.
 

--- a/web/docs/Backend Starters/Decoupled Drupal/local-development.md
+++ b/web/docs/Backend Starters/Decoupled Drupal/local-development.md
@@ -13,8 +13,8 @@ The example local environment configurations outlined below are based on
 
 Depending on your role, you may only need a local backend environment, or you
 may instead prefer a local environment that can run both the backend and
-front-end. The following sections outline the steps to set up a local
-environment for each of these use cases.
+frontend. The following sections outline the steps to set up a local environment
+for each of these use cases.
 
 ## Backend Only Setup
 
@@ -70,18 +70,17 @@ tooling:
 Note: Replace `%SITE-NAME%`, `%PANTHEON_SITE_ID%`, and `%PORT-NUMBER%`, with
 site name, site id and required port number for the frontend site.
 
-- Clone the Front-end Site code base into the `./frontend` directory. You will
-  most likely want to add this directory to your `.gitignore` file for the
-  project.
+- Clone the frontend code base into the `./frontend` directory. You will most
+  likely want to add this directory to your `.gitignore` file for the project.
   ```
   cd frontend
   git clone git@github.com:pantheon-systems/example-fe-site.git .
   ```
 - Consult `.env.example` to create the required environment variables files for
-  your Front-end Site.
+  your frontend site.
 - Run `lando start` to start the containers.
 - Install the Drupal site and select profiles like:
   pantheon_decoupled_umami_demo & pantheon_decoupled_profile.
-- To start your Front-end site, run `lando npm run develop`. It will now be
+- To start your frontend site, run `lando npm run develop`. It will now be
   available at the URL specified in the `proxy` section of the `.lando.yml`
   file.

--- a/web/docs/Backend Starters/Decoupled WordPress/caching-considerations.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/caching-considerations.md
@@ -7,9 +7,9 @@ sidebar_position: 3
 
 With the appropriate configuration, WordPress can be configured to cache GraphQL
 requests on a CDN until the underlying content changes. This can improve
-performance for front-end sites that rely on these endpoints, and also reduce
-the load on your CMS in cases where a large amount of API requests will be made
-in a short period of time, like a full site build process.
+performance for frontend sites that rely on these endpoints, and also reduce the
+load on your CMS in cases where a large amount of API requests will be made in a
+short period of time, like a full site build process.
 
 ## Using the Backend Starter Project
 
@@ -64,9 +64,9 @@ composer require wpackagist-plugin/pantheon-advanced-page-cache
 
 - In the WordPress dashboard, enable the Pantheon Advanced Page Cache plugin.
 
-### Taking Advantage of GraphQL Caching on the Front-end
+### Taking Advantage of GraphQL Caching on the Frontend
 
 For details on how to make full use of WPGraphQL Network Caching in your
-front-end application, see the
+frontend application, see the
 [Surrogate Key Based Cache Purging](/docs/frontend-starters/nextjs/nextjs-wordpress/next-wordpress-surrogate-key-caching)
-entry in the Front-end Starters section of the documentation.
+entry in the Frontend Starters section of the documentation.

--- a/web/docs/Backend Starters/Decoupled WordPress/configuring-existing-project.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/configuring-existing-project.md
@@ -5,10 +5,10 @@ slug: '/backend-starters/decoupled-wordpress/configuring-an-existing-project'
 sidebar_position: 1
 ---
 
-While we offer a backend starter project for use with our front-end starter
-kits, you may instead prefer to use an existing WordPress project. Follow the
-steps below to configure an existing WordPress project to work with one of our
-front-end starter kits.
+While we offer a backend starter project for use with our frontend starter kits,
+you may instead prefer to use an existing WordPress project. Follow the steps
+below to configure an existing WordPress project to work with one of our
+frontend starter kits.
 
 ## Before You begin
 
@@ -19,7 +19,7 @@ preferred method.
 
 - Install and activate the
   [WPGraphQL Plugin](https://wordpress.org/plugins/wp-graphql/).
-- If you are planning on using the Gatsby WordPress front-end starter kit,
+- If you are planning on using the Gatsby WordPress frontend starter kit,
   install and activate the
   [WPGatsby Plugin](https://wordpress.org/plugins/wp-gatsby/). This plugin is
   not required for the Next.js and WordPress starter kit.
@@ -36,10 +36,10 @@ with the name 'Example Menu'. If a menu with this name does not exist, the
 footer menu will not display. The footer component in the starter kit can be
 customized to source data from a different menu.
 
-## Set the Necessary Front-End Environment Variables
+## Set the Necessary Frontend Environment Variables
 
 At this point, your WordPress site should be configured to work with one of our
-front-end starter kits. Within your front-end project you will also need to set
+frontend starter kits. Within your frontend project you will also need to set
 the necessary environment variables to source data from your WordPress backend.
 
 - [Instructions for the Next.js and WordPress starter kit](../../Frontend%20Starters/Next.js/Next.js%20%2B%20WordPress/setting-environment-variables.md)

--- a/web/docs/Backend Starters/Decoupled WordPress/configuring-existing-project.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/configuring-existing-project.md
@@ -5,7 +5,7 @@ slug: '/backend-starters/decoupled-wordpress/configuring-an-existing-project'
 sidebar_position: 1
 ---
 
-While we offer a back-end starter project for use with our front-end starter
+While we offer a backend starter project for use with our front-end starter
 kits, you may instead prefer to use an existing WordPress project. Follow the
 steps below to configure an existing WordPress project to work with one of our
 front-end starter kits.
@@ -27,7 +27,7 @@ preferred method.
 ## Create Supporting Content
 
 Our starter kits assume that there is at least one published post and page in
-your WordPress back-end. A default WordPress install will have a sample of each,
+your WordPress backend. A default WordPress install will have a sample of each,
 but if your site does not have any page or post content, you should create some
 before proceeding.
 
@@ -40,7 +40,7 @@ customized to source data from a different menu.
 
 At this point, your WordPress site should be configured to work with one of our
 front-end starter kits. Within your front-end project you will also need to set
-the necessary environment variables to source data from your WordPress back-end.
+the necessary environment variables to source data from your WordPress backend.
 
 - [Instructions for the Next.js and WordPress starter kit](../../Frontend%20Starters/Next.js/Next.js%20%2B%20WordPress/setting-environment-variables.md)
 - [Instructions for the Gatsby WordPress starter kit](../../Frontend%20Starters/Gatsby/Gatsby%20%2B%20WordPress/setting-environment-variables.md)

--- a/web/docs/Backend Starters/Decoupled WordPress/local-development.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/local-development.md
@@ -13,8 +13,8 @@ The example local environment configurations outlined below are based on
 
 Depending on your role, you may only need a local backend environment, or you
 may instead prefer a local environment that can run both the backend and
-front-end. The following sections outline the steps to set up a local
-environment for each of these use cases.
+frontend. The following sections outline the steps to set up a local environment
+for each of these use cases.
 
 ## Backend Only Setup
 
@@ -70,7 +70,7 @@ tooling:
 Note: Replace `%SITE-NAME%`, `%PANTHEON_SITE_ID%`, and `%PORT-NUMBER%`, with
 site name, site id and required port number for the frontend site.
 
-- Clone the Front-end Site code base into the `./frontend` directory. You will
+- Clone the frontend site code base into the `./frontend` directory. You will
   most likely want to add this directory to your `.gitignore` file for the
   project.
   ```
@@ -78,10 +78,10 @@ site name, site id and required port number for the frontend site.
   git clone git@github.com:pantheon-systems/example-fe-site.git .
   ```
 - Consult `.env.example` to create the required environment variables files for
-  your Front-end Site.
+  your frontend site.
 - Run `lando start` to start the containers.
 - Install the WordPress site and activate the plugin `WP Gatsby` if your
-  Front-end Site is using Gatsby.
-- To start your Front-end site, run `lando npm run develop`. It will now be
+  frontend site is using Gatsby.
+- To start your frontend site, run `lando npm run develop`. It will now be
   available at the URL specified in the `proxy` section of the `.lando.yml`
   file.

--- a/web/docs/Backend Starters/Decoupled WordPress/local-development.md
+++ b/web/docs/Backend Starters/Decoupled WordPress/local-development.md
@@ -12,7 +12,7 @@ The example local environment configurations outlined below are based on
 [Lando installation instructions](https://docs.lando.dev/getting-started/installation.html).
 
 Depending on your role, you may only need a local backend environment, or you
-may instead prefer a local environment that can run both the back-end and
+may instead prefer a local environment that can run both the backend and
 front-end. The following sections outline the steps to set up a local
 environment for each of these use cases.
 

--- a/web/docs/Backend Starters/terminus-decoupled-kit-plugin.md
+++ b/web/docs/Backend Starters/terminus-decoupled-kit-plugin.md
@@ -15,7 +15,7 @@ starter kits.
 
 The `decoupled-kit:create` command guides you through the following tasks:
 
-- Creating a new site on Pantheon for the CMS back-end of your choice.
+- Creating a new site on Pantheon for the CMS backend of your choice.
 - Optionally installing your CMS.
 - Creating a front-end codebase that sources data from your newly created CMS
   project. This codebase will be automatically configured for local development,
@@ -39,7 +39,7 @@ terminus self:plugin:install pantheon-systems/terminus-decoupled-kit-plugin
 
 ### decoupled-kit:create
 
-Creates a back-end CMS site on Pantheon and a front-end codebase that sources
+Creates a backend CMS site on Pantheon and a front-end codebase that sources
 data from the CMS site.
 
 To run interactively:

--- a/web/docs/Backend Starters/terminus-decoupled-kit-plugin.md
+++ b/web/docs/Backend Starters/terminus-decoupled-kit-plugin.md
@@ -17,7 +17,7 @@ The `decoupled-kit:create` command guides you through the following tasks:
 
 - Creating a new site on Pantheon for the CMS backend of your choice.
 - Optionally installing your CMS.
-- Creating a front-end codebase that sources data from your newly created CMS
+- Creating a frontend codebase that sources data from your newly created CMS
   project. This codebase will be automatically configured for local development,
   and can later be deployed to Pantheon using the
   [import repository workflow](https://docs.pantheon.io/guides/decoupled/no-starter-kit/import-repo).
@@ -39,8 +39,8 @@ terminus self:plugin:install pantheon-systems/terminus-decoupled-kit-plugin
 
 ### decoupled-kit:create
 
-Creates a backend CMS site on Pantheon and a front-end codebase that sources
-data from the CMS site.
+Creates a backend CMS site on Pantheon and a frontend codebase that sources data
+from the CMS site.
 
 To run interactively:
 
@@ -95,12 +95,12 @@ Creates a new site named `site`, human-readably labeled `label`, associated with
 ## Related Projects
 
 - [Create Pantheon Decoupled Kit](https://www.npmjs.com/package/create-pantheon-decoupled-kit) -
-  NodeJS CLI used to create and upgrade front-end codebases based on Pantheon
+  NodeJS CLI used to create and upgrade frontend codebases based on Pantheon
   starter kits. Used by this terminus plugin and can also be used independently.
 
 ## Known Limitations
 
-- Currently this terminus plugin creates your front-end codebase, but does not
-  automatically deploy it to Pantheon. You can deploy your front-end codebase to
+- Currently this terminus plugin creates your frontend codebase, but does not
+  automatically deploy it to Pantheon. You can deploy your frontend codebase to
   Pantheon using the
   [import repository workflow](https://docs.pantheon.io/guides/decoupled/no-starter-kit/import-repo).

--- a/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + Drupal/surrogate-key-based-caching.md
@@ -48,7 +48,7 @@ purge content from a cache when the content in Drupal changes.
 :::note
 
 The Decoupled Kit
-[Drupal Back-end Starter Project](../../../Backend%20Starters/Decoupled%20Drupal/creating-a-new-project.mdx)
+[Drupal Backend Starter Project](../../../Backend%20Starters/Decoupled%20Drupal/creating-a-new-project.mdx)
 and [Drupal Next.js Starter Kit](./intro.md) handle the configuration below
 automatically.
 

--- a/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
+++ b/web/docs/Frontend Starters/Next.js/Next.js + WordPress/surrogate-key-based-caching.md
@@ -52,7 +52,7 @@ WordPress changes.
 :::note
 
 The Decoupled Kit
-[WordPress Back-end Starter Project](../../../Backend%20Starters/Decoupled%20WordPress/creating-a-new-project.md)
+[WordPress Backend Starter Project](../../../Backend%20Starters/Decoupled%20WordPress/creating-a-new-project.md)
 and [WordPress Next.js Starter Kit](./intro.md) handle the configuration below
 automatically.
 

--- a/web/docs/decoupled-kit-overview.mdx
+++ b/web/docs/decoupled-kit-overview.mdx
@@ -22,8 +22,8 @@ this callout at the top of the section or page.
 :::
 
 Decoupled Kit is a collection of utilities for building a decoupled front-end
-that sources data from a CMS back-end. Conceptually, a “Kit” is a combination of
-a compatible CMS back end and JavaScript front end. For example, we have kits
+that sources data from a CMS backend. Conceptually, a “Kit” is a combination of
+a compatible CMS backend and JavaScript front end. For example, we have kits
 with WordPress + Gatsby, WordPress + Next.js, and Drupal + Next.js.
 
 At a slightly lower level, Decoupled Kit is a series of CMS starter projects,

--- a/web/docs/decoupled-kit-overview.mdx
+++ b/web/docs/decoupled-kit-overview.mdx
@@ -21,13 +21,13 @@ this callout at the top of the section or page.
 
 :::
 
-Decoupled Kit is a collection of utilities for building a decoupled front-end
+Decoupled Kit is a collection of utilities for building a decoupled frontend
 that sources data from a CMS backend. Conceptually, a “Kit” is a combination of
-a compatible CMS backend and JavaScript front end. For example, we have kits
-with WordPress + Gatsby, WordPress + Next.js, and Drupal + Next.js.
+a compatible CMS backend and JavaScript frontend. For example, we have kits with
+WordPress + Gatsby, WordPress + Next.js, and Drupal + Next.js.
 
 At a slightly lower level, Decoupled Kit is a series of CMS starter projects,
-front-end starter kits, and developer documentation. Let’s take a closer look at
+frontend starter kits, and developer documentation. Let’s take a closer look at
 each of these focus areas.
 
 ## Frontend


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?

Changed to use the term 'backend' in all cases.
Use the term 'frontend' unless the context is the Front-end Sites product.

There was some Slack discussion if this is the correct language long term. I think this change still makes sense as it is small in scope, provides consistency, and doesn't change any URL slugs. We can change again if necessary, and we can account for having to handle redirects and updating dependent links in the estimate.

## Where were the changes made?

Docs md/mdx files.

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

Reviewing docs site locally.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->