### PR TITLE
KIT-111: Prevent Caching In Test Preview Route

### DIFF
--- a/.changeset/tender-geckos-smash.md
+++ b/.changeset/tender-geckos-smash.md
@@ -1,0 +1,5 @@
+---
+"create-pantheon-decoupled-kit": patch
+---
+
+[next-drupal] Prevent Caching In Test Preview Route

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
@@ -30,7 +30,7 @@ const preview = async (req, res) => {
 		let content;
 		try {
 			//  Clear access token
-			delete store.token.accessToken;
+			Object.keys(store.token).forEach((v) => (store.token[v] = ''));
 			content = await store.getObjectByPath({
 				objectName,
 				path: slug,

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
@@ -29,6 +29,8 @@ const preview = async (req, res) => {
 		// validate the content
 		let content;
 		try {
+			//  Clear access token
+			delete store.token.accessToken;
 			content = await store.getObjectByPath({
 				objectName,
 				path: slug,
@@ -45,9 +47,6 @@ const preview = async (req, res) => {
 				message: error.message,
 			});
 		}
-
-		//  Clear access token
-		delete store.token.accessToken;
 
 		if (!content) {
 			return res.status(404).json(CONTENT_NOT_FOUND);

--- a/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
+++ b/packages/create-pantheon-decoupled-kit/src/templates/next-drupal/pages/api/preview.js
@@ -32,6 +32,7 @@ const preview = async (req, res) => {
 			content = await store.getObjectByPath({
 				objectName,
 				path: slug,
+				refresh: true,
 			});
 		} catch (error) {
 			process.env.DEBUG_MODE &&
@@ -44,6 +45,10 @@ const preview = async (req, res) => {
 				message: error.message,
 			});
 		}
+
+		//  Clear access token
+		delete store.token.accessToken;
+
 		if (!content) {
 			return res.status(404).json(CONTENT_NOT_FOUND);
 		}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Prevents refresh and clears the `access_token` if `test=true` in the preview route.

## Where were the changes made?
`next-drupal-starter`
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
Locally
## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->