### PR TITLE
KIT-67: Add playwright config to generate report

### DIFF
--- a/ci-tests/package.json
+++ b/ci-tests/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"description": "Decoupled Kit Playwright tests run in CI",
 	"scripts": {
+		"playwright": "playwright",
 		"test:next-drupal-search": "playwright test tests/next-drupal-search.spec.ts",
 		"test:next-wp-acf": "playwright test tests/next-wp-acf.spec.ts",
 		"test:gatsby-wp-acf": "playwright test tests/gatsby-wp-acf.spec.ts",

--- a/ci-tests/playwright.config.ts
+++ b/ci-tests/playwright.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+	reporter: [['html', { open: 'never' }]],
+});


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
The playwright trace was not being generated.
Also added `playwright` to the `ci-tests` workspace to be able to run things like `pnpm -F ci-tests playwright show-report if the report is in the `ci-tests/playwright-report` dir.
## Where were the changes made?
`ci-tests` workspace
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->