### PR TITLE
KIT-97: Update NextJs to 13.5.6

### DIFF
--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/package.json.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/package.json.ts
@@ -24,7 +24,7 @@ const json: TemplateFn = ({ data, utils }) => /* JSON */ `{
 		"@pantheon-systems/nextjs-kit": "${data.nextjsKitVersion}",
 		${utils.if(data.tailwindcss, tailwindcssDeps(false))}
 		"dotenv": "^16.0.2",
-		"next": "13.4.7",
+		"next": "13.5.6",
 		"next-seo": "^6.1.0",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-wp/package.json.ts
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-wp/package.json.ts
@@ -25,7 +25,7 @@ const json: TemplateFn = ({ data, utils }) => /* JSON */ `{
 		"@pantheon-systems/wordpress-kit": "${data.wordpressKitVersion}",
 		${utils.if(data.tailwindcss, tailwindcssDeps(false))}
 		"dotenv": "^16.0.2",
-		"next": "13.4.7",
+		"next": "13.5.6",
 		"next-seo": "^6.1.0",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",

--- a/packages/nextjs-kit/package.json
+++ b/packages/nextjs-kit/package.json
@@ -88,7 +88,7 @@
 		"autoprefixer": "^10.4.16",
 		"eslint-plugin-prettier": "^5.0.0",
 		"jsdom": "^22.1.0",
-		"next": "13.4.3",
+		"next": "13.5.6",
 		"postcss": "^8.4.30",
 		"prettier": "^3.0.3",
 		"react": "18.2.0",

--- a/packages/nextjs-kit/src/components/contentWithImage.tsx
+++ b/packages/nextjs-kit/src/components/contentWithImage.tsx
@@ -35,7 +35,12 @@ export const ContentWithImage: React.FC<ContentProps> = ({
 	contentClassName = 'ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto',
 }: ContentProps) => {
 	const router = useRouter();
+	let ResolvedImage = Image;
 
+	if ('default' in ResolvedImage) {
+		ResolvedImage = (ResolvedImage as unknown as { default: typeof Image })
+			.default;
+	}
 	return (
 		<article className="ps-prose ps-max-w-none xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-mx-auto ps-py-4 ps-px-12">
 			<section className="ps-prose xs:ps-prose-xs md:ps-prose-md lg:ps-prose-lg ps-mt-10 ps-max-w-screen lg:ps-max-w-screen-lg md:ps-max-w-screen-md sm:ps-max-w-screen-sm ps-mx-auto">
@@ -52,7 +57,7 @@ export const ContentWithImage: React.FC<ContentProps> = ({
 			<div className="ps-mt-12 ps-max-w-screen ps-mx-auto lg:ps-max-w-screen-lg [&*>img]:ps-rounded-lg">
 				{imageProps ? (
 					<div className="ps-relative ps-mb-10 ps-min-h-[50vh]">
-						<Image
+						<ResolvedImage
 							priority
 							src={imageProps.src}
 							style={{

--- a/packages/nextjs-kit/src/components/recipe.tsx
+++ b/packages/nextjs-kit/src/components/recipe.tsx
@@ -1,5 +1,5 @@
-import Image, { type ImageProps } from 'next/image.js';
 import { useRouter } from 'next/compat/router.js';
+import Image, { type ImageProps } from 'next/image.js';
 
 export interface RecipeProps {
 	title: string;
@@ -38,6 +38,12 @@ export const Recipe: React.FC<RecipeProps> = ({
 	children,
 }: RecipeProps) => {
 	const router = useRouter();
+	let ResolvedImage = Image;
+
+	if ('default' in ResolvedImage) {
+		ResolvedImage = (ResolvedImage as unknown as { default: typeof Image })
+			.default;
+	}
 	return (
 		<article className="ps-prose lg:ps-prose-xl ps-mt-10 ps-mx-auto h-fit ps-p-4 sm:ps-p-0">
 			<header>
@@ -56,7 +62,7 @@ export const Recipe: React.FC<RecipeProps> = ({
 			</header>
 			{imageProps ? (
 				<div className="ps-relative ps-max-w-lg ps-mx-auto ps-min-w-full ps-h-[50vh] ps-rounded-lg ps-shadow-lg ps-overflow-hidden ps-mt-12 ps-mb-10">
-					<Image
+					<ResolvedImage
 						priority
 						src={imageProps.src}
 						style={{ objectFit: 'cover', padding: '0', margin: 'auto' }}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Updates nextjs-kit and the starters to 13.5.6.
- Includes workaround for `<Image />` component outlined [here](https://github.com/colbyfayock/next-cloudinary/pull/229).
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Locally.

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->