### PR TITLE
KIT-63: Adjust Gatsby Health Check Environment Variable Valid Protocol

### DIFF
--- a/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
@@ -101,4 +101,18 @@ describe('GatsbyWordPressHealthCheck', () => {
 
 		expect(url.href).toEqual('https://wordpress.test/wp/graphql');
 	});
+	it('should fail if no protocol is set for the WPGRAPHQL_URL', async ({
+		logSpy,
+	}) => {
+		process.env['WPGRAPHQL_URL'] = 'wordpress.test';
+		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
+		await HC.validateEndpoint()
+			.then((hc) => hc.validateWPGatsbyPlugin())
+			.then((hc) => hc.validateMenu())
+			.then((hc) => hc.validateAuth())
+			.catch(console.error);
+
+		const result = logSpy.mock.calls.map(([call]) => call);
+		expect(result).toMatchSnapshot();
+	});
 });

--- a/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
@@ -110,7 +110,7 @@ describe('GatsbyWordPressHealthCheck', () => {
 			.then((hc) => hc.validateWPGatsbyPlugin())
 			.then((hc) => hc.validateMenu())
 			.then((hc) => hc.validateAuth())
-			.catch(console.error);
+			.catch((err) => console.log(err.message));
 
 		const result = logSpy.mock.calls.map(([call]) => call);
 		expect(result).toMatchSnapshot();

--- a/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
@@ -27,7 +27,7 @@ describe('GatsbyWordPressHealthCheck', () => {
 	it('should pass for a valid PANTHEON_CMS_ENDPOINT and invalid auth', async ({
 		logSpy,
 	}) => {
-		process.env['PANTHEON_CMS_ENDPOINT'] = 'https://wordpress.test';
+		process.env['PANTHEON_CMS_ENDPOINT'] = 'wordpress.test';
 		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 		await HC.validateEndpoint()
 			.then((hc) => hc.validateWPGatsbyPlugin())
@@ -39,7 +39,7 @@ describe('GatsbyWordPressHealthCheck', () => {
 		expect(result).toMatchSnapshot();
 	});
 	it('should pass for a valid backend and valid auth', async ({ logSpy }) => {
-		process.env['PANTHEON_CMS_ENDPOINT'] = 'https://wordpress.test';
+		process.env['PANTHEON_CMS_ENDPOINT'] = 'wordpress.test';
 		process.env['WP_APPLICATION_USERNAME'] = 'a1b2c3-d4e5g6';
 		process.env['WP_APPLICATION_PASSWORD'] = 'mysecretsecret';
 
@@ -69,7 +69,7 @@ describe('GatsbyWordPressHealthCheck', () => {
 	it('should show a helpful error message if the backend is invalid', async ({
 		logSpy,
 	}) => {
-		process.env['PANTHEON_CMS_ENDPOINT'] = 'https://invalid.wordpress.test';
+		process.env['PANTHEON_CMS_ENDPOINT'] = 'invalid.wordpress.test';
 		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 		await HC.validateEndpoint()
 			.then((hc) => hc.validateWPGatsbyPlugin())

--- a/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
+++ b/packages/decoupled-kit-health-check/__tests__/GatsbyWordPressHealthCheck.test.ts
@@ -27,7 +27,7 @@ describe('GatsbyWordPressHealthCheck', () => {
 	it('should pass for a valid PANTHEON_CMS_ENDPOINT and invalid auth', async ({
 		logSpy,
 	}) => {
-		process.env['PANTHEON_CMS_ENDPOINT'] = 'wordpress.test';
+		process.env['PANTHEON_CMS_ENDPOINT'] = 'https://wordpress.test';
 		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 		await HC.validateEndpoint()
 			.then((hc) => hc.validateWPGatsbyPlugin())
@@ -39,7 +39,7 @@ describe('GatsbyWordPressHealthCheck', () => {
 		expect(result).toMatchSnapshot();
 	});
 	it('should pass for a valid backend and valid auth', async ({ logSpy }) => {
-		process.env['PANTHEON_CMS_ENDPOINT'] = 'wordpress.test';
+		process.env['PANTHEON_CMS_ENDPOINT'] = 'https://wordpress.test';
 		process.env['WP_APPLICATION_USERNAME'] = 'a1b2c3-d4e5g6';
 		process.env['WP_APPLICATION_PASSWORD'] = 'mysecretsecret';
 
@@ -69,7 +69,7 @@ describe('GatsbyWordPressHealthCheck', () => {
 	it('should show a helpful error message if the backend is invalid', async ({
 		logSpy,
 	}) => {
-		process.env['PANTHEON_CMS_ENDPOINT'] = 'invalid.wordpress.test';
+		process.env['PANTHEON_CMS_ENDPOINT'] = 'https://invalid.wordpress.test';
 		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 		await HC.validateEndpoint()
 			.then((hc) => hc.validateWPGatsbyPlugin())
@@ -95,7 +95,7 @@ describe('GatsbyWordPressHealthCheck', () => {
 		expect(result).toMatchSnapshot();
 	});
 	it('should handle a trailing slash in the URL', async () => {
-		process.env['WPGRAPHQL_URL'] = 'wordpress.test/wp/graphql/';
+		process.env['WPGRAPHQL_URL'] = 'https://wordpress.test/wp/graphql/';
 		const HC = new GatsbyWordPressHealthCheck({ env: process.env });
 		const url = HC.getURL();
 

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
@@ -6,6 +6,8 @@ exports[`GatsbyWordPressHealthCheck > should fail if no protocol is set for the 
   "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
   "⎩✅ WPGRAPHQL_URL is set!",
   "Validating CMS endpoint...",
+  "⎩❌ WPGRAPHQL_URL could not be fetched from.
+Check that wordpress.test is valid and provides a 200 response",
 ]
 `;
 

--- a/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
+++ b/packages/decoupled-kit-health-check/__tests__/__snapshots__/GatsbyWordPressHealthCheck.test.ts.snap
@@ -1,5 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`GatsbyWordPressHealthCheck > should fail if no protocol is set for the WPGRAPHQL_URL 1`] = `
+[
+  "No .env* file found, assuming production environment.",
+  "Checking for PANTHEON_CMS_ENDPOINT or WPGRAPHQL_URL...",
+  "⎩✅ WPGRAPHQL_URL is set!",
+  "Validating CMS endpoint...",
+]
+`;
+
 exports[`GatsbyWordPressHealthCheck > should pass for a valid PANTHEON_CMS_ENDPOINT and invalid auth 1`] = `
 [
   "No .env* file found, assuming production environment.",

--- a/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
@@ -73,7 +73,13 @@ export class GatsbyWordPressHealthCheck extends WordPressHealthCheck {
 			? Object.entries(backendVars).filter(([key]) => key === 'WPGRAPHQL_URL')
 			: Object.entries(backendVars);
 
-		this.endpoint = endpoint;
+		const url =
+			envVar === 'PANTHEON_CMS_ENDPOINT'
+				? /^https?:\/\//.test(endpoint)
+					? endpoint
+					: `https://${endpoint}`
+				: endpoint;
+		this.endpoint = url;
 		this.envVar = envVar;
 	}
 	getURL() {

--- a/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
@@ -83,9 +83,16 @@ export class GatsbyWordPressHealthCheck extends WordPressHealthCheck {
 		this.envVar = envVar;
 	}
 	getURL() {
-		const url = new URL(this.endpoint);
-		url.pathname = '/wp/graphql';
-		return url;
+		try {
+			const url = new URL(this.endpoint);
+			url.pathname = '/wp/graphql';
+			return url;
+		} catch (error) {
+			throw new InvalidCMSEndpointError({
+				endpointType: this.envVar,
+				endpoint: this.endpoint,
+			});
+		}
 	}
 	async checkFor200(url: URL) {
 		try {

--- a/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
@@ -1,13 +1,13 @@
 import dotenv from 'dotenv';
 import { logger } from '../utils/logger';
 import { resolveDotenvFile } from '../utils/resolveDotenvFile';
+import { WordPressHealthCheck } from './HealthCheckBase';
 import {
 	BackendNotSetError,
 	DecoupledMenuError,
 	InvalidCMSEndpointError,
 	WPGatsbyPluginError,
 } from './errors';
-import { WordPressHealthCheck } from './HealthCheckBase';
 
 export class GatsbyWordPressHealthCheck extends WordPressHealthCheck {
 	endpoint: string;
@@ -73,7 +73,10 @@ export class GatsbyWordPressHealthCheck extends WordPressHealthCheck {
 			? Object.entries(backendVars).filter(([key]) => key === 'WPGRAPHQL_URL')
 			: Object.entries(backendVars);
 
-		const url = /^https:\/\//.test(endpoint) ? endpoint : `https://${endpoint}`;
+		const url =
+			/^https:\/\//.test(endpoint) || /^http:\/\//.test(endpoint)
+				? endpoint
+				: `https://${endpoint}`;
 
 		this.endpoint = url;
 		this.envVar = envVar;

--- a/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
+++ b/packages/decoupled-kit-health-check/src/classes/GatsbyWordPressHealthCheck.ts
@@ -73,12 +73,7 @@ export class GatsbyWordPressHealthCheck extends WordPressHealthCheck {
 			? Object.entries(backendVars).filter(([key]) => key === 'WPGRAPHQL_URL')
 			: Object.entries(backendVars);
 
-		const url =
-			/^https:\/\//.test(endpoint) || /^http:\/\//.test(endpoint)
-				? endpoint
-				: `https://${endpoint}`;
-
-		this.endpoint = url;
+		this.endpoint = endpoint;
 		this.envVar = envVar;
 	}
 	getURL() {


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Health check will not fail if CMS is http but will fail if no protocol is set.

## Where were the changes made?
`decoupled-kit-health-check`

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?
locally

## Additional information

<!--- Add any other context about the feature or fix here. --->
Test steps can be found in the comments of the related ticket.

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->