### PR TITLE
KIT-67: Add slack notification to add-on regression test workflow

### DIFF
--- a/.github/workflows/cli-addon-tests.yml
+++ b/.github/workflows/cli-addon-tests.yml
@@ -85,6 +85,92 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure() || ${{ github.event_name }} != 'push'
         with:
-          name: playwright-report
-          path: playwright-report/
+          name: ${{ matrix.label }}-playwright-report
+          path: ci-tests/playwright-report
           retention-days: 30
+
+      - name: Send Slack message
+        if: success()
+        id: slack-success
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }} Succeeded :large_green_circle:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ matrix.label }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "action_id": "basic_success_view",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+      - name: Send Slack message
+        if: failure()
+        id: slack-failure
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }} Failed :red_circle:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ matrix.label }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "action_id": "basic_failure_view",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Pantheon Systems Decoupled Kits
 
+Tests:
 [![CircleCI](https://circleci.com/gh/pantheon-systems/decoupled-kit-js/tree/canary.svg?style=svg)](https://circleci.com/gh/pantheon-systems/decoupled-kit-js/tree/canary)
+
+![Headless regression testing](https://github.com/pantheon-systems/decoupled-kit-js/actions/workflows/cli-addon-tests.yml/badge.svg)
+![Canary Release](https://github.com/pantheon-systems/decoupled-kit-js/actions/workflows/canary-release.yml/badge.svg)
+![Split Canary Sites](https://github.com/pantheon-systems/decoupled-kit-js/actions/workflows/canary-sites-split.yml/badge.svg)
+![Starter Split and Changesets](https://github.com/pantheon-systems/decoupled-kit-js/actions/workflows/release-and-split.yml/badge.svg)
 
 - [Prerequisites](#prerequisites)
 - [Getting Started](#getting-started)


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Add slack notification step to the cli add-on regression test workflow
- Fix the upload path for the playwright test result
- Added badges for the GitHub actions to the README

## Where were the changes made?
ci-addon-tests workflow, README
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested the blocks in the [slack block builder](https://app.slack.com/block-kit-builder)
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->