### PR TITLE
KIT-46: Setup pnpm if building storybook

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,43 @@
+name: Setup node
+description: Setup the monorepo and install node, optionally install pnpm
+
+inputs:
+  pnpm:
+    description: If true, also set up pnpm
+    default: 'true'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+
+    - name: Install pnpm
+      if: inputs.pnpm == true
+      uses: pnpm/action-setup@v2
+      with:
+        version: 8.8.0
+        run_install: false
+
+    - name: Get pnpm store directory
+      if: inputs.pnpm == true
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - name: Setup pnpm cache
+      if: inputs.pnpm == true
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      if: inputs.pnpm == true
+      shell: bash
+      run: pnpm install

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,6 @@ description: Setup the monorepo and install node, optionally install pnpm
 inputs:
   pnpm:
     description: If true, also set up pnpm
-    default: 'true'
     required: true
 
 runs:

--- a/.github/workflows/canary-sites-split.yml
+++ b/.github/workflows/canary-sites-split.yml
@@ -56,9 +56,16 @@ jobs:
 
       - name: Setup node
         if: ${{ matrix.generator_cmd != '' }}
-        uses: actions/setup-node@v3
+        uses: ./.github/actions/setup-node
         with:
-          node-version: 18
+          pnpm: false
+
+      - name: Setup node and pmpm
+        if: ${{ matrix.build == true }}
+        uses: ./.github/actions/setup-node
+        with:
+          pnpm: true
+
         # install canary version of the CLI
         # run the command to generate the starter in the matrix.local_path directory
       - name: Generate starter
@@ -81,7 +88,6 @@ jobs:
           mkdir -p ./${{ matrix.out_path }}}
           cp  ${{ github.workspace }}/.github/templates/empty-package.json ./${{ matrix.out_path }}/package.json
           mv ./${{ matrix.local_path }}/storybook-static ./${{ matrix.out_path }}/storybook-static
-
 
       - name: Split repos
         uses: 'danharrin/monorepo-split-github-action@v2.3.0'


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Add a composite action that will setup node, and pnpm if the flag is true.
We should update other actions to use this so we only have to update node and pnpm versions in one spot for our actions, it's easy to miss a file.

## Where were the changes made?
CI
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->