### PR TITLE
KIT-72: Fix flickering and nextjs mobile routing bug

### DIFF
--- a/.changeset/five-apricots-press.md
+++ b/.changeset/five-apricots-press.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+Bump `nextjs-kit` version

--- a/.changeset/neat-planes-share.md
+++ b/.changeset/neat-planes-share.md
@@ -1,0 +1,6 @@
+---
+'@pantheon-systems/nextjs-kit': patch
+---
+
+Updated re-export of the `react-kit` header to properly close the mobile overlay
+when clicking a route that may not need navigating to.

--- a/.changeset/pretty-mayflies-jam.md
+++ b/.changeset/pretty-mayflies-jam.md
@@ -1,0 +1,8 @@
+---
+'@pantheon-systems/react-kit': minor
+---
+
+Lift the state to determine if the mobile nav menu is open in the Header
+component to fix issues where metaframework Link components don't close the menu
+when the framework doesn't actually change the route. Also fixed an issue where
+the component was re-rendering more than necessary.

--- a/packages/nextjs-kit/__tests__/snapshotTests/__snapshots__/header.test.tsx.snap
+++ b/packages/nextjs-kit/__tests__/snapshotTests/__snapshots__/header.test.tsx.snap
@@ -2,110 +2,114 @@
 
 exports[`<Header /> > should render 'header' 1`] = `
 <DocumentFragment>
-  <header
-    class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+  <div
+    class="rk-w-full"
   >
-    <a
-      href="/"
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
     >
-      <img
-        alt="PantheonLogo"
-        src="/test-img-src"
-      />
-    </a>
-    <div
-      class="rk-w-full rk-hidden rk-flex-wrap lg:rk-flex"
-    >
-      <nav
-        aria-label="Main"
-        class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+      <a
+        href="/"
       >
-        <ul
-          class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+        <img
+          alt="PantheonLogo"
+          src="/test-img-src"
+        />
+      </a>
+      <div
+        class="rk-w-full rk-hidden rk-flex-wrap lg:rk-flex"
+      >
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
         >
-          <li
-            class="rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mx-4 lg:rk-mb-0 lg:rk-w-fit"
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
           >
-            <a
-              class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
-              href="/"
+            <li
+              class="rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mx-4 lg:rk-mb-0 lg:rk-w-fit"
             >
-              Home
-            </a>
-          </li>
-          <li
-            class="rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mx-4 lg:rk-mb-0 lg:rk-w-fit"
-          >
-            <a
-              class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
-              href="/posts"
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mx-4 lg:rk-mb-0 lg:rk-w-fit"
             >
-              Posts
-            </a>
-          </li>
-          <li
-            class="rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mx-4 lg:rk-mb-0 lg:rk-w-fit"
-          >
-            <a
-              class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
-              href="/pages"
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/posts"
+              >
+                Posts
+              </a>
+            </li>
+            <li
+              class="rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mx-4 lg:rk-mb-0 lg:rk-w-fit"
             >
-              Pages
-            </a>
-          </li>
-        </ul>
-      </nav>
-      <hr
-        class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
-      />
-      <nav
-        aria-label="Secondary"
-        class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
-      >
-        <ul
-          class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
         />
-      </nav>
-    </div>
-    <button
-      aria-hidden="true"
-      class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
-      data-testid="open-nav"
-    >
-      <svg
-        aria-label="open"
-        fill="none"
-        height="24"
-        viewBox="0 0 40 40"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+          />
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="open-nav"
       >
-        <circle
-          cx="20"
-          cy="20"
+        <svg
+          aria-label="open"
           fill="none"
-          r="20"
-        />
-        <path
-          d="M9 12H31"
-          stroke="#171717"
-          stroke-linecap="round"
-          stroke-width="2"
-        />
-        <path
-          d="M9 20H31"
-          stroke="#171717"
-          stroke-linecap="round"
-          stroke-width="2"
-        />
-        <path
-          d="M9 28L31 28"
-          stroke="#171717"
-          stroke-linecap="round"
-          stroke-width="2"
-        />
-      </svg>
-    </button>
-  </header>
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M9 12H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 20H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 28L31 28"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
 </DocumentFragment>
 `;

--- a/packages/nextjs-kit/__tests__/snapshotTests/header.test.tsx
+++ b/packages/nextjs-kit/__tests__/snapshotTests/header.test.tsx
@@ -1,9 +1,18 @@
 import { render } from '@testing-library/react';
-import { Header } from '../../src/components/Header/index';
 import Link from 'next/link';
+import { Header } from '../../src/components/Header/index';
 /**
  * @vitest-environment jsdom
  */
+
+vi.mock('next/router', () => ({
+	useRouter: () => ({
+		events: {
+			on: vi.fn(),
+			off: vi.fn(),
+		},
+	}),
+}));
 
 const navItems = [
 	{

--- a/packages/nextjs-kit/src/components/Header/index.tsx
+++ b/packages/nextjs-kit/src/components/Header/index.tsx
@@ -5,12 +5,29 @@ import {
 	type NavItem,
 } from '@pantheon-systems/react-kit/components/Header';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
 const Header = (props: NavHeaderProps) => {
+	const { events } = useRouter();
+	const [isOpen, setIsOpen] = useState(false);
+	const handleOpen = () => setIsOpen((prev) => !prev);
+	useEffect(() => {
+		events.on('routeChangeComplete', () => {
+			setIsOpen(false);
+		});
+
+		return () => {
+			events.off('routeChangeComplete', () => {
+				setIsOpen(false);
+			});
+		};
+	});
 	return (
 		<ReactKitHeader
 			{...props}
 			linkComponent={props?.linkComponent ? props.linkComponent : Link}
+			mobileNavHandler={[isOpen, handleOpen]}
 		/>
 	);
 };

--- a/packages/react-kit/__tests__/snapshotTests/Header.test.tsx
+++ b/packages/react-kit/__tests__/snapshotTests/Header.test.tsx
@@ -1,6 +1,7 @@
 import { Header } from '@components/Header';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import clsx from 'clsx';
+import { useState } from 'react';
 
 const Logo = () => {
 	return <span>ExampleLogo</span>;
@@ -29,8 +30,11 @@ const NavItems = [
 ));
 
 const TestHeader = () => {
+	const [isOpen, setIsOpen] = useState(false);
+	const handleOpen = () => setIsOpen((prev) => !prev);
 	return (
 		<Header
+			mobileNavHandler={[isOpen, handleOpen]}
 			mainNavItems={NavItems}
 			secondaryNavItems={[
 				{
@@ -87,8 +91,8 @@ describe('<Header />', () => {
 		});
 		waitFor(() => {
 			fireEvent.keyUp(window, { key: 'Esc', code: 'Escape' });
-			expect(openBtn).toBeVisible();
 			expect(asFragment()).toMatchSnapshot();
+			expect(openBtn).toBeVisible();
 		});
 	});
 });

--- a/packages/react-kit/__tests__/snapshotTests/__snapshots__/Header.test.tsx.snap
+++ b/packages/react-kit/__tests__/snapshotTests/__snapshots__/Header.test.tsx.snap
@@ -132,14 +132,14 @@ exports[`<Header /> > should open the nav overlay 2`] = `
         ExampleLogo
       </span>
       <div
-        class="rk-w-full rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12"
+        class="rk-w-full rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12 lg:rk-hidden"
       >
         <nav
           aria-label="Main"
           class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
         >
           <ul
-            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full"
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
           >
             <li
               class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
@@ -181,7 +181,7 @@ exports[`<Header /> > should open the nav overlay 2`] = `
           class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
         >
           <ul
-            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full"
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
           >
             <li
               class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
@@ -198,7 +198,7 @@ exports[`<Header /> > should open the nav overlay 2`] = `
       </div>
       <button
         aria-hidden="false"
-        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
         data-testid="close-nav"
       >
         <svg
@@ -235,117 +235,121 @@ exports[`<Header /> > should open the nav overlay 3`] = `<DocumentFragment />`;
 
 exports[`<Header /> > should render Header 1`] = `
 <DocumentFragment>
-  <header
-    class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+  <div
+    class="rk-w-full"
   >
-    <span>
-      ExampleLogo
-    </span>
-    <div
-      class="rk-w-full rk-hidden rk-flex-wrap lg:rk-flex"
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
     >
-      <nav
-        aria-label="Main"
-        class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+      <span>
+        ExampleLogo
+      </span>
+      <div
+        class="rk-w-full rk-hidden rk-flex-wrap lg:rk-flex"
       >
-        <ul
-          class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
         >
-          <li
-            class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
           >
-            <a
-              class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
-              href="/"
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
             >
-              Home
-            </a>
-          </li>
-          <li
-            class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
-          >
-            <a
-              class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
-              href="/articles"
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
             >
-              Articles
-            </a>
-          </li>
-          <li
-            class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
-          >
-            <a
-              class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
-              href="/pages"
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/articles"
+              >
+                Articles
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
             >
-              Pages
-            </a>
-          </li>
-        </ul>
-      </nav>
-      <hr
-        class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
-      />
-      <nav
-        aria-label="Secondary"
-        class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
-      >
-        <ul
-          class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
+        />
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
         >
-          <li
-            class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
           >
-            <a
-              class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
-              href="/secondary-nav-item"
+            <li
+              class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
             >
-              a secondary nav item
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-    <button
-      aria-hidden="true"
-      class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
-      data-testid="open-nav"
-    >
-      <svg
-        aria-label="open"
-        fill="none"
-        height="24"
-        viewBox="0 0 40 40"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+              <a
+                class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
+                href="/secondary-nav-item"
+              >
+                a secondary nav item
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="open-nav"
       >
-        <circle
-          cx="20"
-          cy="20"
+        <svg
+          aria-label="open"
           fill="none"
-          r="20"
-        />
-        <path
-          d="M9 12H31"
-          stroke="#171717"
-          stroke-linecap="round"
-          stroke-width="2"
-        />
-        <path
-          d="M9 20H31"
-          stroke="#171717"
-          stroke-linecap="round"
-          stroke-width="2"
-        />
-        <path
-          d="M9 28L31 28"
-          stroke="#171717"
-          stroke-linecap="round"
-          stroke-width="2"
-        />
-      </svg>
-    </button>
-  </header>
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M9 12H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 20H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 28L31 28"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
 </DocumentFragment>
 `;
 
@@ -483,14 +487,14 @@ exports[`<Header /> > the escape key should close the nav 3`] = `
         ExampleLogo
       </span>
       <div
-        class="rk-w-full rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12"
+        class="rk-w-full rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12 lg:rk-hidden"
       >
         <nav
           aria-label="Main"
           class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
         >
           <ul
-            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full"
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
           >
             <li
               class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
@@ -532,7 +536,7 @@ exports[`<Header /> > the escape key should close the nav 3`] = `
           class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
         >
           <ul
-            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full"
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
           >
             <li
               class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
@@ -549,7 +553,7 @@ exports[`<Header /> > the escape key should close the nav 3`] = `
       </div>
       <button
         aria-hidden="false"
-        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
         data-testid="close-nav"
       >
         <svg
@@ -582,9 +586,7 @@ exports[`<Header /> > the escape key should close the nav 3`] = `
 </DocumentFragment>
 `;
 
-exports[`<Header /> > the escape key should close the nav 4`] = `<DocumentFragment />`;
-
-exports[`<Header /> > the escape key should close the nav 5`] = `
+exports[`<Header /> > the escape key should close the nav 4`] = `
 <DocumentFragment>
   <div
     class="rk-w-full"
@@ -704,6 +706,940 @@ exports[`<Header /> > the escape key should close the nav 5`] = `
 </DocumentFragment>
 `;
 
-exports[`<Header /> > the escape key should close the nav 6`] = `<DocumentFragment />`;
+exports[`<Header /> > the escape key should close the nav 5`] = `<DocumentFragment />`;
 
-exports[`<Header /> > the escape key should close the nav 7`] = `<DocumentFragment />`;
+exports[`<Header /> > the escape key should close the nav 6`] = `
+<DocumentFragment>
+  <div
+    class="rk-w-full"
+  >
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+    >
+      <span>
+        ExampleLogo
+      </span>
+      <div
+        class="rk-w-full rk-hidden rk-flex-wrap lg:rk-flex"
+      >
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+          >
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/articles"
+              >
+                Articles
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
+        />
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+          >
+            <li
+              class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
+            >
+              <a
+                class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
+                href="/secondary-nav-item"
+              >
+                a secondary nav item
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="open-nav"
+      >
+        <svg
+          aria-label="open"
+          fill="none"
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M9 12H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 20H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 28L31 28"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Header /> > the escape key should close the nav 7`] = `
+<DocumentFragment>
+  <div
+    class="rk-w-full"
+  >
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+    >
+      <span>
+        ExampleLogo
+      </span>
+      <div
+        class="rk-w-full rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12 lg:rk-hidden"
+      >
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
+          >
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/articles"
+              >
+                Articles
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
+        />
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
+          >
+            <li
+              class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
+            >
+              <a
+                class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
+                href="/secondary-nav-item"
+              >
+                a secondary nav item
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="close-nav"
+      >
+        <svg
+          fill="none"
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M11 11L29 29"
+            stroke="black"
+            stroke-width="2"
+          />
+          <path
+            d="M29 11L11 29"
+            stroke="black"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Header /> > the escape key should close the nav 8`] = `<DocumentFragment />`;
+
+exports[`<Header /> > the escape key should close the nav 9`] = `
+<DocumentFragment>
+  <div
+    class="rk-w-full"
+  >
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+    >
+      <span>
+        ExampleLogo
+      </span>
+      <div
+        class="rk-w-full rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12 lg:rk-hidden"
+      >
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
+          >
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/articles"
+              >
+                Articles
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
+        />
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
+          >
+            <li
+              class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
+            >
+              <a
+                class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
+                href="/secondary-nav-item"
+              >
+                a secondary nav item
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="close-nav"
+      >
+        <svg
+          fill="none"
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M11 11L29 29"
+            stroke="black"
+            stroke-width="2"
+          />
+          <path
+            d="M29 11L11 29"
+            stroke="black"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Header /> > the escape key should close the nav 10`] = `
+<DocumentFragment>
+  <div
+    class="rk-w-full"
+  >
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+    >
+      <span>
+        ExampleLogo
+      </span>
+      <div
+        class="rk-w-full rk-hidden rk-flex-wrap lg:rk-flex"
+      >
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+          >
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/articles"
+              >
+                Articles
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
+        />
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+          >
+            <li
+              class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
+            >
+              <a
+                class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
+                href="/secondary-nav-item"
+              >
+                a secondary nav item
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="open-nav"
+      >
+        <svg
+          aria-label="open"
+          fill="none"
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M9 12H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 20H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 28L31 28"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Header /> > the escape key should close the nav 11`] = `<DocumentFragment />`;
+
+exports[`<Header /> > the escape key should close the nav 12`] = `
+<DocumentFragment>
+  <div
+    class="rk-w-full"
+  >
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+    >
+      <span>
+        ExampleLogo
+      </span>
+      <div
+        class="rk-w-full rk-hidden rk-flex-wrap lg:rk-flex"
+      >
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+          >
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/articles"
+              >
+                Articles
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
+        />
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+          >
+            <li
+              class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
+            >
+              <a
+                class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
+                href="/secondary-nav-item"
+              >
+                a secondary nav item
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="open-nav"
+      >
+        <svg
+          aria-label="open"
+          fill="none"
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M9 12H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 20H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 28L31 28"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Header /> > the escape key should close the nav 13`] = `
+<DocumentFragment>
+  <div
+    class="rk-w-full"
+  >
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+    >
+      <span>
+        ExampleLogo
+      </span>
+      <div
+        class="rk-w-full rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12 lg:rk-hidden"
+      >
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
+          >
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/articles"
+              >
+                Articles
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
+        />
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
+          >
+            <li
+              class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
+            >
+              <a
+                class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
+                href="/secondary-nav-item"
+              >
+                a secondary nav item
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="close-nav"
+      >
+        <svg
+          fill="none"
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M11 11L29 29"
+            stroke="black"
+            stroke-width="2"
+          />
+          <path
+            d="M29 11L11 29"
+            stroke="black"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Header /> > the escape key should close the nav 14`] = `<DocumentFragment />`;
+
+exports[`<Header /> > the escape key should close the nav 15`] = `
+<DocumentFragment>
+  <div
+    class="rk-w-full"
+  >
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+    >
+      <span>
+        ExampleLogo
+      </span>
+      <div
+        class="rk-w-full rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12 lg:rk-hidden"
+      >
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
+          >
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/articles"
+              >
+                Articles
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
+        />
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-menu-vertical rk-w-full lg:rk-hidden"
+          >
+            <li
+              class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
+            >
+              <a
+                class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
+                href="/secondary-nav-item"
+              >
+                a secondary nav item
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="close-nav"
+      >
+        <svg
+          fill="none"
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M11 11L29 29"
+            stroke="black"
+            stroke-width="2"
+          />
+          <path
+            d="M29 11L11 29"
+            stroke="black"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Header /> > the escape key should close the nav 16`] = `
+<DocumentFragment>
+  <div
+    class="rk-w-full"
+  >
+    <header
+      class="rk-z-10 rk-flex rk-w-full rk-items-center rk-py-4"
+    >
+      <span>
+        ExampleLogo
+      </span>
+      <div
+        class="rk-w-full rk-hidden rk-flex-wrap lg:rk-flex"
+      >
+        <nav
+          aria-label="Main"
+          class="rk-flex rk-items-center rk-mr-auto lg:rk-w-3/4"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+          >
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit rk-font-bold"
+                href="/"
+              >
+                Home
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/articles"
+              >
+                Articles
+              </a>
+            </li>
+            <li
+              class="rk-mx-2 rk-mb-8 rk-w-full rk-justify-start rk-text-lg rk-text-black lg:rk-mb-0 lg:rk-w-fit"
+            >
+              <a
+                class="rk-link-hover rk-w-full rk-text-left rk-flex rk-w-full rk-min-w-full sm:rk-w-fit"
+                href="/pages"
+              >
+                Pages
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <hr
+          class="divide-x rk-mb-8 rk-ml-auto rk-flex rk-w-full rk-min-w-full lg:rk-hidden"
+        />
+        <nav
+          aria-label="Secondary"
+          class="rk-flex rk-items-center lg:rk-w-1/4 lg:rk-justify-end"
+        >
+          <ul
+            class="lg:rk-menu-horizontal rk-hidden rk-flex-wrap lg:rk-flex"
+          >
+            <li
+              class="rk-mr-auto first:rk-mb-3 lg:rk-mx-3 lg:rk-mr-0 first:lg:rk-mb-0"
+            >
+              <a
+                class="rk-capitalize rk-align-start rk-text-sm rk-bg-neutral-900 rk-text-white rk-rounded-lg hover:rk-bg-neutral-700 hover:rk-border-neutral-700 hover:rk-text-white active:rk-bg-neutral-500 rk-btn rk-btn-sm rk-px-4 rk-h-10"
+                href="/secondary-nav-item"
+              >
+                a secondary nav item
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <button
+        aria-hidden="false"
+        class="rk-btn rk-h-10 rk-max-h-10 rk-min-h-fit rk-rounded-full rk-border-none rk-bg-white rk-p-2 rk-text-black	hover:rk-bg-neutral-100 hover:rk-text-neutral-900 active:rk-bg-neutral-300 [&>*:first-child]:rk-w-6 rk-ml-auto lg:rk-hidden"
+        data-testid="open-nav"
+      >
+        <svg
+          aria-label="open"
+          fill="none"
+          height="24"
+          viewBox="0 0 40 40"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="20"
+            cy="20"
+            fill="none"
+            r="20"
+          />
+          <path
+            d="M9 12H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 20H31"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+          <path
+            d="M9 28L31 28"
+            stroke="#171717"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </header>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Header /> > the escape key should close the nav 17`] = `<DocumentFragment />`;
+
+exports[`<Header /> > the escape key should close the nav 18`] = `<DocumentFragment />`;
+
+exports[`<Header /> > the escape key should close the nav 19`] = `<DocumentFragment />`;

--- a/packages/react-kit/src/components/Header/Header.stories.tsx
+++ b/packages/react-kit/src/components/Header/Header.stories.tsx
@@ -3,6 +3,7 @@ import { Button } from '@components/Button';
 import { Header as NavHeader } from '@components/Header';
 import { Row } from '@components/Row';
 import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
 import { type NavHeaderProps } from './props';
 
 const Header = ({
@@ -12,13 +13,21 @@ const Header = ({
 	linkComponent,
 }: Pick<
 	NavHeaderProps,
-	'mainNavItems' | 'secondaryNavItems' | 'Logo' | 'linkComponent'
+	| 'mainNavItems'
+	| 'secondaryNavItems'
+	| 'Logo'
+	| 'linkComponent'
+	| 'mobileNavHandler'
 > & {
 	manyItems: boolean;
 }) => {
+	const [isOpen, setIsOpen] = useState<boolean>(false);
+	const handleOpen = () => setIsOpen((prev) => !prev);
+
 	return (
 		<Row type="flex" className="rk-mx-auto rk-bg-white">
 			<NavHeader
+				mobileNavHandler={[isOpen, handleOpen]}
 				linkComponent={linkComponent}
 				overlayStyles="rk-bg-white"
 				Logo={Logo}

--- a/packages/react-kit/src/components/Header/Header.tsx
+++ b/packages/react-kit/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { Button, IconButton } from '@components/Button';
 import clsx from 'clsx';
 import FocusTrap from 'focus-trap-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { CloseSVG, HamburgerMenuSVG } from './HeaderIcons';
 import { NavHeaderProps, isNavItemArray } from './props';
 /**
@@ -15,34 +15,22 @@ export const Header = ({
 	navbarStyles,
 	focusTrapOptions,
 	linkComponent,
+	mobileNavHandler: [isOpen, handleOpen],
 }: NavHeaderProps) => {
-	const [isOpen, setIsOpen] = useState(false);
-	const [windowWidth, setWindowWidth] = useState<number>(0);
-	const handleOpen = () => setIsOpen((prev) => !prev);
-
-	const MAX_MOBILE_NAV_WIDTH = 1023;
 	const LinkComponent = linkComponent ? linkComponent : 'a';
 
 	useEffect(() => {
 		const handleKeyUp = (e: KeyboardEvent) => {
 			if (e.key === 'Escape' || e.key === 'Esc') {
-				setIsOpen(false);
+				handleOpen(false);
 			}
 		};
-		const handleResize = () => {
-			setWindowWidth(window?.innerWidth);
-			windowWidth > MAX_MOBILE_NAV_WIDTH && setIsOpen(false);
-		};
-		setWindowWidth(window?.innerWidth);
-
-		window?.addEventListener('resize', handleResize);
-		window?.addEventListener('keyup', handleKeyUp);
+		window.addEventListener('keyup', handleKeyUp);
 
 		return () => {
-			window?.removeEventListener('resize', handleResize);
-			window?.removeEventListener('keyup', handleKeyUp);
+			window.removeEventListener('keyup', handleKeyUp);
 		};
-	}, [windowWidth]);
+	}, [isOpen, handleOpen]);
 
 	/**
 	 * Need to use a ref here so the FocusTrap can work properly.
@@ -55,14 +43,14 @@ export const Header = ({
 			nav: clsx('rk-flex rk-items-center'),
 			ul: clsx(
 				'lg:rk-menu-horizontal',
-				isOpen && windowWidth <= MAX_MOBILE_NAV_WIDTH
-					? 'rk-menu-vertical rk-w-full'
+				isOpen
+					? 'rk-menu-vertical rk-w-full lg:rk-hidden'
 					: 'rk-hidden rk-flex-wrap lg:rk-flex',
 			),
 			overlay: clsx(
 				'rk-w-full',
-				isOpen && windowWidth <= MAX_MOBILE_NAV_WIDTH
-					? 'rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12'
+				isOpen
+					? 'rk-absolute rk-bottom-0 rk-left-0 rk-z-10 rk-h-[calc(100%_-_72px)] rk-flex-col rk-overflow-y-auto rk-overflow-x-hidden rk-px-4 rk-pb-4 rk-pt-8 sm:rk-px-6 lg:rk-px-12 lg:rk-hidden'
 					: 'rk-hidden rk-flex-wrap lg:rk-flex',
 			),
 		};
@@ -166,18 +154,18 @@ export const Header = ({
 						</ul>
 					</nav>
 				</div>
-				{isOpen && windowWidth <= MAX_MOBILE_NAV_WIDTH ? (
+				{isOpen ? (
 					<IconButton
-						aria-hidden={isOpen && windowWidth >= MAX_MOBILE_NAV_WIDTH}
+						aria-hidden={!isOpen}
 						onClick={handleOpen}
-						className="rk-ml-auto"
+						className="rk-ml-auto lg:rk-hidden"
 						data-testid="close-nav"
 					>
 						<CloseSVG />
 					</IconButton>
 				) : (
 					<IconButton
-						aria-hidden={!isOpen && windowWidth >= MAX_MOBILE_NAV_WIDTH}
+						aria-hidden={isOpen}
 						onClick={handleOpen}
 						className="rk-ml-auto lg:rk-hidden"
 						data-testid="open-nav"
@@ -192,26 +180,17 @@ export const Header = ({
 	NavList.displayName = 'NavList';
 
 	return (
-		<>
-			{windowWidth > MAX_MOBILE_NAV_WIDTH ? (
+		<FocusTrap
+			active={isOpen}
+			paused={!isOpen}
+			focusTrapOptions={focusTrapOptions}
+		>
+			<div className="rk-w-full">
 				<NavList
 					mainNavItems={mainNavItems}
 					secondaryNavItems={secondaryNavItems}
 				/>
-			) : (
-				<FocusTrap
-					active={isOpen}
-					paused={!isOpen}
-					focusTrapOptions={focusTrapOptions}
-				>
-					<div className="rk-w-full">
-						<NavList
-							mainNavItems={mainNavItems}
-							secondaryNavItems={secondaryNavItems}
-						/>
-					</div>
-				</FocusTrap>
-			)}
-		</>
+			</div>
+		</FocusTrap>
 	);
 };

--- a/packages/react-kit/src/components/Header/props.ts
+++ b/packages/react-kit/src/components/Header/props.ts
@@ -1,5 +1,5 @@
 import { Props as FocusTrapProps } from 'focus-trap-react';
-
+import { type Dispatch } from 'react';
 /**
  * A navigation item is a tuple of a label and a href.
  * @example
@@ -53,7 +53,25 @@ export type NavHeaderProps = Readonly<{
 	 * Options to pass to the FocusTrap component used to trap focus within the mobile nav overlay.
 	 */
 	focusTrapOptions?: FocusTrapProps['focusTrapOptions'];
+	/**
+	 * If a custom link component is required, like for metaframework, pass it here, otherwise an anchor tag will be used.
+	 */
 	linkComponent?: React.ElementType;
+
+	/**
+	 * State and setter for the open state of the mobile nav overlay.
+	 * @example
+	 * ```tsx
+	 * const [isOpen, setIsOpen] = useState(false);
+	 * const handleOpen = () => setIsOpen((prev) => !prev);
+	 *
+	 * <NavHeader
+	 * 	mobileNavHandler={[isOpen, handleOpen]}
+	 * 	...
+	 * />
+	 * ```
+	 */
+	mobileNavHandler: [boolean, Dispatch<boolean>];
 }>;
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -804,6 +804,13 @@ packages:
       '@babel/highlight': 7.22.20
       chalk: 2.4.2
 
+  /@babel/code-frame@7.23.5:
+    resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.23.4
+      chalk: 2.4.2
+
   /@babel/compat-data@7.22.20:
     resolution: {integrity: sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==}
     engines: {node: '>=6.9.0'}
@@ -1141,10 +1148,14 @@ packages:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.0
+      '@babel/types': 7.23.5
 
   /@babel/helper-string-parser@7.22.5:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-string-parser@7.23.4:
+    resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-identifier@7.22.20:
@@ -1181,12 +1192,27 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
+  /@babel/highlight@7.23.4:
+    resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.20
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+
   /@babel/parser@7.23.0:
     resolution: {integrity: sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
       '@babel/types': 7.23.0
+
+  /@babel/parser@7.23.5:
+    resolution: {integrity: sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.23.5
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.15(@babel/core@7.23.0):
     resolution: {integrity: sha512-FB9iYlz7rURmRJyXRKEnalYPPdn87H5no108cyuQQyMwlpJ2SJtpIUBI27kdTin956pz+LPypkPVPUTlxOmrsg==}
@@ -3202,9 +3228,9 @@ packages:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.13
-      '@babel/parser': 7.23.0
-      '@babel/types': 7.23.0
+      '@babel/code-frame': 7.23.5
+      '@babel/parser': 7.23.5
+      '@babel/types': 7.23.5
 
   /@babel/traverse@7.23.2:
     resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
@@ -3228,6 +3254,14 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+
+  /@babel/types@7.23.5:
+    resolution: {integrity: sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
@@ -4899,7 +4933,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.6.1
-      globals: 13.22.0
+      globals: 13.23.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -8494,6 +8528,7 @@ packages:
 
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -10802,6 +10837,7 @@ packages:
   /domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
+    deprecated: Use your platform's native DOMException instead
     dependencies:
       webidl-conversions: 7.0.0
 
@@ -12357,7 +12393,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
-    dev: true
 
   /globalthis@1.0.3:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
@@ -13666,7 +13701,7 @@ packages:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
-      ws: 8.13.0
+      ws: 8.14.2
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -19155,18 +19190,6 @@ packages:
       utf-8-validate:
         optional: true
     dev: false
-
-  /ws@8.13.0:
-    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   /ws@8.14.2:
     resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Use css instead of JS to display proper components based on mobile or desktop nav
- Lift the piece of state that handles the mobile nav so that our metaframework re-exports can handle any cases like closing the modal on navigation

## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information
I am not in love with the way state is lifted out here, but it works. Ideally there would be a default implementation so this prop would be optional, but had some trouble with that as hooks can not be called conditionally. I was wondering if there was a different/better way to extract this hook?

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->