### PR TITLE
KIT-126: Setup snapshot releases for `feat/*`

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,0 +1,147 @@
+name: Snapshot Release
+
+on:
+  push:
+    branches:
+      - feat/*
+  pull_request:
+    branches:
+      - feat/*
+
+permissions:
+  pull-requests: read
+  contents: write
+
+jobs:
+  snapshot_release:
+    name: Snapshot Release
+    runs-on: ubuntu-latest
+
+    steps:
+      # ensure the github.actor is a member of the team to prevent unauthorized releases
+      - name: Check for authorized user
+        uses: tspascoal/get-user-teams-membership@v3
+        id: check-authorization
+        with:
+          username: ${{ github.actor }}
+          team: 'decoupled-kit'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail if not authorized
+        if: steps.check-authorization.outputs.isTeamMember == 'false'
+        run: exit 1
+          
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup node and pmpm
+        uses: ./.github/actions/setup-node
+        with:
+          pnpm: 'true'
+
+       # there is no action for snapshot releases so we need to add the npm token and run the commands manually  
+      - name: Append npm token to .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            provenance=true
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # https://github.com/changesets/changesets/issues/1195
+      # Snapshots won't work in pre mode so we exit pre mode
+      - name: Exit pre mode
+        run: pnpm changeset pre exit
+
+      - name: Version and publish snapshot release
+        run: |
+          echo "TAG_NAME=$(basename ${{ github.head_ref || github.ref_name }})" >> $GITHUB_ENV
+          pnpm changeset version --snapshot $TAG_NAME
+          pnpm changeset publish -- snapshot --tag $TAG_NAME
+
+      - name: Send Slack success message
+        if: success()
+        id: slack-success
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }} Succeeded :large_green_circle:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Snapshot release for $TAG_NAME released to npm"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "action_id": "basic_success_view",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+      - name: Send Slack failure message
+        if: failure()
+        id: slack-failure
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ github.workflow }} Failed :red_circle:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Snapshot release for $TAG_NAME failed"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "action_id": "basic_failure_view",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           echo "TAG_NAME=$(basename ${{ github.head_ref || github.ref_name }})" >> $GITHUB_ENV
           pnpm changeset version --snapshot $TAG_NAME
-          pnpm changeset publish --snapshot --tag $TAG_NAME
+          pnpm changeset publish --snapshot --no-git-tag --tag $TAG_NAME
 
       - name: Send Slack success message
         if: success()

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           echo "TAG_NAME=$(basename ${{ github.head_ref || github.ref_name }})" >> $GITHUB_ENV
           pnpm changeset version --snapshot $TAG_NAME
-          pnpm changeset publish -- snapshot --tag $TAG_NAME
+          pnpm changeset publish --snapshot --tag $TAG_NAME
 
       - name: Send Slack success message
         if: success()

--- a/configs/prettier.config.js
+++ b/configs/prettier.config.js
@@ -13,7 +13,7 @@ module.exports = {
 			files: ['.github/**/*.yml'],
 			options: {
 				useTabs: false,
-				printWidth: 300,
+				printWidth: Infinity,
 			},
 		},
 	],


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Added a new GitHub Action workflow that does a snapshot release on push or PR to any feat/* branch. It should take the branch name as the tag name.
We may want an action in the future that cleans up snapshots older than X months but for now I don't think it's necessary.

https://github.com/apollographql/apollo-client/blob/main/.github/workflows/snapshot-release.yml#L73C11-L79 was very helpful in writing this.

## Where were the changes made?

CI

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Tested some of the commands locally and asked CoPilot for some help, accuracy on that is TBD
## Additional information

<!--- Add any other context about the feature or fix here. --->
Tried to add a check to make sure the submitter is part of the team to prevent unauthorized access to the releases.



<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->