### PR TITLE
KIT-126: Use team name instead of slug

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -22,7 +22,7 @@ jobs:
         id: check-authorization
         with:
           username: ${{ github.actor }}
-          team: 'decoupled-kit'
+          team: 'Decoupled Kit'
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Fail if not authorized
@@ -37,7 +37,7 @@ jobs:
         with:
           pnpm: 'true'
 
-        # there is no action for snapshot releases so we need to add the npm token and run the commands manually
+      # there is no action for snapshot releases so we need to add the npm token and run the commands manually
       - name: Append npm token to .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
@@ -123,7 +123,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "plain_text",
-                    "text": "Snapshot release for ${{ steps.version-and-publish.outputs.tag_name }} failed"
+                    "text": "Snapshot release for ${{ github.ref }} failed"
                   }
                 },
                 {

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -22,7 +22,7 @@ jobs:
         id: check-authorization
         with:
           username: ${{ github.actor }}
-          team: 'Decoupled Kit'
+          team: ${{ vars.TEAM_NAME }}
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Fail if not authorized


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Use the team name instead of the slug. Docs on the action were not clear which to use but since it failed with the slug I'm guessing this is the fix.
Should we use an action env var here instead?

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->