### PR TITLE
KIT-46: Fix react-kit storybook deployment

### DIFF
--- a/.github/templates/emtpy-package.json
+++ b/.github/templates/emtpy-package.json
@@ -9,5 +9,8 @@
 		"start": "npm run noop"
 	},
 	"author": "pantheon-systems",
-	"license": "GPL-3.0-or-later"
+	"license": "GPL-3.0-or-later",
+	"engines": {
+		"node": "18"
+	}
 }

--- a/.github/templates/emtpy-package.json
+++ b/.github/templates/emtpy-package.json
@@ -1,0 +1,13 @@
+{
+	"name": "storybook",
+	"private": true,
+	"version": "0.0.0",
+	"description": "For deploying static sites with no dependencies or build step",
+	"scripts": {
+		"noop": ":",
+		"build": "npm run noop",
+		"start": "npm run noop"
+	},
+	"author": "pantheon-systems",
+	"license": "GPL-3.0-or-later"
+}

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -42,10 +42,12 @@ jobs:
           - local_path: 'web'
             split_repository: 'decoupled-kit-docs-canary'
             generator_cmd: ''
+
           # react-kit storybook
           - local_path: 'packages/react-kit'
             split_repository: 'storybook-react-kit'
             generator_cmd: ''
+            build: true
 
     steps:
       - name: Checkout code
@@ -69,6 +71,14 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows
           cp ${{ github.workspace }}/.github/templates/trigger-e2e.yml.template ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows/trigger-e2e.yml
+      
+      - name: Build Storybook
+        if: ${{ matrix.build == true }}
+        run: |
+          pnpm -F ./${{ matrix.local_path }} build-storybook
+          cp ${{ github.workspace }}/.github/templates/empty-package.json ${{ github.workspace }}/${{ matrix.local_path }}/package.json
+          rm -rf !${{ github.workspace }}/${{ matrix.local_path }}/storybook-static
+
 
       - name: Split repos
         uses: 'danharrin/monorepo-split-github-action@v2.3.0'
@@ -91,13 +101,13 @@ jobs:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": "GitHub Action result: ${{ job.status }}\n${{ github.ref }}",
+              "text": "GitHub Action result: ${{ job.status }}\n${{ matrix.split_repository }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Action result: ${{ job.status }}\n${{ github.ref }}"
+                    "text": "GitHub Action result: ${{ job.status }}\n${{ matrix.split_repository }}"
                   }
                 }
               ]

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -45,6 +45,7 @@ jobs:
 
           # react-kit storybook
           - local_path: 'packages/react-kit'
+            out_path: 'storybook/react-kit'
             split_repository: 'storybook-react-kit'
             generator_cmd: ''
             build: true
@@ -71,20 +72,22 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows
           cp ${{ github.workspace }}/.github/templates/trigger-e2e.yml.template ${{ github.workspace }}/${{ matrix.local_path }}/.github/workflows/trigger-e2e.yml
-      
+
+        # build storybook, copy output to a clean dir with the empty package.json
       - name: Build Storybook
         if: ${{ matrix.build == true }}
         run: |
           pnpm -F ./${{ matrix.local_path }} build-storybook
-          cp ${{ github.workspace }}/.github/templates/empty-package.json ${{ github.workspace }}/${{ matrix.local_path }}/package.json
-          rm -rf !${{ github.workspace }}/${{ matrix.local_path }}/storybook-static
+          mkdir -p ./${{ matrix.out_path }}}
+          cp  ${{ github.workspace }}/.github/templates/empty-package.json ./${{ matrix.out_path }}/package.json
+          mv ./${{ matrix.local_path }}/storybook-static ./${{ matrix.out_path }}/storybook-static
 
 
       - name: Split repos
         uses: 'danharrin/monorepo-split-github-action@v2.3.0'
         with:
-          # ↓ split <local_path> directory
-          package_directory: '${{ matrix.local_path }}'
+          # ↓ split <local_path> or <out_path> directory
+          package_directory: ${{ !matrix.out_path && matrix.local_path || matrix.out_path }}
 
           # ↓ into https://github.com/org/split_repository repository
           repository_organization: 'pantheon-systems'

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -82,8 +82,5 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"tailwindcss": "^3.3.3"
-	},
-	"engines": {
-		"node": "18"
 	}
 }

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -82,5 +82,8 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"tailwindcss": "^3.3.3"
+	},
+	"engines": {
+		"node": "18"
 	}
 }


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Since the `react-kit` is a package, we use some workspace configs that are not available in the build container after the repo is split to its mirror. As a workaround, the action now takes `build` and `out_path` vars in the matrix. If build exists it will run `build-storybook` for the package and copy the artifact to `./storybook/{package name}` along with an empty package.json which is necessary for the build container, even if it is not doing the build.
 
## Where were the changes made?
canary-sites-split workflow

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested by running the commands locally and deploying the result to FES.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->