### PR TITLE
Update snapshots for 2024

### DIFF
--- a/packages/nextjs-kit/__tests__/snapshotTests/__snapshots__/footer.test.tsx.snap
+++ b/packages/nextjs-kit/__tests__/snapshotTests/__snapshots__/footer.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`<Footer /> > should render 'footer' 1`] = `
       <span
         class="mx-auto"
       >
-        © 2023 Built with 
+        © 2024 Built with 
         <a
           class="text-white hover:text-blue-100 underline"
           href="https://nextjs.org/"


### PR DESCRIPTION
 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Need to update the snapshot for the new year. This should trigger the cli-addon regression tests to create a new PR with updated snapshots as well since those have been failing since the copy year changed over.

## Where were the changes made?
Update nextjs-kit snapshot tests
<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->