### PR TITLE
Try checkout with token to enable workflows on changeset branches

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -25,6 +25,7 @@ jobs:
           # workaround to ensure force pushes to changeset branch use machine account
           # see https://github.com/changesets/action/issues/70
           persist-credentials: false
+          token: ${{ secrets.ACCESS_TOKEN }}
       - uses: pnpm/action-setup@v2
         with:
           version: 8.8.0

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -102,6 +102,7 @@ jobs:
           # workaround to ensure force pushes to changeset branch use machine account
           # see https://github.com/changesets/action/issues/70
           persist-credentials: false
+          token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Setup node
         if: ${{ matrix.generator_cmd != '' }}


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
We tried this before but it didn't work by itself. Maybe with the `persist-credentials: false` and this setting, workflows will properly run on the changeset branch?

## Where were the changes made?
release actions
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->