### PR TITLE
Do not persist credentials for release checkouts

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -22,7 +22,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.ACCESS_TOKEN }}
+          # workaround to ensure force pushes to changeset branch use machine account
+          # see https://github.com/changesets/action/issues/70
+          persist-credentials: false
       - uses: pnpm/action-setup@v2
         with:
           version: 8.8.0

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -99,7 +99,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.ACCESS_TOKEN }}
+          # workaround to ensure force pushes to changeset branch use machine account
+          # see https://github.com/changesets/action/issues/70
+          persist-credentials: false
 
       - name: Setup node
         if: ${{ matrix.generator_cmd != '' }}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Another attempt at fixing the test workflow not running on the changesets branch.
https://github.com/changesets/action/issues/70 this thread points to turning off persisted credentials as a solution. I don't think it will but there is a chance the split action might fail due to this, worth keeping an eye on it.
## Where were the changes made?
changeset actions
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->