### PR TITLE
KIT-126: Build after version to get proper deps versions in CLI

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           echo "tag_name=$(basename ${{ github.head_ref || github.ref_name }})" >> $GITHUB_OUTPUT
           pnpm changeset version --snapshot $(basename ${{ github.head_ref || github.ref_name }})
+          pnpm build:cli
           pnpm changeset publish --snapshot --no-git-tag --tag $(basename ${{ github.head_ref || github.ref_name }})
 
       - name: Send Slack success message


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Build the CLI after running the version command so that the CLI has any snapshot versions it needs in the templates.
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->