### PR TITLE
Remove deps from test fixtures

### DIFF
--- a/packages/create-pantheon-decoupled-kit/__tests__/fixtures/runESLint/withLint/package.json
+++ b/packages/create-pantheon-decoupled-kit/__tests__/fixtures/runESLint/withLint/package.json
@@ -24,30 +24,5 @@
 		"test:watch": "vitest",
 		"update-snapshots": "vitest run --update --silent",
 		"coverage": "vitest run --coverage"
-	},
-	"dependencies": {
-		"@pantheon-systems/nextjs-kit": "1.7.0",
-		"@pantheon-systems/wordpress-kit": "2.13.0",
-		"@tailwindcss/typography": "^0.5.9",
-		"dotenv": "^16.4.4",
-		"next": "^13.1.5",
-		"next-seo": "^6.4.0",
-		"react": "18.2.0",
-		"react-dom": "18.2.0",
-		"sharp": "^0.33.2"
-	},
-	"devDependencies": {
-		"@testing-library/react": "14.2.1",
-		"@vitejs/plugin-react": "^4.2.1",
-		"autoprefixer": "^10.4.12",
-		"c8": "^7.12.0",
-		"eslint": "^8.56.0",
-		"eslint-config-next": "^14.1.0",
-		"msw": "^1.0.0",
-		"postcss": "^8.4.21",
-		"prettier": "^3.2.5",
-		"tailwindcss": "^3.1.8",
-		"vite": "^5.0.12",
-		"vitest": "^1.2.2"
 	}
 }

--- a/packages/create-pantheon-decoupled-kit/__tests__/fixtures/runESLint/withLintFix/package.json
+++ b/packages/create-pantheon-decoupled-kit/__tests__/fixtures/runESLint/withLintFix/package.json
@@ -25,30 +25,5 @@
 		"test:watch": "vitest",
 		"update-snapshots": "vitest run --update --silent",
 		"coverage": "vitest run --coverage"
-	},
-	"dependencies": {
-		"@pantheon-systems/nextjs-kit": "1.7.0",
-		"@pantheon-systems/wordpress-kit": "2.13.0",
-		"@tailwindcss/typography": "^0.5.9",
-		"dotenv": "^16.4.4",
-		"next": "^13.1.5",
-		"next-seo": "^6.4.0",
-		"react": "18.2.0",
-		"react-dom": "18.2.0",
-		"sharp": "^0.33.2"
-	},
-	"devDependencies": {
-		"@testing-library/react": "14.2.1",
-		"@vitejs/plugin-react": "^4.2.1",
-		"autoprefixer": "^10.4.12",
-		"c8": "^7.12.0",
-		"eslint": "^8.56.0",
-		"eslint-config-next": "^14.1.0",
-		"msw": "^1.0.0",
-		"postcss": "^8.4.21",
-		"prettier": "^3.2.5",
-		"tailwindcss": "^3.1.8",
-		"vite": "^5.0.12",
-		"vitest": "^1.2.2"
 	}
 }

--- a/packages/create-pantheon-decoupled-kit/__tests__/fixtures/runESLint/withoutLint/package.json
+++ b/packages/create-pantheon-decoupled-kit/__tests__/fixtures/runESLint/withoutLint/package.json
@@ -23,30 +23,5 @@
 		"test:watch": "vitest",
 		"update-snapshots": "vitest run --update --silent",
 		"coverage": "vitest run --coverage"
-	},
-	"dependencies": {
-		"@pantheon-systems/nextjs-kit": "1.7.0",
-		"@pantheon-systems/wordpress-kit": "2.13.0",
-		"@tailwindcss/typography": "^0.5.9",
-		"dotenv": "^16.4.4",
-		"next": "^13.1.5",
-		"next-seo": "^6.4.0",
-		"react": "18.2.0",
-		"react-dom": "18.2.0",
-		"sharp": "^0.33.2"
-	},
-	"devDependencies": {
-		"@testing-library/react": "14.2.1",
-		"@vitejs/plugin-react": "^4.2.1",
-		"autoprefixer": "^10.4.12",
-		"c8": "^7.12.0",
-		"eslint": "^8.56.0",
-		"eslint-config-next": "^14.1.0",
-		"msw": "^1.0.0",
-		"postcss": "^8.4.21",
-		"prettier": "^3.2.5",
-		"tailwindcss": "^3.1.8",
-		"vite": "^5.0.12",
-		"vitest": "^1.2.2"
 	}
 }

--- a/packages/create-pantheon-decoupled-kit/vite.config.mts
+++ b/packages/create-pantheon-decoupled-kit/vite.config.mts
@@ -29,6 +29,7 @@ export default defineConfig(() => {
 			globals: true,
 			coverage: {
 				reportsDirectory: `./coverage`,
+				all: false,
 			},
 			include: ['./__tests__**/*.test.*'],
 		},


### PR DESCRIPTION
These were causing false positives for dependabot. They aren't necessary for our tests.
Changed the vitest coverage.all option to flase

 <!--- ** Partial or incorrectly filled out PRs may be asked for more info.--->

## What changes were made?
Forgot that forks don't work anymore. Supersedes #1108 
## Where were the changes made?

<!--- Please add the appropriate label(s) --->
<!--- For example, for changes to the next-drupal-starter, select the next-drupal label--->

## How have the changes been tested?

## Additional information

<!--- Add any other context about the feature or fix here. --->

<!-- prettier-ignore -->
Don't forget to [add a changeset](https://github.com/pantheon-systems/decoupled-kit-js#generating-a-changeset) if needed!
<!-- Only changes to packages or starters require a changeset -->
<!-- If changes are across starters/packages, please use separate changesets -->