### PR TITLE
KIT-142: Fix gatsby develop infinite re-render

### DIFF
--- a/.changeset/calm-countries-roll.md
+++ b/.changeset/calm-countries-roll.md
@@ -1,0 +1,5 @@
+---
+'create-pantheon-decoupled-kit': patch
+---
+
+[gatsby-wp] Fix develop mode infinite loop due to d.ts files

--- a/packages/create-pantheon-decoupled-kit/src/templates/tailwind-shared/tailwind.config.cjs.hbs
+++ b/packages/create-pantheon-decoupled-kit/src/templates/tailwind-shared/tailwind.config.cjs.hbs
@@ -6,9 +6,13 @@ const { tailwindcssPlugin } = require('@pantheon-systems/wordpress-kit');
 {{/if}}
 module.exports = {
 	content: [
+		{{#if gatsby}}
+		'./src/{pages,components,templates}/**/*.{jsx,tsx}'
+		{{else}}
 		'./pages/**/*.{js,ts,jsx,tsx}',
 		'./components/**/*.{js,ts,jsx,tsx}',
 		'./src/**/*.{js,jsx,ts,tsx}'
+		{{/if}}
 	],
 	theme: {
 		extend: {},


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
- Fix the tailwindcss config for gatsby so that it does not force an infinite re-render in dev mode due to the `d.ts` files
## Where were the changes made?
`cli` templates.
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->