### PR TITLE
Do not set git user in changeset action

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -39,6 +39,7 @@ jobs:
       - name: create and publish versions
         uses: changesets/action@v1
         with:
+          setupGitUser: false
           version: pnpm ci:version
           publish: pnpm ci:publish
           commit: 'canary-release'

--- a/.github/workflows/release-and-split.yml
+++ b/.github/workflows/release-and-split.yml
@@ -23,6 +23,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # workaround to ensure force pushes to changeset branch use machine account
+          # see https://github.com/changesets/action/issues/70
+          persist-credentials: false
+          token: ${{ secrets.ACCESS_TOKEN }}
       - uses: pnpm/action-setup@v2
         with:
           version: 8.8.0
@@ -36,6 +40,7 @@ jobs:
       - name: create and publish versions
         uses: changesets/action@v1
         with:
+          setupGitUser: false
           version: pnpm ci:version
           commit: 'Update versions'
           title: 'Update versions'
@@ -98,12 +103,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          # workaround to ensure force pushes to changeset branch use machine account
-          # see https://github.com/changesets/action/issues/70
-          persist-credentials: false
-          token: ${{ secrets.ACCESS_TOKEN }}
-
       - name: Setup node
         if: ${{ matrix.generator_cmd != '' }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
This is my last idea. I see the new code scanning workflows are running on the changeset branch, so I'm still unclear on why the test workflow isn't being triggered.
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->